### PR TITLE
Incorporate graph analysis feedback into docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,6 +97,8 @@ Neo4j holds the ownership graph. Cypher + GDS plugin enable BFS path queries and
 - `Company {id, name, country}`
 - `Country {code, name}`
 - `VesselName {name, date_from, date_to}`
+- `Address {address_id, street, city, country}` — registered address (P.O. box or physical)
+- `Person {person_id, name, nationality}` — directors, nominees, beneficial owners
 
 **Relationship types:**
 - `(Vessel)-[:OWNED_BY {since, until}]->(Company)`
@@ -105,6 +107,9 @@ Neo4j holds the ownership graph. Cypher + GDS plugin enable BFS path queries and
 - `(Company)-[:CONTROLLED_BY]->(Company)` — beneficial ownership layers
 - `(Vessel)-[:ALIAS {date}]->(VesselName)`
 - `(Company)-[:SANCTIONED_BY {list, date}]->(SanctionsRegime)`
+- `(Company)-[:REGISTERED_AT]->(Address)` — enables shared-address clustering
+- `(Company)-[:DIRECTED_BY {since, until}]->(Person)` — nominee/director network
+- `(Vessel)-[:STS_CONTACT {timestamp, lat, lon, duration_h}]->(Vessel)` — co-location events recorded as graph edges
 
 **Key GDS queries:**
 ```cypher
@@ -152,6 +157,8 @@ Computed by Neo4j GDS.
 | `sanctions_distance` | Min BFS hops from vessel to any sanctioned entity (0 = vessel itself sanctioned) |
 | `cluster_sanctions_ratio` | Fraction of vessels in same Neo4j community that are sanctioned |
 | `shared_manager_risk` | Max sanctions_distance among all vessels sharing the same manager |
+| `shared_address_centrality` | Number of distinct vessels sharing the same registered address as any company in this vessel's ownership chain |
+| `sts_hub_degree` | Number of distinct vessels this vessel has been co-located with (STS_CONTACT degree) — identifies laundering hubs |
 
 ### Trade Flow Mismatch Features
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,6 +36,7 @@
 - Identity volatility features: `flag_changes_2y`, `name_changes_2y`, `owner_changes_2y` (`src/features/identity.py`)
 - Ownership graph features (Neo4j GDS BFS): `sanctions_distance`, `cluster_sanctions_ratio` (`src/features/ownership_graph.py`)
 - Trade flow mismatch: `route_cargo_mismatch` (`src/features/trade_mismatch.py`)
+- GEBCO bathymetric mask: H3 hexagon set for the 200m-depth boundary; used to filter STS candidates to plausible draught zones (`src/features/bathymetric_mask.py`)
 
 **Acceptance:** `vessel_features` table in DuckDB has one row per MMSI with no null values for core features; STS candidate count matches independently verified events from open-source maritime incident reports.
 
@@ -136,6 +137,44 @@ B4 ──► B5 (VDES transmission)
 B5 ──► B6 (port dashboard)
 B6 ──► A4 (confirmed labels loop back to improve scoring)
 ```
+
+---
+
+## Phase C — Post-Submission Enhancements
+
+> These items are out of scope for the Phase A proposal submission (deadline: 29 April 2026). They represent validated improvements to be prioritised if a trial contract is awarded.
+
+### C1 · Dashboard Migration: FastAPI + HTMX
+
+The Phase A Streamlit dashboard (`src/viz/dashboard.py`) is optimised for development speed. For a multi-user port operations deployment, replace it with:
+
+- **FastAPI** as the API layer — existing `src/ingest/`, `src/score/` modules become endpoints with no rewrite
+- **HTMX** for partial updates — the ranked watchlist table and map refresh independently; no full-page reload on each interaction
+- **Server-Sent Events (SSE)** replacing Streamlit's WebSocket toast for the `confidence > 0.75` alert — one-directional, HTTP-native, load-balancer compatible
+- **MapLibre GL JS** consuming a `/api/vessels/geojson` endpoint for the vessel position layer
+
+This is a stateless, Docker-deployable architecture that scales horizontally without the per-session memory overhead of Streamlit.
+
+**Migration path:** Streamlit dashboard ships with the Phase A prototype. FastAPI + HTMX replaces it in C1 without changing any scoring or ingestion code.
+
+### C2 · Geopolitical Context Layer (GDELT + RAG)
+
+SHAP `top_signals` explain *which features* drove a flag but not *why those features matter now*. A RAG layer adds geopolitical context:
+
+- Daily GDELT event CSV ingested and indexed in a local vector store (e.g. ChromaDB)
+- For each high-confidence candidate, retrieve relevant GDELT events (sanction announcements, port bans, incident reports) by IMO / flag state / ownership country
+- Local LLM (Ollama) generates a one-paragraph analyst brief: "Vessel flagged due to 3 ownership changes in 6 months; last change coincides with OFAC designation of managing company on [date]"
+
+This keeps the stack fully offline-capable (no cloud LLM dependency) and satisfies the Cap Vista explainability requirement at the human-analyst level.
+
+### C3 · Causal Sanction-Response Model
+
+Quantify the causal link between sanction events and observable AIS behaviour:
+
+- **Instrument:** sanction announcement date × affected flag state / entity
+- **Outcome:** AIS gap frequency in the area of interest for vessels connected to that entity (within 2 hops in Neo4j)
+- **Method:** DoWhy `LinearDML` or difference-in-differences with vessel-type fixed effects
+- **Output:** Per-sanction-regime estimated effect size and confidence interval; feeds into the `graph_risk_score` weight calibration
 
 ---
 

