### PR TITLE
Implement A5 validation metrics and dashboard reporting

### DIFF
--- a/src/score/validate.py
+++ b/src/score/validate.py
@@ -1,0 +1,124 @@
+"""Validate watchlist quality against OFAC ground truth."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import duckdb
+import polars as pl
+from dotenv import load_dotenv
+from sklearn.metrics import roc_auc_score
+
+from src.score.watchlist import DEFAULT_DB_PATH, DEFAULT_OUTPUT_PATH as DEFAULT_WATCHLIST_PATH, build_candidate_watchlist
+
+load_dotenv()
+
+DEFAULT_METRICS_PATH = os.getenv("VALIDATION_METRICS_PATH", "data/processed/validation_metrics.json")
+
+
+def _positive_identifier_sets(db_path: str) -> tuple[set[str], set[str]]:
+    con = duckdb.connect(db_path, read_only=True)
+    try:
+        rows = con.execute(
+            """
+            SELECT DISTINCT COALESCE(mmsi, '') AS mmsi, COALESCE(imo, '') AS imo
+            FROM sanctions_entities
+            WHERE lower(COALESCE(list_source, '')) LIKE '%ofac%'
+              AND (mmsi IS NOT NULL OR imo IS NOT NULL)
+            """
+        ).fetchall()
+    finally:
+        con.close()
+
+    mmsi_set = {str(mmsi) for mmsi, _ in rows if mmsi}
+    imo_set = {str(imo) for _, imo in rows if imo}
+    return mmsi_set, imo_set
+
+
+def label_watchlist_against_ofac(watchlist_df: pl.DataFrame, db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
+    mmsi_set, imo_set = _positive_identifier_sets(db_path)
+    if watchlist_df.is_empty():
+        return watchlist_df.with_columns(pl.lit(False).alias("is_ofac_listed"))
+
+    labels = [
+        (str(row["mmsi"]) in mmsi_set) or (str(row.get("imo", "")) in imo_set)
+        for row in watchlist_df.iter_rows(named=True)
+    ]
+    return watchlist_df.with_columns(pl.Series("is_ofac_listed", labels))
+
+
+def compute_validation_metrics(labeled_watchlist_df: pl.DataFrame) -> dict[str, float | int | None]:
+    if labeled_watchlist_df.is_empty():
+        return {
+            "candidate_count": 0,
+            "positive_count": 0,
+            "precision_at_50": 0.0,
+            "recall_at_200": 0.0,
+            "auroc": None,
+        }
+
+    ranked = labeled_watchlist_df.sort("confidence", descending=True)
+    labels = ranked["is_ofac_listed"].cast(pl.Int8).to_list()
+    scores = ranked["confidence"].to_list()
+    positive_count = int(sum(labels))
+
+    top_50 = ranked.head(min(50, ranked.height))
+    top_200 = ranked.head(min(200, ranked.height))
+
+    precision_at_50 = float(top_50["is_ofac_listed"].cast(pl.Int8).mean() or 0.0)
+    recall_hits = int(top_200["is_ofac_listed"].cast(pl.Int8).sum())
+    recall_at_200 = float(recall_hits / positive_count) if positive_count else 0.0
+
+    auroc: float | None
+    if positive_count and positive_count != len(labels):
+        auroc = float(roc_auc_score(labels, scores))
+    else:
+        auroc = None
+
+    return {
+        "candidate_count": ranked.height,
+        "positive_count": positive_count,
+        "precision_at_50": round(precision_at_50, 4),
+        "recall_at_200": round(recall_at_200, 4),
+        "auroc": round(auroc, 4) if auroc is not None else None,
+    }
+
+
+def write_validation_metrics(metrics: dict[str, float | int | None], output_path: str = DEFAULT_METRICS_PATH) -> None:
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(metrics, indent=2) + "\n")
+
+
+def validate_watchlist(
+    db_path: str = DEFAULT_DB_PATH,
+    watchlist_path: str = DEFAULT_WATCHLIST_PATH,
+    metrics_path: str = DEFAULT_METRICS_PATH,
+) -> dict[str, float | int | None]:
+    if Path(watchlist_path).exists():
+        watchlist_df = pl.read_parquet(watchlist_path)
+    else:
+        watchlist_df = build_candidate_watchlist(db_path)
+
+    labeled = label_watchlist_against_ofac(watchlist_df, db_path)
+    metrics = compute_validation_metrics(labeled)
+    write_validation_metrics(metrics, metrics_path)
+    return metrics
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate candidate watchlist against OFAC ground truth")
+    parser.add_argument("--db", default=DEFAULT_DB_PATH)
+    parser.add_argument("--watchlist", default=DEFAULT_WATCHLIST_PATH)
+    parser.add_argument("--output", default=DEFAULT_METRICS_PATH)
+    args = parser.parse_args()
+
+    metrics = validate_watchlist(args.db, args.watchlist, args.output)
+    print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/viz/dashboard.py
+++ b/src/viz/dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 
 import polars as pl
 import pydeck as pdk
@@ -13,6 +14,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 DEFAULT_WATCHLIST_PATH = os.getenv("WATCHLIST_OUTPUT_PATH", "data/processed/candidate_watchlist.parquet")
+DEFAULT_VALIDATION_PATH = os.getenv("VALIDATION_METRICS_PATH", "data/processed/validation_metrics.json")
 
 
 @st.cache_data(show_spinner=False)
@@ -20,6 +22,17 @@ def load_watchlist(path: str) -> pl.DataFrame:
     if not os.path.exists(path):
         return pl.DataFrame()
     return pl.read_parquet(path)
+
+
+@st.cache_data(show_spinner=False)
+def load_validation_metrics(path: str) -> dict | None:
+    candidate = Path(path)
+    if not candidate.exists():
+        return None
+    try:
+        return json.loads(candidate.read_text())
+    except Exception:
+        return None
 
 
 def _color_for_confidence(value: float) -> list[int]:
@@ -45,6 +58,8 @@ def main() -> None:
         st.warning("candidate_watchlist.parquet not found or empty. Run src/score/watchlist.py first.")
         return
 
+    metrics = load_validation_metrics(DEFAULT_VALIDATION_PATH)
+
     with st.sidebar:
         st.header("Filters")
         min_confidence = st.slider("Minimum confidence", 0.0, 1.0, 0.4, 0.05)
@@ -60,6 +75,14 @@ def main() -> None:
     col1.metric("Candidates", filtered.height)
     col2.metric("High confidence", filtered.filter(pl.col("confidence") >= 0.75).height)
     col3.metric("Avg confidence", f"{filtered['confidence'].mean():.2f}")
+
+    if metrics:
+        st.subheader("Validation")
+        v1, v2, v3 = st.columns(3)
+        v1.metric("Precision@50", f"{metrics.get('precision_at_50', 0.0):.2f}")
+        v2.metric("Recall@200", f"{metrics.get('recall_at_200', 0.0):.2f}")
+        auroc = metrics.get("auroc")
+        v3.metric("AUROC", "N/A" if auroc is None else f"{auroc:.2f}")
 
     left, right = st.columns([3, 2])
 
@@ -109,3 +132,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,76 @@
+import json
+
+import duckdb
+import polars as pl
+
+from src.score.validate import (
+    compute_validation_metrics,
+    label_watchlist_against_ofac,
+    validate_watchlist,
+)
+from src.score.watchlist import write_candidate_watchlist
+
+
+def _seed_validation_data(db_path: str) -> None:
+    con = duckdb.connect(db_path)
+    try:
+        con.execute(
+            """
+            INSERT INTO sanctions_entities (entity_id, name, mmsi, imo, flag, type, list_source)
+            VALUES
+                ('ofac-1', 'ALPHA', '111111111', 'IMO111', 'IR', 'Vessel', 'ofac_sdn'),
+                ('ofac-2', 'CHARLIE', '333333333', 'IMO333', 'PA', 'Vessel', 'ofac_sdn')
+            """
+        )
+    finally:
+        con.close()
+
+
+def _sample_watchlist() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "mmsi": ["111111111", "222222222", "333333333", "444444444"],
+            "imo": ["IMO111", "IMO222", "IMO333", "IMO444"],
+            "vessel_name": ["ALPHA", "BRAVO", "CHARLIE", "DELTA"],
+            "vessel_type": ["Tanker", "Tanker", "Tanker", "Cargo"],
+            "flag": ["IR", "SG", "PA", "SG"],
+            "confidence": [0.99, 0.60, 0.55, 0.10],
+            "anomaly_score": [0.95, 0.50, 0.45, 0.10],
+            "graph_risk_score": [0.90, 0.40, 0.60, 0.10],
+            "identity_score": [0.80, 0.30, 0.35, 0.05],
+            "top_signals": ["[]", "[]", "[]", "[]"],
+        }
+    )
+
+
+def test_label_watchlist_against_ofac(tmp_db):
+    _seed_validation_data(tmp_db)
+    labeled = label_watchlist_against_ofac(_sample_watchlist(), tmp_db)
+
+    assert labeled["is_ofac_listed"].to_list() == [True, False, True, False]
+
+
+def test_compute_validation_metrics():
+    labeled = _sample_watchlist().with_columns(pl.Series("is_ofac_listed", [True, False, True, False]))
+    metrics = compute_validation_metrics(labeled)
+
+    assert metrics["candidate_count"] == 4
+    assert metrics["positive_count"] == 2
+    assert metrics["precision_at_50"] == 0.5
+    assert metrics["recall_at_200"] == 1.0
+    assert metrics["auroc"] is not None
+
+
+def test_validate_watchlist_writes_metrics_file(tmp_db, tmp_path):
+    _seed_validation_data(tmp_db)
+    watchlist = _sample_watchlist()
+    watchlist_path = tmp_path / "candidate_watchlist.parquet"
+    metrics_path = tmp_path / "validation_metrics.json"
+
+    write_candidate_watchlist(watchlist, str(watchlist_path))
+    metrics = validate_watchlist(tmp_db, str(watchlist_path), str(metrics_path))
+
+    assert metrics_path.exists()
+    persisted = json.loads(metrics_path.read_text())
+    assert persisted == metrics
+    assert persisted["recall_at_200"] == 1.0


### PR DESCRIPTION
## Summary
- add OFAC-ground-truth validation in src/score/validate.py
- compute and persist Precision@50, Recall@200, and AUROC
- surface validation metrics in the Streamlit dashboard
- add tests for label generation, metric calculation, and metrics-file output

## Validation
- ./.venv/bin/python -m pytest tests/test_validate.py tests/test_scoring_pipeline.py tests/test_feature_matrix.py tests/test_schema.py -q

## Scope
- completes #11
- builds on merged A4 work from #17