### PR TITLE
docs: add data analytics documentation

### DIFF
--- a/docs/analytics-overview.md
+++ b/docs/analytics-overview.md
@@ -1,0 +1,117 @@
+# Analytics Overview
+
+End-to-end data flow for the arktrace Maritime Pattern of Life (MPOL) shadow fleet screening pipeline.
+
+## Pipeline stages
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  DATA SOURCES                                                           │
+│  aisstream.io WebSocket · Marine Cadastre Parquet · OpenSanctions       │
+│  Equasis vessel registry · UN Comtrade API · GDELT event CSV            │
+└────────────────────────────┬────────────────────────────────────────────┘
+                             │  src/ingest/
+                             ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  STORAGE                                                                │
+│  DuckDB  ──  ais_positions, vessel_meta, sanctions_entities,            │
+│              trade_flow, vessel_features, analyst_briefs, chat_cache,   │
+│              cleared_vessels                                            │
+│  Neo4j   ──  Vessel · Company · Country · VesselName graph             │
+│  LanceDB ──  GDELT event vectors (RAG context)                         │
+└────────────────────────────┬────────────────────────────────────────────┘
+                             │  src/features/
+                             ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  FEATURE ENGINEERING  (19 features, one row per MMSI)                  │
+│  AIS Behavioral   · Identity Volatility                                 │
+│  Ownership Graph  · Trade Flow Mismatch                                 │
+└────────────────────────────┬────────────────────────────────────────────┘
+                             │  src/score/
+                             ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  SCORING ENGINE                                                         │
+│  HDBSCAN baseline  →  Isolation Forest  →  Composite confidence score  │
+│  causal_sanction.py calibrates graph_risk weight (C3)                  │
+└────────────────────────────┬────────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  OUTPUTS                                                                │
+│  candidate_watchlist.parquet  ·  composite_scores.parquet               │
+│  anomaly_scores.parquet       ·  causal_effects.parquet                 │
+└────────────────────────────┬────────────────────────────────────────────┘
+                             │  src/api/
+                             ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  DASHBOARD  (FastAPI + HTMX + MapLibre GL)                              │
+│  http://localhost:8000                                                   │
+│  /api/vessels/geojson  ·  /api/watchlist/top  ·  /api/alerts/sse       │
+│  /api/briefs/{mmsi}    ·  /api/chat                                     │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Data sources
+
+| Source | Module | Protocol | Content |
+|---|---|---|---|
+| **aisstream.io** | `src/ingest/ais_stream.py` | WebSocket | Live AIS positions for a configurable bounding box |
+| **Marine Cadastre** | `src/ingest/marine_cadastre.py` | Parquet files | Annual US-coastal AIS archive (2022–2025); useful for Gulf of Mexico historical backfill |
+| **OpenSanctions** | `src/ingest/sanctions.py` | JSONL | Merged OFAC SDN, EU, UN consolidated lists |
+| **Equasis** | `src/ingest/vessel_registry.py` | HTTP scrape / CSV | Vessel ownership chains → Neo4j |
+| **UN Comtrade** | `src/features/trade_mismatch.py` | REST API | Bilateral crude oil trade statistics (HS 2709) |
+| **GDELT** | `src/ingest/gdelt.py` | CSV | Geopolitical event stream; indexed in LanceDB for RAG |
+
+## Storage layer
+
+### DuckDB tables
+
+| Table | Key columns | Purpose |
+|---|---|---|
+| `ais_positions` | mmsi, timestamp, lat, lon, sog | Raw AIS tracks; primary key (mmsi, timestamp) |
+| `vessel_meta` | mmsi, imo, name, flag, ship_type | Static registry data |
+| `sanctions_entities` | entity_id, name, mmsi, imo, list_source | Merged sanctions lists |
+| `trade_flow` | reporter, partner, hs_code, period, trade_value_usd | Comtrade bilateral statistics |
+| `vessel_features` | mmsi + 19 feature columns | Computed feature matrix (one row per vessel) |
+| `analyst_briefs` | mmsi, watchlist_version, brief | Cached LLM-generated analyst briefings |
+| `chat_cache` | cache_key, question_hash, response | Cached analyst Q&A responses |
+| `cleared_vessels` | mmsi, cleared_at, cleared_by | Phase B inspection outcomes (cleared) |
+
+Each region runs its own DuckDB file (e.g. `singapore.duckdb`, `japansea.duckdb`) so data is fully isolated between deployment areas.
+
+### Neo4j graph
+
+Node types: `Vessel`, `Company`, `Country`, `VesselName`
+
+Relationship types:
+
+| Relationship | Meaning |
+|---|---|
+| `OWNED_BY` | Vessel → Company (registered owner) |
+| `MANAGED_BY` | Vessel → Company (technical manager) |
+| `REGISTERED_IN` | Vessel or Company → Country (flag/registration) |
+| `ALIAS` | Vessel → VesselName (historical name) |
+| `SANCTIONED_BY` | Company → sanctions list entity |
+
+BFS traversal depth up to 3 hops is used to compute `sanctions_distance` and related graph features.
+
+### LanceDB (GDELT)
+
+Daily GDELT event rows are embedded and stored in a local LanceDB vector store. The analyst chat and brief generation endpoints retrieve the top-k most relevant events for a given vessel's flag state, ownership country, and watchlist confidence to construct geopolitical context.
+
+## Orchestration
+
+`scripts/run_pipeline.py` runs the full 10-step pipeline in order:
+
+1. Schema initialisation
+2. Marine Cadastre historical backfill (optional)
+3. Neo4j startup
+4. Live AIS streaming
+5. Sanctions loading
+6. Ownership graph computation
+7. Feature engineering (AIS → identity → trade mismatch → build matrix)
+8. Scoring (C3 causal calibration → MPOL baseline → anomaly → composite → watchlist)
+9. GDELT ingestion
+10. Dashboard launch
+
+See [Pipeline Operations](pipeline-operations.md) for per-region configuration and [Regional Playbooks](regional-playbooks.md) for analyst-persona-specific guidance.

