### PR TITLE
Implement A4 scoring engine, watchlist output, and dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies (including dev)
-        run: uv sync --all-extras
+        run: uv sync --all-extras --group dev
 
       - name: Run tests
-        run: uv run pytest tests/ -v
+        run: uv run --group dev python -m pytest tests/ -v
 
   license_check:
     name: OSS License Check

--- a/src/score/__init__.py
+++ b/src/score/__init__.py
@@ -1,0 +1,1 @@
+"""Scoring and watchlist generation modules."""

--- a/src/score/anomaly.py
+++ b/src/score/anomaly.py
@@ -1,0 +1,144 @@
+"""Isolation Forest-based anomaly scoring for vessel features."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import duckdb
+import numpy as np
+import polars as pl
+from dotenv import load_dotenv
+from sklearn.ensemble import IsolationForest
+from sklearn.preprocessing import StandardScaler
+
+from src.score.mpol_baseline import DEFAULT_OUTPUT_PATH as DEFAULT_BASELINE_PATH
+from src.score.mpol_baseline import build_mpol_baseline
+
+load_dotenv()
+
+DEFAULT_DB_PATH = os.getenv("DB_PATH", "data/processed/mpol.duckdb")
+DEFAULT_OUTPUT_PATH = os.getenv("ANOMALY_SCORES_PATH", "data/processed/anomaly_scores.parquet")
+
+ANOMALY_FEATURE_COLUMNS = [
+    "ais_gap_count_30d",
+    "ais_gap_max_hours",
+    "position_jump_count",
+    "sts_candidate_count",
+    "port_call_ratio",
+    "loitering_hours_30d",
+    "flag_changes_2y",
+    "name_changes_2y",
+    "owner_changes_2y",
+    "high_risk_flag_ratio",
+    "ownership_depth",
+    "sanctions_distance",
+    "cluster_sanctions_ratio",
+    "shared_manager_risk",
+    "shared_address_centrality",
+    "sts_hub_degree",
+    "route_cargo_mismatch",
+    "declared_vs_estimated_cargo_value",
+]
+
+
+def load_feature_frame(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
+    con = duckdb.connect(db_path, read_only=True)
+    try:
+        return con.execute(
+            f"SELECT mmsi, {', '.join(ANOMALY_FEATURE_COLUMNS)} FROM vessel_features ORDER BY mmsi"
+        ).pl()
+    finally:
+        con.close()
+
+
+def fit_isolation_forest(feature_df: pl.DataFrame) -> tuple[StandardScaler, IsolationForest]:
+    matrix = feature_df.select(ANOMALY_FEATURE_COLUMNS).fill_null(0).to_numpy()
+    if matrix.shape[0] == 0:
+        raise ValueError("Cannot train anomaly model on empty feature set")
+
+    clean_subset = feature_df.filter(pl.col("sanctions_distance") >= 3)
+    train_df = clean_subset if clean_subset.height >= 4 else feature_df
+    train_matrix = train_df.select(ANOMALY_FEATURE_COLUMNS).fill_null(0).to_numpy()
+
+    scaler = StandardScaler()
+    train_scaled = scaler.fit_transform(train_matrix)
+
+    model = IsolationForest(
+        n_estimators=200,
+        contamination="auto",
+        random_state=42,
+    )
+    model.fit(train_scaled)
+    return scaler, model
+
+
+def score_anomalies(
+    feature_df: pl.DataFrame,
+    baseline_df: pl.DataFrame | None = None,
+) -> tuple[pl.DataFrame, StandardScaler, IsolationForest]:
+    if feature_df.is_empty():
+        empty = pl.DataFrame(schema={
+            "mmsi": pl.Utf8,
+            "cluster_label": pl.Int32,
+            "baseline_noise_score": pl.Float32,
+            "isolation_raw_score": pl.Float32,
+            "anomaly_score": pl.Float32,
+        })
+        return empty, StandardScaler(), IsolationForest(random_state=42)
+
+    if baseline_df is None:
+        baseline_df = build_mpol_baseline(DEFAULT_DB_PATH)
+
+    scaler, model = fit_isolation_forest(feature_df)
+    matrix = feature_df.select(ANOMALY_FEATURE_COLUMNS).fill_null(0).to_numpy()
+    scaled = scaler.transform(matrix)
+
+    raw = -model.decision_function(scaled)
+    if np.ptp(raw) == 0:
+        normalized = np.full(raw.shape, 0.5, dtype=np.float32)
+    else:
+        normalized = ((raw - raw.min()) / np.ptp(raw)).astype(np.float32)
+
+    joined = feature_df.select("mmsi").join(baseline_df, on="mmsi", how="left").with_columns([
+        pl.col("cluster_label").fill_null(0).cast(pl.Int32),
+        pl.col("baseline_noise_score").fill_null(0.0).cast(pl.Float32),
+        pl.Series("isolation_raw_score", raw.astype(np.float32)),
+        pl.Series("isolation_norm_score", normalized),
+    ])
+
+    result = joined.with_columns(
+        (0.75 * pl.col("isolation_norm_score") + 0.25 * pl.col("baseline_noise_score"))
+        .clip(0.0, 1.0)
+        .alias("anomaly_score")
+    ).select([
+        "mmsi",
+        "cluster_label",
+        "baseline_noise_score",
+        "isolation_raw_score",
+        "anomaly_score",
+    ])
+
+    return result, scaler, model
+
+
+def write_anomaly_scores(df: pl.DataFrame, output_path: str = DEFAULT_OUTPUT_PATH) -> None:
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    df.write_parquet(output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Score anomalies from vessel_features")
+    parser.add_argument("--db", default=DEFAULT_DB_PATH)
+    parser.add_argument("--output", default=DEFAULT_OUTPUT_PATH)
+    args = parser.parse_args()
+
+    feature_df = load_feature_frame(args.db)
+    baseline_df = build_mpol_baseline(args.db)
+    anomaly_df, _, _ = score_anomalies(feature_df, baseline_df)
+    write_anomaly_scores(anomaly_df, args.output)
+    print(f"Anomaly rows written: {anomaly_df.height}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/score/composite.py
+++ b/src/score/composite.py
@@ -1,0 +1,237 @@
+"""Build composite confidence scores and signal explanations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+import duckdb
+import numpy as np
+import polars as pl
+from dotenv import load_dotenv
+
+from src.score.anomaly import ANOMALY_FEATURE_COLUMNS, load_feature_frame, score_anomalies
+from src.score.mpol_baseline import build_mpol_baseline
+
+load_dotenv()
+
+DEFAULT_DB_PATH = os.getenv("DB_PATH", "data/processed/mpol.duckdb")
+DEFAULT_OUTPUT_PATH = os.getenv("COMPOSITE_SCORES_PATH", "data/processed/composite_scores.parquet")
+
+FEATURE_VALUE_COLUMNS = [
+    "ais_gap_count_30d",
+    "ais_gap_max_hours",
+    "position_jump_count",
+    "sts_candidate_count",
+    "flag_changes_2y",
+    "name_changes_2y",
+    "owner_changes_2y",
+    "sanctions_distance",
+    "shared_address_centrality",
+    "sts_hub_degree",
+]
+
+
+def load_watchlist_context(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
+    con = duckdb.connect(db_path, read_only=True)
+    try:
+        return con.execute(
+            """
+            WITH latest_positions AS (
+                SELECT
+                    mmsi,
+                    lat AS last_lat,
+                    lon AS last_lon,
+                    timestamp AS last_seen,
+                    ROW_NUMBER() OVER (PARTITION BY mmsi ORDER BY timestamp DESC) AS rn
+                FROM ais_positions
+            )
+            SELECT
+                vf.*, 
+                COALESCE(vm.imo, '') AS imo,
+                COALESCE(vm.name, vf.mmsi) AS vessel_name,
+                COALESCE(vm.ship_type, 0) AS ship_type,
+                COALESCE(vm.flag, '') AS flag,
+                lp.last_lat,
+                lp.last_lon,
+                lp.last_seen
+            FROM vessel_features vf
+            LEFT JOIN vessel_meta vm ON vm.mmsi = vf.mmsi
+            LEFT JOIN latest_positions lp ON lp.mmsi = vf.mmsi AND lp.rn = 1
+            ORDER BY vf.mmsi
+            """
+        ).pl()
+    finally:
+        con.close()
+
+
+def _ship_type_label(ship_type: int) -> str:
+    if 80 <= ship_type <= 89:
+        return "Tanker"
+    if 70 <= ship_type <= 79:
+        return "Cargo"
+    if 60 <= ship_type <= 69:
+        return "Passenger"
+    if ship_type == 0:
+        return "Unknown"
+    return f"Type {ship_type}"
+
+
+def _normalize_series(expr: pl.Expr, cap: float) -> pl.Expr:
+    return (expr.cast(pl.Float32) / cap).clip(0.0, 1.0)
+
+
+def _compute_graph_risk(df: pl.DataFrame) -> pl.Series:
+    sanctions_component = np.where(
+        df["sanctions_distance"].to_numpy() >= 99,
+        0.0,
+        np.clip(1.0 - (df["sanctions_distance"].to_numpy() / 5.0), 0.0, 1.0),
+    )
+    manager_component = np.where(
+        df["shared_manager_risk"].to_numpy() >= 99,
+        0.0,
+        np.clip(1.0 - (df["shared_manager_risk"].to_numpy() / 5.0), 0.0, 1.0),
+    )
+    cluster_component = np.clip(df["cluster_sanctions_ratio"].to_numpy(), 0.0, 1.0)
+    score = 0.6 * sanctions_component + 0.3 * cluster_component + 0.1 * manager_component
+    return pl.Series("graph_risk_score", score.astype(np.float32))
+
+
+def _compute_identity_score(df: pl.DataFrame) -> pl.Series:
+    score = (
+        0.30 * np.clip(df["flag_changes_2y"].to_numpy() / 5.0, 0.0, 1.0)
+        + 0.25 * np.clip(df["name_changes_2y"].to_numpy() / 5.0, 0.0, 1.0)
+        + 0.20 * np.clip(df["owner_changes_2y"].to_numpy() / 5.0, 0.0, 1.0)
+        + 0.15 * np.clip(df["high_risk_flag_ratio"].to_numpy(), 0.0, 1.0)
+        + 0.10 * np.clip(df["ownership_depth"].to_numpy() / 6.0, 0.0, 1.0)
+    )
+    return pl.Series("identity_score", score.astype(np.float32))
+
+
+def _top_signals_fallback(feature_df: pl.DataFrame) -> list[str]:
+    rows: list[str] = []
+    for row in feature_df.iter_rows(named=True):
+        candidates = []
+        for feature in FEATURE_VALUE_COLUMNS:
+            value = row.get(feature)
+            if value is None:
+                continue
+            magnitude = abs(float(value))
+            candidates.append((feature, value, magnitude))
+        candidates.sort(key=lambda item: item[2], reverse=True)
+        payload = [
+            {
+                "feature": feature,
+                "value": value,
+                "contribution": round(magnitude, 3),
+            }
+            for feature, value, magnitude in candidates[:3]
+        ]
+        rows.append(json.dumps(payload))
+    return rows
+
+
+def _compute_top_signals(feature_df: pl.DataFrame, model, scaled_matrix: np.ndarray) -> pl.Series:
+    try:
+        import shap
+
+        explainer = shap.TreeExplainer(model)
+        shap_values = explainer.shap_values(scaled_matrix)
+        values = np.asarray(shap_values)
+        if values.ndim == 3:
+            values = values[0]
+        if values.shape[0] != feature_df.height:
+            raise ValueError("Unexpected SHAP output shape")
+
+        rows = []
+        for idx, row in enumerate(feature_df.iter_rows(named=True)):
+            contributions = []
+            shap_row = values[idx]
+            denom = float(np.abs(shap_row).sum()) or 1.0
+            for col_idx, feature in enumerate(ANOMALY_FEATURE_COLUMNS):
+                contributions.append(
+                    {
+                        "feature": feature,
+                        "value": row.get(feature),
+                        "contribution": round(abs(float(shap_row[col_idx])) / denom, 3),
+                    }
+                )
+            contributions.sort(key=lambda item: item["contribution"], reverse=True)
+            rows.append(json.dumps(contributions[:3]))
+        return pl.Series("top_signals", rows)
+    except Exception:
+        return pl.Series("top_signals", _top_signals_fallback(feature_df))
+
+
+def compute_composite_scores(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
+    feature_df = load_feature_frame(db_path)
+    context_df = load_watchlist_context(db_path)
+    if feature_df.is_empty() or context_df.is_empty():
+        return pl.DataFrame()
+
+    baseline_df = build_mpol_baseline(db_path)
+    anomaly_df, scaler, model = score_anomalies(feature_df, baseline_df)
+    scaled = scaler.transform(feature_df.select(ANOMALY_FEATURE_COLUMNS).fill_null(0).to_numpy())
+    top_signals = _compute_top_signals(feature_df, model, scaled)
+
+    scored = context_df.join(anomaly_df, on="mmsi", how="left").with_columns([
+        _compute_graph_risk(context_df),
+        _compute_identity_score(context_df),
+        top_signals,
+    ])
+
+    scored = scored.with_columns([
+        (0.4 * pl.col("anomaly_score") + 0.4 * pl.col("graph_risk_score") + 0.2 * pl.col("identity_score"))
+        .clip(0.0, 1.0)
+        .alias("confidence"),
+        pl.col("ship_type").map_elements(_ship_type_label, return_dtype=pl.Utf8).alias("vessel_type"),
+    ])
+
+    return scored.select([
+        "mmsi",
+        "imo",
+        "vessel_name",
+        "vessel_type",
+        "flag",
+        "confidence",
+        "anomaly_score",
+        "graph_risk_score",
+        "identity_score",
+        "top_signals",
+        "last_lat",
+        "last_lon",
+        "last_seen",
+        "ais_gap_count_30d",
+        "ais_gap_max_hours",
+        "position_jump_count",
+        "sts_candidate_count",
+        "flag_changes_2y",
+        "name_changes_2y",
+        "owner_changes_2y",
+        "sanctions_distance",
+        "shared_address_centrality",
+        "sts_hub_degree",
+        "cluster_label",
+        "baseline_noise_score",
+    ]).sort("confidence", descending=True)
+
+
+def write_composite_scores(df: pl.DataFrame, output_path: str = DEFAULT_OUTPUT_PATH) -> None:
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    df.write_parquet(output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compute composite watchlist scores")
+    parser.add_argument("--db", default=DEFAULT_DB_PATH)
+    parser.add_argument("--output", default=DEFAULT_OUTPUT_PATH)
+    args = parser.parse_args()
+
+    df = compute_composite_scores(args.db)
+    write_composite_scores(df, args.output)
+    print(f"Composite rows written: {df.height}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/score/mpol_baseline.py
+++ b/src/score/mpol_baseline.py
@@ -1,0 +1,121 @@
+"""Compute a normal-behavior baseline using HDBSCAN-style clustering."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import duckdb
+import numpy as np
+import polars as pl
+from dotenv import load_dotenv
+from sklearn.preprocessing import StandardScaler
+
+try:
+    from sklearn.cluster import HDBSCAN
+except ImportError:  # pragma: no cover - fallback path for older sklearn builds
+    HDBSCAN = None
+
+load_dotenv()
+
+DEFAULT_DB_PATH = os.getenv("DB_PATH", "data/processed/mpol.duckdb")
+DEFAULT_OUTPUT_PATH = os.getenv("MPOL_BASELINE_PATH", "data/processed/mpol_baseline.parquet")
+
+BEHAVIOR_COLUMNS = [
+    "ais_gap_count_30d",
+    "ais_gap_max_hours",
+    "position_jump_count",
+    "sts_candidate_count",
+    "port_call_ratio",
+    "loitering_hours_30d",
+]
+
+
+def load_behavior_frame(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
+    con = duckdb.connect(db_path, read_only=True)
+    try:
+        return con.execute(
+            """
+            SELECT
+                vf.mmsi,
+                COALESCE(vm.ship_type, 0) AS ship_type,
+                COALESCE(vf.ais_gap_count_30d, 0) AS ais_gap_count_30d,
+                COALESCE(vf.ais_gap_max_hours, 0.0) AS ais_gap_max_hours,
+                COALESCE(vf.position_jump_count, 0) AS position_jump_count,
+                COALESCE(vf.sts_candidate_count, 0) AS sts_candidate_count,
+                COALESCE(vf.port_call_ratio, 0.5) AS port_call_ratio,
+                COALESCE(vf.loitering_hours_30d, 0.0) AS loitering_hours_30d
+            FROM vessel_features vf
+            LEFT JOIN vessel_meta vm ON vm.mmsi = vf.mmsi
+            ORDER BY vf.mmsi
+            """
+        ).pl()
+    finally:
+        con.close()
+
+
+def _cluster_group(group: pl.DataFrame) -> pl.DataFrame:
+    if group.is_empty():
+        return pl.DataFrame(schema={
+            "mmsi": pl.Utf8,
+            "cluster_label": pl.Int32,
+            "baseline_noise_score": pl.Float32,
+        })
+
+    matrix = group.select(BEHAVIOR_COLUMNS).to_numpy()
+    if len(group) < 3 or np.unique(matrix, axis=0).shape[0] < 2 or HDBSCAN is None:
+        labels = np.zeros(len(group), dtype=np.int32)
+        noise = np.zeros(len(group), dtype=np.float32)
+    else:
+        scaler = StandardScaler()
+        scaled = scaler.fit_transform(matrix)
+        min_cluster_size = max(2, min(10, len(group) // 2 or 2))
+        model = HDBSCAN(min_cluster_size=min_cluster_size, min_samples=1, allow_single_cluster=True)
+        labels = model.fit_predict(scaled).astype(np.int32)
+        noise = (labels == -1).astype(np.float32)
+
+    return pl.DataFrame({
+        "mmsi": group["mmsi"],
+        "cluster_label": labels,
+        "baseline_noise_score": noise,
+    })
+
+
+def compute_mpol_baseline(feature_df: pl.DataFrame) -> pl.DataFrame:
+    if feature_df.is_empty():
+        return pl.DataFrame(schema={
+            "mmsi": pl.Utf8,
+            "cluster_label": pl.Int32,
+            "baseline_noise_score": pl.Float32,
+        })
+
+    outputs: list[pl.DataFrame] = []
+    for ship_type, group in feature_df.partition_by("ship_type", as_dict=True).items():
+        _ = ship_type
+        outputs.append(_cluster_group(group))
+
+    return pl.concat(outputs).sort("mmsi")
+
+
+def build_mpol_baseline(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
+    return compute_mpol_baseline(load_behavior_frame(db_path))
+
+
+def write_mpol_baseline(df: pl.DataFrame, output_path: str = DEFAULT_OUTPUT_PATH) -> None:
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    df.write_parquet(output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compute MPOL clustering baseline")
+    parser.add_argument("--db", default=DEFAULT_DB_PATH)
+    parser.add_argument("--output", default=DEFAULT_OUTPUT_PATH)
+    args = parser.parse_args()
+
+    baseline = build_mpol_baseline(args.db)
+    write_mpol_baseline(baseline, args.output)
+    print(f"Baseline rows written: {baseline.height}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/score/watchlist.py
+++ b/src/score/watchlist.py
@@ -1,0 +1,39 @@
+"""Write candidate watchlist parquet output."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import polars as pl
+from dotenv import load_dotenv
+
+from src.score.composite import DEFAULT_DB_PATH, compute_composite_scores
+
+load_dotenv()
+
+DEFAULT_OUTPUT_PATH = os.getenv("WATCHLIST_OUTPUT_PATH", "data/processed/candidate_watchlist.parquet")
+
+
+def build_candidate_watchlist(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
+    return compute_composite_scores(db_path)
+
+
+def write_candidate_watchlist(df: pl.DataFrame, output_path: str = DEFAULT_OUTPUT_PATH) -> None:
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    df.write_parquet(output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build candidate watchlist parquet")
+    parser.add_argument("--db", default=DEFAULT_DB_PATH)
+    parser.add_argument("--output", default=DEFAULT_OUTPUT_PATH)
+    args = parser.parse_args()
+
+    watchlist = build_candidate_watchlist(args.db)
+    write_candidate_watchlist(watchlist, args.output)
+    print(f"Watchlist rows written: {watchlist.height}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/viz/dashboard.py
+++ b/src/viz/dashboard.py
@@ -1,0 +1,111 @@
+"""Streamlit dashboard for ranked candidate watchlist."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import polars as pl
+import pydeck as pdk
+import streamlit as st
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DEFAULT_WATCHLIST_PATH = os.getenv("WATCHLIST_OUTPUT_PATH", "data/processed/candidate_watchlist.parquet")
+
+
+@st.cache_data(show_spinner=False)
+def load_watchlist(path: str) -> pl.DataFrame:
+    if not os.path.exists(path):
+        return pl.DataFrame()
+    return pl.read_parquet(path)
+
+
+def _color_for_confidence(value: float) -> list[int]:
+    if value >= 0.7:
+        return [220, 38, 38, 180]
+    if value >= 0.4:
+        return [245, 158, 11, 180]
+    return [34, 197, 94, 180]
+
+
+def _map_frame(df: pl.DataFrame) -> pl.DataFrame:
+    return df.filter(pl.col("last_lat").is_not_null() & pl.col("last_lon").is_not_null()).with_columns(
+        pl.col("confidence").map_elements(_color_for_confidence, return_dtype=pl.List(pl.Int64)).alias("color")
+    )
+
+
+def main() -> None:
+    st.set_page_config(page_title="MPOL Watchlist", layout="wide")
+    st.title("Shadow Fleet Candidate Watchlist")
+
+    watchlist = load_watchlist(DEFAULT_WATCHLIST_PATH)
+    if watchlist.is_empty():
+        st.warning("candidate_watchlist.parquet not found or empty. Run src/score/watchlist.py first.")
+        return
+
+    with st.sidebar:
+        st.header("Filters")
+        min_confidence = st.slider("Minimum confidence", 0.0, 1.0, 0.4, 0.05)
+        vessel_types = sorted(watchlist["vessel_type"].unique().to_list())
+        selected_types = st.multiselect("Vessel types", vessel_types, default=vessel_types)
+        top_n = st.slider("Top N rows", 10, min(500, watchlist.height), min(50, watchlist.height))
+
+    filtered = watchlist.filter(
+        (pl.col("confidence") >= min_confidence) & (pl.col("vessel_type").is_in(selected_types))
+    ).head(top_n)
+
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Candidates", filtered.height)
+    col2.metric("High confidence", filtered.filter(pl.col("confidence") >= 0.75).height)
+    col3.metric("Avg confidence", f"{filtered['confidence'].mean():.2f}")
+
+    left, right = st.columns([3, 2])
+
+    with left:
+        st.subheader("Map")
+        map_df = _map_frame(filtered)
+        if map_df.is_empty():
+            st.info("No candidate positions available for the current filters.")
+        else:
+            layer = pdk.Layer(
+                "ScatterplotLayer",
+                data=map_df.to_dicts(),
+                get_position="[last_lon, last_lat]",
+                get_fill_color="color",
+                get_radius=20000,
+                pickable=True,
+            )
+            view_state = pdk.ViewState(
+                latitude=float(map_df["last_lat"].mean()),
+                longitude=float(map_df["last_lon"].mean()),
+                zoom=4,
+            )
+            st.pydeck_chart(pdk.Deck(layers=[layer], initial_view_state=view_state, tooltip={"text": "{vessel_name}\nConfidence: {confidence}"}))
+
+    with right:
+        st.subheader("Ranked table")
+        display_df = filtered.select([
+            "mmsi",
+            "vessel_name",
+            "vessel_type",
+            "flag",
+            "confidence",
+            "top_signals",
+        ]).to_pandas()
+        st.dataframe(display_df, use_container_width=True, hide_index=True)
+
+    st.subheader("Top signals")
+    top_row = filtered.head(1)
+    if top_row.height:
+        record = top_row.row(0, named=True)
+        st.markdown(f"**{record['vessel_name']}** ({record['mmsi']})")
+        try:
+            st.json(json.loads(record["top_signals"]))
+        except Exception:
+            st.code(record["top_signals"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scoring_pipeline.py
+++ b/tests/test_scoring_pipeline.py
@@ -1,0 +1,82 @@
+import json
+
+import duckdb
+
+from src.score.anomaly import load_feature_frame, score_anomalies
+from src.score.composite import compute_composite_scores
+from src.score.mpol_baseline import build_mpol_baseline
+from src.score.watchlist import build_candidate_watchlist, write_candidate_watchlist
+
+
+def _seed_scoring_data(db_path: str) -> None:
+    con = duckdb.connect(db_path)
+    try:
+        con.execute(
+            """
+            INSERT INTO vessel_meta (mmsi, imo, name, flag, ship_type)
+            VALUES
+                ('111111111', 'IMO111', 'ALPHA', 'IR', 82),
+                ('222222222', 'IMO222', 'BRAVO', 'SG', 82),
+                ('333333333', 'IMO333', 'CHARLIE', 'PA', 82),
+                ('444444444', 'IMO444', 'DELTA', 'SG', 70)
+            """
+        )
+        con.execute(
+            """
+            INSERT INTO ais_positions (mmsi, timestamp, lat, lon, sog, nav_status, ship_type)
+            VALUES
+                ('111111111', '2026-03-01 00:00:00+00', 1.20, 103.80, 0.8, 1, 82),
+                ('222222222', '2026-03-01 00:00:00+00', 1.30, 103.90, 12.0, 5, 82),
+                ('333333333', '2026-03-01 00:00:00+00', 1.40, 104.00, 9.0, 5, 82),
+                ('444444444', '2026-03-01 00:00:00+00', 1.50, 104.10, 7.0, 5, 70)
+            """
+        )
+        con.execute(
+            """
+            INSERT INTO vessel_features (
+                mmsi, ais_gap_count_30d, ais_gap_max_hours, position_jump_count,
+                sts_candidate_count, port_call_ratio, loitering_hours_30d,
+                flag_changes_2y, name_changes_2y, owner_changes_2y,
+                high_risk_flag_ratio, ownership_depth, sanctions_distance,
+                cluster_sanctions_ratio, shared_manager_risk, shared_address_centrality,
+                sts_hub_degree, route_cargo_mismatch, declared_vs_estimated_cargo_value
+            )
+            VALUES
+                ('111111111', 12, 18.0, 4, 3, 0.10, 22.0, 3, 2, 2, 1.0, 4, 1, 0.50, 1, 8, 4, 1.0, 100000.0),
+                ('222222222', 1, 1.0, 0, 0, 0.90, 1.0, 0, 0, 0, 0.0, 1, 5, 0.00, 5, 0, 0, 0.0, 0.0),
+                ('333333333', 2, 2.5, 0, 1, 0.70, 2.0, 0, 1, 0, 0.1, 2, 4, 0.10, 4, 1, 1, 0.0, 1000.0),
+                ('444444444', 0, 0.5, 0, 0, 0.95, 0.5, 0, 0, 0, 0.0, 1, 6, 0.00, 6, 0, 0, 0.0, 0.0)
+            """
+        )
+    finally:
+        con.close()
+
+
+def test_baseline_and_anomaly_scores(tmp_db):
+    _seed_scoring_data(tmp_db)
+
+    baseline = build_mpol_baseline(tmp_db)
+    assert baseline.height == 4
+
+    features = load_feature_frame(tmp_db)
+    anomaly_df, _, _ = score_anomalies(features, baseline)
+    assert anomaly_df.height == 4
+    assert anomaly_df["anomaly_score"].min() >= 0.0
+    assert anomaly_df["anomaly_score"].max() <= 1.0
+
+
+def test_composite_and_watchlist_output(tmp_db, tmp_path):
+    _seed_scoring_data(tmp_db)
+
+    composite = compute_composite_scores(tmp_db)
+    assert composite.height == 4
+    assert composite["confidence"].is_sorted(descending=True)
+
+    first_signals = json.loads(composite.row(0, named=True)["top_signals"])
+    assert 1 <= len(first_signals) <= 3
+    assert {"feature", "value", "contribution"} <= set(first_signals[0])
+
+    watchlist = build_candidate_watchlist(tmp_db)
+    output_path = tmp_path / "candidate_watchlist.parquet"
+    write_candidate_watchlist(watchlist, str(output_path))
+    assert output_path.exists()


### PR DESCRIPTION
## Summary
- add MPOL baseline clustering and Isolation Forest anomaly scoring
- add composite confidence scoring and top-signals generation
- add candidate watchlist parquet output
- add the Phase A Streamlit dashboard for map, ranked table, and filters
- fix CI test invocation for uv-managed dev dependencies

## Validation
- uv sync --group dev
- uv run --group dev python -m pytest tests/test_scoring_pipeline.py -q
- ./.venv/bin/python -m pytest tests/test_scoring_pipeline.py tests/test_feature_matrix.py tests/test_schema.py -q

## Scope
- completes #10
- follows merged A3 PR #16