### PR TITLE
fix: upgrade upload-pages-artifact to v4 to resolve mutable action ref

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build docs
         run: mkdocs build --strict
 
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
         with:
           path: site/
 


### PR DESCRIPTION
## Problem

Pages workflow still fails after #2. The org policy blocks actions with mutable tag references. `upload-pages-artifact@v3` (SHA `56afc609`) internally calls `actions/upload-artifact@v4` as a mutable tag — this triggers the policy violation:

> The action actions/upload-artifact@v4 is not allowed … all actions must also be pinned to a full-length commit SHA.

## Fix

Upgrade `upload-pages-artifact` from v3 (`56afc609`) → v4 (`7b1f4a7`). The v4 release pins its internal `upload-artifact` call to `ea165f8d65b6e75b540449e92b4886f43607fa02` (v4.6.2).

## Test plan

- [ ] Workflow starts without `startup_failure`
- [ ] `mkdocs build --strict` passes
- [ ] Pages deploys to https://edgesentry.github.io/capvista-mpol-analysis/

🤖 Generated with [Claude Code](https://claude.com/claude-code)