--- a/docs/feature-engineering.md
+++ b/docs/feature-engineering.md
@@ -1,0 +1,183 @@
+# Feature Engineering
+
+The arktrace pipeline computes 19 features across four families for every vessel MMSI. All features are written to the `vessel_features` DuckDB table by `src/features/build_matrix.py`.
+
+## Feature families
+
+| Family | Module | Features | Backend |
+|---|---|---|---|
+| AIS Behavioral | `ais_behavior.py` | 6 | DuckDB / Polars |
+| Identity Volatility | `identity.py` | 5 | Neo4j + DuckDB |
+| Ownership Graph | `ownership_graph.py` | 5 | Neo4j BFS |
+| Trade Flow Mismatch | `trade_mismatch.py` | 2 | DuckDB + Comtrade API |
+| **Total** | | **19** | |
+
+---
+
+## AIS Behavioral features
+
+Source: `ais_positions` table, computed over a rolling window (default 30 days, configurable with `--window`).
+
+### `ais_gap_count_30d`
+
+Count of AIS transmission gaps longer than the configured threshold (default 6 hours) in the last 30 days.
+
+**Shadow fleet signal:** Deliberate AIS switch-off is the primary evasion technique for sanctioned tankers. A gap of 6+ hours during transit is operationally unusual for a compliant vessel and strongly correlated with dark-transfer events.
+
+**Implementation:** The Polars lazy pipeline computes the time delta between consecutive position rows for each MMSI. Gaps are counted and summed per vessel over the rolling window.
+
+### `ais_gap_max_hours`
+
+Duration in hours of the longest single AIS gap in the window.
+
+**Shadow fleet signal:** Compliant vessels rarely go dark for more than 2–4 hours. Gaps above 12 hours indicate a port call without AIS, an at-sea dark period, or equipment failure. Gaps above 24 hours in open water are a strong evasion indicator.
+
+### `position_jump_count`
+
+Count of consecutive position pairs where the implied speed exceeds 50 knots (calculated via Haversine distance / elapsed time).
+
+**Shadow fleet signal:** GPS spoofing is endemic in the Taiwan Strait, Black Sea, and Persian Gulf approaches. A vessel that "jumps" 200 km in 30 minutes without leaving any intermediate positions is almost certainly receiving a spoofed GPS signal, often to mask its true location during a dark STS transfer.
+
+**Implementation:** Uses a 1-hour sliding window for robustness against occasional timestamp errors.
+
+### `sts_candidate_count`
+
+Count of distinct vessels that have occupied the same H3 hexagon (resolution 8, ~0.7 km cell edge) within 2 hours of the subject vessel.
+
+**Shadow fleet signal:** Ship-to-Ship transfers occur at anchorages and in open water. Two tankers sharing the same ~0.7 km cell for a sustained period without a declared port call are STS candidates. H3 resolution 8 is chosen to match the beam of a VLCC at anchor (width ≈ 60 m) within the cell precision.
+
+**Implementation:** H3 hexagon IDs are pre-computed for all positions; a self-join on hexagon + time window identifies co-located vessels.
+
+### `port_call_ratio`
+
+Fraction of time in the window spent within 5 nm of a known port, as a proxy for legitimate port activity.
+
+**Shadow fleet signal:** Shadow fleet tankers minimise declared port calls to avoid physical inspection and AIS-based monitoring by port state control authorities. A low `port_call_ratio` combined with high loitering hours suggests the vessel is active at sea but avoiding port records.
+
+### `loitering_hours_30d`
+
+Total hours spent moving slower than 2 knots outside declared moorage areas, accumulated over the window.
+
+**Shadow fleet signal:** Loitering at sea at very low SOG (below steerage way) is a behavioural precursor to dark STS. Genuine commercial tankers loiter only when waiting for a berth, which shows up near ports. Open-water low-speed drifting suggests rendezvous behaviour.
+
+---
+
+## Identity Volatility features
+
+Source: Neo4j (ownership changes) + `vessel_meta` DuckDB table. Computed over a 2-year lookback.
+
+### `flag_changes_2y`
+
+Number of flag state changes recorded in the vessel registry over the past 2 years.
+
+**Shadow fleet signal:** Legitimate shipping companies rarely reflag vessels. Repeated reflagging — especially to open-registry states (Panama, Marshall Islands, Comoros) — is a known evasion technique to escape the watch-list of any single port state authority, reset OFAC exposure tracking, and complicate due-diligence checks.
+
+### `name_changes_2y`
+
+Number of vessel name changes in 2 years.
+
+**Shadow fleet signal:** Name changes are used to break continuity between a vessel's current identity and its history of sanctioned voyages. A vessel renamed from "ATLANTIC SUN" to "PACIFIC STAR" can avoid automated blocklist checks that match on vessel name.
+
+### `owner_changes_2y`
+
+Number of registered owner changes in 2 years.
+
+**Shadow fleet signal:** Ownership obfuscation through rapid beneficial-owner changes is a key sanctions evasion technique. This feature counts distinct ownership transitions recorded in the Equasis Neo4j graph over 2 years.
+
+### `high_risk_flag_ratio`
+
+Fraction of companies in the vessel's full ownership chain that are registered in high-risk flag states.
+
+**High-risk flags:** KP, IR, VE, SY, CU, RU, KM, GA, CM, PW, KI, TG, SL, ST
+
+**Shadow fleet signal:** Even if the vessel itself flies a neutral flag, shell companies up the ownership chain may be registered in North Korea, Iran, or Venezuela. This ratio surfaces ownership-level exposure that vessel-flag screening misses.
+
+### `ownership_depth`
+
+BFS path length from the vessel to the ultimate beneficial owner, capped at 5.
+
+**Shadow fleet signal:** The average legitimate tanker has an ownership chain of 2–3 hops (vessel → shipowner → holding company). Chains of 4–6 hops suggest deliberate opacity: SPVs nested inside other SPVs to frustrate beneficial ownership disclosure requirements.
+
+---
+
+## Ownership Graph features
+
+Source: Neo4j graph, computed via native Cypher BFS (no GDS plugin required). All graph features use `sanctions_distance` from the merged OpenSanctions dataset.
+
+### `sanctions_distance`
+
+Minimum BFS hop count from the vessel to any node in the Neo4j graph that carries a `SANCTIONED_BY` relationship.
+
+| Value | Meaning |
+|---|---|
+| 0 | Vessel itself is directly designated |
+| 1 | Registered owner or manager is designated |
+| 2 | Parent company or beneficial owner is designated |
+| 99 | No graph connection to any sanctioned entity |
+
+**Shadow fleet signal:** This is the strongest individual predictor in the model. A vessel 1–2 hops from an OFAC/EU/UN entity has a >60% empirical probability of appearing in open-source shadow fleet incident reports.
+
+### `cluster_sanctions_ratio`
+
+Fraction of vessels sharing the same registered owner or manager cluster that are individually sanctioned (i.e. have `sanctions_distance = 0`).
+
+**Shadow fleet signal:** Sanctioned fleets tend to operate in clusters. If 50% of the vessels sharing a manager are on the OFAC list, the remaining 50% are likely operating on behalf of the same beneficial owner but have not yet been individually designated.
+
+### `shared_manager_risk`
+
+Minimum `sanctions_distance` across all vessels co-managed with this vessel.
+
+**Shadow fleet signal:** A vessel managed by a company that also manages an OFAC-listed tanker inherits operational risk even if its own ownership chain looks clean.
+
+### `shared_address_centrality`
+
+Count of distinct vessels sharing the same registered company address.
+
+**Shadow fleet signal:** Shell companies used as nominee owners for sanctioned fleets frequently register multiple vessels at the same address. High centrality (> 5 vessels at one address) is a red flag for a nominee ownership structure.
+
+### `sts_hub_degree`
+
+Count of distinct vessels with which this vessel has had AIS-confirmed STS proximity events (from `sts_candidate_count` data).
+
+**Shadow fleet signal:** A vessel that repeatedly co-locates with many different partner vessels is functioning as an STS hub — a central intermediary in a dark transfer network. Hub degree > 3 is rare in legitimate bunkering operations.
+
+---
+
+## Trade Flow Mismatch features
+
+Source: DuckDB `trade_flow` table (populated from the UN Comtrade+ REST API, free tier 500 requests/day). Restricted to crude oil (HS 2709) and petroleum products (HS 2710).
+
+### `route_cargo_mismatch`
+
+Binary flag indicating whether the vessel is a tanker operating on routes from sanctioned exporters with no corresponding bilateral trade record in Comtrade.
+
+| Value | Condition |
+|---|---|
+| 1.0 | Tanker (AIS type 80–89) from a sanctioned flag state (KP, IR, VE, SY, CU, RU) with zero Comtrade crude imports from that flag in the period |
+| 0.5 | Some trade volume but below expected for vessel size |
+| 0.0 | Not a tanker, or not from a sanctioned flag |
+
+**Shadow fleet signal:** Iranian crude exports have been ~0 in official UN Comtrade records since 2019, yet ~1.5 mbpd of Iranian crude moves via dark tanker networks each year. A tanker arriving from Iranian waters with no matching Comtrade import record is operating off the books.
+
+### `declared_vs_estimated_cargo_value`
+
+Difference (USD) between the declared cargo value from AIS voyage data and the UN Comtrade statistical estimate for the same route.
+
+**Shadow fleet signal:** Deliberate under-declaration of cargo value is used to reduce tax and duty exposure in destination countries. A large positive discrepancy (declared < estimated) is consistent with dark oil sales.
+
+---
+
+## Build matrix
+
+`src/features/build_matrix.py` merges all four feature families on MMSI using DuckDB JOINs and writes the result to the `vessel_features` table. Missing values are filled with sensible defaults:
+
+| Column | Default when missing |
+|---|---|
+| `sanctions_distance` | 99 (no graph connection) |
+| `cluster_sanctions_ratio` | 0.0 |
+| `shared_manager_risk` | 99 |
+| `high_risk_flag_ratio` | 0.0 |
+| `ownership_depth` | 1 |
+| All count features | 0 |
+
+Pass `--skip-neo4j` to run without a Neo4j connection (graph features default to safe values).

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -1,0 +1,231 @@
+# Pipeline Operations
+
+How to run the arktrace MPOL screening pipeline for each supported region, configure parameters, and interpret outputs.
+
+## Quick start
+
+```bash
+# Interactive — prompts for region selection, retries failed steps
+uv run python scripts/run_pipeline.py
+
+# Non-interactive — Singapore region, fails fast
+uv run python scripts/run_pipeline.py --region singapore --non-interactive
+```
+
+Prerequisites: Docker (for Neo4j), a valid `AISSTREAM_API_KEY` in `.env`, and Python 3.12+.
+
+---
+
+## Region presets
+
+| Region | Flag | DuckDB | Gap threshold | Feature window | Weights (A / G / I) |
+|---|---|---|---|---|---|
+| Singapore / Malacca | `singapore` | `singapore.duckdb` | 6 h | 30 d | 0.40 / 0.40 / 0.20 |
+| Japan Sea / DPRK | `japan` | `japansea.duckdb` | 12 h | 60 d | 0.40 / 0.40 / 0.20 |
+| Middle East | `middleeast` | `middleeast.duckdb` | 12 h | 60 d | 0.40 / 0.40 / 0.20 |
+| Europe / Baltic | `europe` | `europe.duckdb` | 6 h | 45 d | 0.35 / 0.35 / 0.30 |
+| US Gulf | `gulf` | `gulf.duckdb` | 6 h | 14 d | 0.50 / 0.30 / 0.20 |
+
+The preset weights are starting points. The C3 causal model automatically calibrates `w_graph` at the start of each scoring cycle.
+
+---
+
+## Pipeline steps
+
+The pipeline runs 10 steps in sequence. Each step prints a status line; in interactive mode, failed steps prompt retry or skip.
+
+| # | Step | Key modules |
+|---|---|---|
+| 1 | Schema initialisation | `src/ingest/schema.py` |
+| 2 | Marine Cadastre historical backfill | `src/ingest/marine_cadastre.py` |
+| 3 | Neo4j startup | `scripts/start_neo4j.sh` |
+| 4 | Live AIS streaming | `src/ingest/ais_stream.py` |
+| 5 | Sanctions loading | `src/ingest/sanctions.py` |
+| 6 | Ownership graph | `src/ingest/vessel_registry.py` + `src/features/ownership_graph.py` |
+| 7 | Feature engineering | `src/features/ais_behavior.py` + `identity.py` + `trade_mismatch.py` + `build_matrix.py` |
+| 8 | Scoring | `src/score/causal_sanction.py` + `mpol_baseline.py` + `anomaly.py` + `composite.py` + `watchlist.py` |
+| 9 | GDELT ingestion | `src/ingest/gdelt.py` |
+| 10 | Dashboard | `src/api/main.py` (uvicorn) |
+
+---
+
+## Common CLI flags
+
+### Live AIS streaming (`--stream-duration`)
+
+```bash
+# Collect 300 seconds of live AIS before moving on
+uv run python scripts/run_pipeline.py --region singapore \
+  --non-interactive --stream-duration 300
+```
+
+Without `--stream-duration`, non-interactive mode skips live streaming entirely. In interactive mode, streaming runs until Ctrl-C.
+
+### Historical Marine Cadastre backfill (`--marine-cadastre-year`)
+
+Only available for US-covered regions (Gulf of Mexico and US coastal waters). Repeat for multiple years.
+
+```bash
+uv run python scripts/run_pipeline.py --region gulf \
+  --non-interactive \
+  --marine-cadastre-year 2022 \
+  --marine-cadastre-year 2023
+```
+
+### Geopolitical rerouting filter (`--geopolitical-event-filter`)
+
+Down-weights `anomaly_score` for vessels in declared rerouting corridors to reduce false positives. Supply the path to a JSON event file.
+
+```bash
+uv run python scripts/run_pipeline.py --region middleeast \
+  --non-interactive \
+  --geopolitical-event-filter config/geopolitical_events.json
+```
+
+`config/geopolitical_events.json` covers:
+- Red Sea / Cape of Good Hope rerouting (2023-11-01 → ongoing), down_weight 0.5
+- Taiwan Strait GPS spoofing zone (2024-01-01 → ongoing), down_weight 0.7
+
+Add new events to the JSON file without code changes. Format:
+
+```json
+{
+  "events": [
+    {
+      "name": "Description of event",
+      "active_from": "YYYY-MM-DD",
+      "active_to": "YYYY-MM-DD",
+      "corridors": [
+        {"lat_min": -40, "lat_max": -25, "lon_min": 10, "lon_max": 40}
+      ],
+      "down_weight": 0.5
+    }
+  ]
+}
+```
+
+### Dummy vessel seeding (`--seed-dummy`)
+
+Injects four realistic shadow fleet vessels (PETROVSKY ZVEZDA, SARI NOUR, OCEAN VOYAGER, VERA SUNSET) into the DB after feature engineering so they appear on the dashboard during demos without requiring real AIS data.
+
+```bash
+uv run python scripts/run_pipeline.py --region singapore \
+  --non-interactive --seed-dummy
+```
+
+---
+
+## Running steps individually
+
+Each module can be run standalone. Useful for re-running a single step after a failure without re-ingesting all data.
+
+```bash
+# Schema
+uv run python -m src.ingest.schema --db data/processed/singapore.duckdb
+
+# AIS feature engineering (30-day window, 6h gap threshold)
+uv run python -m src.features.ais_behavior \
+  --db data/processed/singapore.duckdb --window 30 --gap-threshold-hours 6
+
+# Build full feature matrix
+uv run python -m src.features.build_matrix --db data/processed/singapore.duckdb
+
+# MPOL baseline (service vessel exclusion on by default)
+uv run python -m src.score.mpol_baseline --db data/processed/singapore.duckdb
+
+# Anomaly scoring
+uv run python -m src.score.anomaly --db data/processed/singapore.duckdb
+
+# C3 causal calibration (produces causal_effects.parquet, prints calibrated w_graph)
+uv run python -m src.score.causal_sanction \
+  --db data/processed/singapore.duckdb \
+  --output data/processed/singapore_causal_effects.parquet
+
+# Composite scoring with calibrated weight
+uv run python -m src.score.composite \
+  --db data/processed/singapore.duckdb \
+  --w-graph 0.52 \
+  --geopolitical-event-filter config/geopolitical_events.json
+
+# Watchlist output
+uv run python -m src.score.watchlist --db data/processed/singapore.duckdb
+```
+
+---
+
+## Environment variables
+
+All configurable paths are also settable via environment variables (useful in Docker Compose):
+
+| Variable | Default | Description |
+|---|---|---|
+| `DB_PATH` | `data/processed/mpol.duckdb` | Active DuckDB path |
+| `AISSTREAM_API_KEY` | — | Required for live AIS ingestion |
+| `NEO4J_URI` | `bolt://localhost:7687` | Neo4j connection string |
+| `NEO4J_USER` | `neo4j` | Neo4j username |
+| `NEO4J_PASSWORD` | `neo4jpassword` | Neo4j password |
+| `WATCHLIST_OUTPUT_PATH` | `data/processed/candidate_watchlist.parquet` | Watchlist parquet output |
+| `COMPOSITE_SCORES_PATH` | `data/processed/composite_scores.parquet` | Composite scores output |
+| `CAUSAL_EFFECTS_PATH` | `data/processed/causal_effects.parquet` | C3 output |
+| `VALIDATION_METRICS_PATH` | `data/processed/validation_metrics.json` | Metrics for dashboard |
+
+---
+
+## Docker Compose
+
+```bash
+# Full pipeline (non-interactive, Singapore preset)
+PIPELINE_REGION=singapore docker compose run --rm pipeline
+
+# With historical backfill
+PIPELINE_REGION=gulf docker compose run --rm pipeline \
+  uv run python scripts/run_pipeline.py \
+  --region gulf --non-interactive \
+  --marine-cadastre-year 2023
+
+# Dashboard only (after pipeline has run)
+docker compose up dashboard
+```
+
+---
+
+## Cleared vessel feedback
+
+When a Phase B physical inspection returns `outcome = cleared`, record the MMSI in the `cleared_vessels` table. On the next scoring cycle, the vessel will be used as a hard negative in HDBSCAN and Isolation Forest training, lowering false positive rates for similar vessels.
+
+```bash
+# Add a cleared vessel (replace values as appropriate)
+duckdb data/processed/singapore.duckdb << 'SQL'
+INSERT INTO cleared_vessels (mmsi, cleared_by, investigation_id, notes)
+VALUES ('123456789', 'officer_kim', 'INV-2026-042',
+        'Boarded 2026-04-15; IMO confirmed, cargo documents valid');
+SQL
+```
+
+---
+
+## Output files
+
+| File | Description |
+|---|---|
+| `data/processed/<region>.duckdb` | All ingested and computed data for the region |
+| `data/processed/<region>_causal_effects.parquet` | C3 causal model per-regime ATT estimates |
+| `data/processed/composite_scores.parquet` | Full scored vessel frame (all vessels) |
+| `data/processed/candidate_watchlist.parquet` | Top candidates, sorted by confidence |
+| `data/processed/validation_metrics.json` | Precision@50, Recall@200, AUROC |
+
+---
+
+## Troubleshooting
+
+**Step 3 (Neo4j) fails — Docker not running**
+Start Docker Desktop and retry. Alternatively, pass `--skip-neo4j` to `build_matrix.py` to run without graph features (graph features default to safe values).
+
+**Step 4 (AIS stream) — 0 rows inserted**
+Check `AISSTREAM_API_KEY` in `.env` and verify the bounding box covers an area with vessel traffic.
+
+**Step 8 (Scoring) — composite returns empty DataFrame**
+`vessel_features` is empty. Re-run step 7 (feature engineering) and confirm `build_matrix.py` completed without errors.
+
+**Dashboard shows no vessels**
+Confirm `WATCHLIST_OUTPUT_PATH` points to the correct parquet file and that it contains rows (`polars.read_parquet(path).height > 0`).

