### PR TITLE
fix: pin setup-python to SHA in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,9 +19,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Problem

`startup_failure` on every Pages run. All edgesentry workflows use SHA-pinned action references; `actions/setup-python@v5` used a mutable tag, which violates the org policy and causes the workflow to fail before any jobs start.

## Fix

- `actions/setup-python@v5` → `@a26af69be951a213d495a4c3e4e4022e16d87065` (v5)
- `actions/checkout` SHA updated to `34e114876b0b11c390a56381ad16ebd13914f8d5` (current v4, matching edgesentry-rs)

## Test plan

- [ ] Workflow starts (no `startup_failure`)
- [ ] `mkdocs build --strict` passes
- [ ] Pages deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)