### PR TITLE
Fix MkDocs strict warning in scenarios and ignore _inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ data/raw/           # downloaded AIS, sanctions, registry raw files — can be l
 data/processed/     # DuckDB files, Parquet outputs, Neo4j database
 site/               # MkDocs build output
 .env                # API keys (aisstream.io, Equasis)
+_inputs/

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -113,7 +113,7 @@ The screening pipeline has identified a Priority 1 candidate. A patrol vessel is
    - edgesentry-app displays the target on chart with live AIS overlay
 
 3. **Physical investigation proceeds**
-   - See [plan-field-investigation.md](../plan-field-investigation.md) for the full workflow implemented in edgesentry-rs / edgesentry-app
+   - See [plan-field-investigation.md](field-investigation.md) for the full workflow implemented in edgesentry-rs / edgesentry-app
 
 4. **Evidence report flows back**
    - Signed `AuditRecord` from edgesentry-audit is received at the shore VDES station


### PR DESCRIPTION
## Summary
- fix broken internal docs link in scenarios page to existing field-investigation page
- add _inputs/ to .gitignore to avoid accidental tracking of local input files

## Why
The docs build runs in strict mode and fails on unresolved links. This change removes the warning and keeps local scratch inputs out of git status.

## Validation
- Link target exists under docs: field-investigation.md