--- a/docs/technical-solution.md
+++ b/docs/technical-solution.md
@@ -45,6 +45,22 @@ For the area of interest (SG + Malacca Strait), aisstream.io with a bounding box
 |---|---|---|---|
 | [UN Comtrade+](https://comtradeplus.un.org) | Bilateral trade by HS code, port, period | REST API → JSON | Free (500 req/day) |
 
+### Geospatial Reference Data
+
+| Source | Data | Format | Cost |
+|---|---|---|---|
+| [GEBCO](https://www.gebco.net/) | Global bathymetric grid (water depth) | NetCDF / GeoTIFF | Free download |
+
+GEBCO is used to build a **200m-depth boundary mask** as an H3 hexagon set. STS candidate detection filters to events within this mask (shallow draught tankers cannot operate in deeper open ocean), reducing false positives from legitimate vessel interactions.
+
+### Geopolitical Event Data
+
+| Source | Data | Format | Cost |
+|---|---|---|---|
+| [GDELT Project](https://www.gdeltproject.org/) | Global news events: sanctions, conflicts, corporate actions | CSV (daily) | Free |
+
+GDELT event records (EventCode, Actor1, Actor2, GoldsteinScale) are ingested as a time-series alongside AIS data. The primary use is correlating sanction announcement dates with AIS gap spikes in the area of interest — providing geopolitical context for anomaly scoring rather than acting as a primary detection signal.
+
 ---
 
 ## Key Algorithms
@@ -98,6 +114,25 @@ RETURN min(totalCost) AS sanctions_distance
 
 Community detection (Louvain) identifies ownership clusters; `cluster_sanctions_ratio` is computed per cluster.
 
+```cypher
+// Hub vessel detection: STS contact degree (vessels acting as laundering intermediaries)
+MATCH (v:Vessel)-[:STS_CONTACT]->(other:Vessel)
+RETURN v.mmsi, count(DISTINCT other) AS sts_hub_degree
+ORDER BY sts_hub_degree DESC
+LIMIT 20
+```
+
+```cypher
+// Shared-address clustering: addresses with >5 distinct vessels in their ownership chain
+MATCH (addr:Address)<-[:REGISTERED_AT]-(c:Company)<-[:OWNED_BY|MANAGED_BY]-(v:Vessel)
+WITH addr, count(DISTINCT v) AS vessel_count
+WHERE vessel_count > 5
+MATCH (addr)<-[:REGISTERED_AT]-(c2:Company)<-[:OWNED_BY|MANAGED_BY]-(v2:Vessel)
+RETURN addr.address_id, addr.city, addr.country, vessel_count,
+       collect(DISTINCT v2.mmsi) AS flagged_mmsi_list
+ORDER BY vessel_count DESC
+```
+
 ### HDBSCAN Normal Behavior Baseline
 
 HDBSCAN clusters vessels by their behavioral feature vector (gap frequency, speed variance, route entropy, loitering ratio), stratified by `ship_type`. Clusters with high internal consistency represent well-understood normal MPOL patterns (e.g. regular container feeders on fixed schedules). Vessels assigned to noise (`cluster = -1`) receive a baseline anomaly weight of 1.0.
@@ -135,6 +170,8 @@ Trained on the subset of vessels with `sanctions_distance ≥ 3` (proxy for "cle
 | `name_changes_2y` | `i32` | Name changes in 2 years |
 | `owner_changes_2y` | `i32` | Ownership changes |
 | `sanctions_distance` | `i32` | BFS hops to nearest sanctioned entity |
+| `shared_address_centrality` | `i32` | Vessels sharing the same registered address in ownership chain |
+| `sts_hub_degree` | `i32` | Distinct vessels contacted in STS co-location events |
 
 ### Example `top_signals` field
 


### PR DESCRIPTION
## Summary

- **architecture.md**: add `Address` and `Person` node types to Neo4j schema; add `REGISTERED_AT`, `DIRECTED_BY`, `STS_CONTACT` relationship types; add `shared_address_centrality` and `sts_hub_degree` to ownership graph features table
- **technical-solution.md**: add GEBCO (bathymetric mask) and GDELT (geopolitical events) to data sources; add hub vessel degree and shared-address clustering Cypher queries to Key Algorithms; add two new output schema columns
- **roadmap.md**: add GEBCO mask step to A3 feature engineering; add **Phase C** covering FastAPI+HTMX dashboard migration (C1), GDELT+RAG explainability layer (C2), and DoWhy causal sanction-response model (C3)

## What is NOT changed

- Streamlit remains the Phase A dashboard — FastAPI+HTMX is scoped to Phase C (post-submission)
- No changes to scoring weights or pipeline code — docs only
- PostgreSQL/TimescaleDB not adopted; DuckDB remains the analytical store

## Test plan

- [ ] Verify MkDocs builds cleanly (`mkdocs build --strict`)
- [ ] Confirm new Neo4j node/relationship types are consistent with existing Cypher examples in the doc
- [ ] Confirm Phase C items are clearly marked as out-of-scope for the Apr 29 submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)