--- a/docs/scoring-model.md
+++ b/docs/scoring-model.md
@@ -1,0 +1,211 @@
+# Scoring Model
+
+The arktrace scoring engine is a three-stage ML pipeline that converts the 19-feature vessel matrix into a single `confidence` score in [0, 1]. Higher scores indicate stronger shadow fleet candidacy.
+
+## Pipeline overview
+
+```
+vessel_features (19 cols)
+        │
+        ├──► HDBSCAN Baseline  (mpol_baseline.py)
+        │         │  baseline_noise_score ∈ {0.0, 1.0}
+        │         ▼
+        └──► Isolation Forest  (anomaly.py)
+                  │  anomaly_score ∈ [0, 1]
+                  ▼
+             Composite Score   (composite.py)
+                  │  confidence ∈ [0, 1]
+                  ▼
+             Watchlist Output  (watchlist.py)
+                  candidate_watchlist.parquet
+```
+
+---
+
+## Stage 1 — HDBSCAN baseline (`src/score/mpol_baseline.py`)
+
+### Purpose
+
+HDBSCAN clusters vessels by behavioural features to define what "normal MPOL behaviour" looks like in the area of interest. Vessels assigned to cluster -1 (HDBSCAN noise) receive `baseline_noise_score = 1.0`; all others receive `0.0`.
+
+### Features used
+
+Six AIS behavioral features: `ais_gap_count_30d`, `ais_gap_max_hours`, `position_jump_count`, `sts_candidate_count`, `port_call_ratio`, `loitering_hours_30d`.
+
+### Clustering design
+
+- Data is partitioned by `ship_type` before clustering. Tankers (type 80–89) form separate clusters from cargo vessels (70–79), so the baseline captures type-specific normality.
+- Service vessel types (AIS 51–59, 31–32 — bunker barges, pilot tenders, SAR craft) are **excluded from HDBSCAN training** by default (`exclude_service_vessels=True`). These craft have high loitering and low SOG that would otherwise compress anomaly scores for shadow fleet STS events near busy anchorages (e.g. Singapore Strait). They are still scored by the Isolation Forest.
+- `min_cluster_size` scales automatically with group size: `max(2, min(10, n // 2))`.
+
+### Cleared vessel hard negatives
+
+Vessels physically inspected and cleared by a Phase B patrol (recorded in the `cleared_vessels` table) always receive `baseline_noise_score = 0.0`, preventing confirmed-normal vessels from inflating false-positive rates in future scoring cycles.
+
+### Hyperparameters
+
+| Parameter | Value |
+|---|---|
+| Algorithm | `sklearn.cluster.HDBSCAN` |
+| `min_samples` | 1 |
+| `allow_single_cluster` | True |
+| Preprocessing | `StandardScaler` per group |
+
+---
+
+## Stage 2 — Isolation Forest anomaly scoring (`src/score/anomaly.py`)
+
+### Purpose
+
+The Isolation Forest assigns each vessel a continuous anomaly score in [0, 1]. It is trained on the "clean" vessel population (vessels with no proximity to sanctioned entities) and then scored on all vessels, including the suspicious ones.
+
+### Features used
+
+All 19 features from `vessel_features`.
+
+### Training set selection
+
+The model trains only on vessels with `sanctions_distance ≥ 3` — far enough from any sanctioned entity to serve as a reasonable clean baseline. If this subset is too small (< 4 vessels), the full feature frame is used as a fallback. **Cleared vessels** from the `cleared_vessels` table are always included in the clean training subset as hard negatives, regardless of their `sanctions_distance`.
+
+### Anomaly score formula
+
+```python
+raw = -model.decision_function(scaled)   # higher = more anomalous
+anomaly_score = 0.75 * norm(raw) + 0.25 * baseline_noise_score
+```
+
+The isolation forest raw score is min-max normalised to [0, 1], then blended 75/25 with the HDBSCAN baseline noise score. The blend ensures that a vessel whose behaviour is globally anomalous (Isolation Forest) AND locally anomalous relative to its ship-type peer group (HDBSCAN noise) receives the highest possible anomaly score.
+
+### Hyperparameters
+
+| Parameter | Value |
+|---|---|
+| Algorithm | `sklearn.ensemble.IsolationForest` |
+| `n_estimators` | 200 |
+| `contamination` | "auto" |
+| `random_state` | 42 |
+| Preprocessing | `StandardScaler` fit on clean subset |
+
+---
+
+## Stage 3 — Composite confidence score (`src/score/composite.py`)
+
+### Purpose
+
+The composite score combines three independent signal families into a single `confidence` value used to rank vessels on the watchlist.
+
+### Formula
+
+```
+confidence = w_anomaly × anomaly_score
+           + w_graph   × graph_risk_score
+           + w_identity × identity_score
+```
+
+Default weights: `w_anomaly = 0.40`, `w_graph = 0.40`, `w_identity = 0.20`.
+
+Weights are region-configurable (see `--w-anomaly`, `--w-graph`, `--w-identity` flags) and automatically calibrated by the C3 causal model (see below).
+
+### Component scores
+
+#### `graph_risk_score`
+
+Weighted combination of three ownership graph signals:
+
+```python
+graph_risk = 0.6 × sanctions_component
+           + 0.3 × cluster_component
+           + 0.1 × manager_component
+```
+
+- `sanctions_component = clip(1 − sanctions_distance / 5, 0, 1)` — maps distance 0 → 1.0, distance 5+ → 0.0
+- `cluster_component = cluster_sanctions_ratio` — direct [0, 1] value
+- `manager_component = clip(1 − shared_manager_risk / 5, 0, 1)` — same mapping as sanctions_component
+
+#### `identity_score`
+
+Weighted combination of identity volatility signals:
+
+```python
+identity = 0.30 × clip(flag_changes_2y / 5, 0, 1)
+         + 0.25 × clip(name_changes_2y / 5, 0, 1)
+         + 0.20 × clip(owner_changes_2y / 5, 0, 1)
+         + 0.15 × clip(high_risk_flag_ratio, 0, 1)
+         + 0.10 × clip(ownership_depth / 6, 0, 1)
+```
+
+#### `anomaly_score`
+
+Output of Stage 2.
+
+### Geopolitical rerouting filter
+
+Before computing `confidence`, an optional geopolitical filter can down-weight `anomaly_score` for vessels in declared rerouting corridors (e.g. Cape of Good Hope diversion since 2023). This reduces false positives from legitimate commercial rerouting. Pass `--geopolitical-event-filter config/geopolitical_events.json`.
+
+See `config/geopolitical_events.json` for the sample file format.
+
+---
+
+## C3 causal weight calibration (`src/score/causal_sanction.py`)
+
+The default `w_graph = 0.40` is calibrated automatically by the C3 Difference-in-Differences model before each scoring cycle. The model estimates the Average Treatment Effect on the Treated (ATT) for three sanction regimes:
+
+| Regime | Announcement dates used |
+|---|---|
+| OFAC Iran | 2012-03-15, 2019-05-08, 2020-01-10 |
+| OFAC Russia | 2022-02-24, 2022-09-15, 2023-02-24 |
+| UN DPRK | 2017-08-05, 2017-09-11, 2017-12-22 |
+
+If the ATT is positive and statistically significant (p < 0.05) for a regime, the graph risk dimension is predictive → `w_graph` is increased proportionally, up to a cap of 0.65. The remaining weight is redistributed proportionally between `w_anomaly` and `w_identity`.
+
+The calibrated weight and per-regime effect sizes are written to `<region>_causal_effects.parquet`.
+
+---
+
+## SHAP explainability (`src/score/composite.py → _compute_top_signals`)
+
+Each row on the watchlist includes a `top_signals` JSON array identifying the 3 features that most influenced the vessel's anomaly score, using SHAP TreeExplainer values from the Isolation Forest:
+
+```json
+[
+  {"feature": "ais_gap_count_30d",  "value": 14,   "contribution": 0.42},
+  {"feature": "sanctions_distance", "value": 1,    "contribution": 0.31},
+  {"feature": "sts_hub_degree",     "value": 6,    "contribution": 0.18}
+]
+```
+
+Contributions are normalised to sum to 1.0 across the top 3. This satisfies the Cap Vista explainability requirement and is rendered in the dashboard alongside the confidence badge.
+
+---
+
+## Validation metrics (`src/score/validate.py`)
+
+The pipeline computes validation metrics against a holdout set of OFAC-listed vessels as positive labels:
+
+| Metric | Target | Meaning |
+|---|---|---|
+| Precision@50 | ≥ 0.60 | ≥ 30 of the top-50 candidates are confirmed OFAC-listed |
+| Recall@200 | — | Fraction of all OFAC-listed vessels recovered in the top 200 |
+| AUROC | — | Area under the ROC curve across the full ranked list |
+
+Metrics are written to `data/processed/validation_metrics.json` and surfaced at `/api/metrics` in the dashboard.
+
+---
+
+## Watchlist output (`src/score/watchlist.py`)
+
+`candidate_watchlist.parquet` contains one row per vessel, sorted by `confidence` descending. Key columns:
+
+| Column | Type | Description |
+|---|---|---|
+| mmsi | str | Maritime Mobile Service Identity |
+| imo | str | IMO number (from vessel_meta) |
+| vessel_name | str | Last known vessel name |
+| vessel_type | str | Human-readable type label (Tanker, Cargo, …) |
+| confidence | float32 | Composite score ∈ [0, 1] |
+| anomaly_score | float32 | Stage 2 output |
+| graph_risk_score | float32 | Ownership graph component |
+| identity_score | float32 | Identity volatility component |
+| top_signals | JSON str | Top-3 SHAP contributing features |
+| last_lat / last_lon | float64 | Most recent AIS position |
+| last_seen | timestamptz | Most recent AIS timestamp |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,11 @@ nav:
   - Technical Solution: technical-solution.md
   - Scenarios: scenarios.md
   - Roadmap: roadmap.md
+  - Analytics:
+    - Overview: analytics-overview.md
+    - Feature Engineering: feature-engineering.md
+    - Scoring Model: scoring-model.md
+    - Pipeline Operations: pipeline-operations.md
   - Field Investigation: field-investigation.md
   - Local E2E Test: local-e2e-test.md
   - Deployment: deployment.md


### PR DESCRIPTION
## Summary

- `docs/analytics-overview.md` — pipeline diagram, data source table, DuckDB schema overview, Neo4j graph model, LanceDB GDELT index, 10-step orchestration summary
- `docs/feature-engineering.md` — all 19 features across 4 families with signal rationale and implementation detail for each
- `docs/scoring-model.md` — HDBSCAN baseline design, Isolation Forest training, SHAP explainability, composite formula, C3 causal weight calibration, validation metrics
- `docs/pipeline-operations.md` — region presets, per-step CLI reference, all flags, env vars, Docker Compose, cleared vessel feedback loop, troubleshooting
- `mkdocs.yml` — adds Analytics nav section with the four new pages

Closes #33

## Test plan

- [x] `mkdocs build` passes (all four new pages resolve in nav)
- [x] No broken internal links — all cross-references use existing file names
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)