### PR TITLE
Implement #57 dashboard review and handoff workflow

### DIFF
--- a/src/api/routes/vessels.py
+++ b/src/api/routes/vessels.py
@@ -81,7 +81,7 @@ def watchlist_top(
 ) -> HTMLResponse:
     df = _load_watchlist()
     if df.is_empty():
-        return HTMLResponse("<tr><td colspan='6'>No data — run watchlist.py first.</td></tr>")
+        return HTMLResponse("<tr><td colspan='9'>No data — run watchlist.py first.</td></tr>")
 
     filtered = df.filter(pl.col("confidence") >= min_confidence)
     if vessel_types:
@@ -91,6 +91,8 @@ def watchlist_top(
     for row in filtered.head(top_n).with_columns(pl.col("last_seen").cast(pl.Utf8)).to_dicts():
         conf = row["confidence"]
         badge_class = "badge-red" if conf >= 0.7 else "badge-yellow" if conf >= 0.4 else "badge-green"
+        vessel_name = str(row["vessel_name"])
+        safe_name_attr = vessel_name.replace("'", "&#39;")
         try:
             signals = json.loads(row.get("top_signals") or "[]")
             signals_text = ", ".join(f"{s['feature']}" for s in signals[:2]) if signals else "—"
@@ -100,13 +102,16 @@ def watchlist_top(
         lat = row.get("last_lat") or ""
         lon = row.get("last_lon") or ""
         rows_html.append(
-            f"<tr class='watchlist-row' data-mmsi='{row['mmsi']}' data-lat='{lat}' data-lon='{lon}' data-name='{row['vessel_name']}'>"
+            f"<tr class='watchlist-row' data-mmsi='{row['mmsi']}' data-lat='{lat}' data-lon='{lon}' data-name='{safe_name_attr}'>"
             f"<td>{row['mmsi']}</td>"
-            f"<td>{row['vessel_name']}</td>"
+            f"<td>{vessel_name}</td>"
             f"<td>{row['vessel_type']}</td>"
             f"<td>{row['flag']}</td>"
             f"<td><span class='badge {badge_class}'>{conf:.2f}</span></td>"
             f"<td class='signals'>{signals_text}</td>"
+            f"<td class='review-tier' data-mmsi='{row['mmsi']}'>—</td>"
+            f"<td class='review-handoff' data-mmsi='{row['mmsi']}'>—</td>"
+            f"<td><button class='brief-btn review-btn' onclick=\"event.stopPropagation(); openReviewPanel('{row['mmsi']}', '{safe_name_attr}');\">Review</button></td>"
             f"</tr>"
         )
 

--- a/src/viz/templates/index.html
+++ b/src/viz/templates/index.html
@@ -322,6 +322,129 @@
       font-family: inherit;
     }
     .brief-btn:hover { background: #2563eb; }
+
+    .review-btn {
+      margin-top: 0;
+      padding: 0.2rem 0.45rem;
+      font-size: 0.68rem;
+      white-space: nowrap;
+    }
+
+    .review-pill {
+      display: inline-block;
+      padding: 0.1rem 0.35rem;
+      border-radius: 3px;
+      font-size: 0.66rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      border: 1px solid #334155;
+      color: #cbd5e1;
+      background: #111827;
+      max-width: 100px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .review-pill-tier-confirmed { color: #4ade80; border-color: #166534; }
+    .review-pill-tier-probable { color: #facc15; border-color: #854d0e; }
+    .review-pill-tier-suspect { color: #fb923c; border-color: #9a3412; }
+    .review-pill-tier-cleared { color: #60a5fa; border-color: #1d4ed8; }
+    .review-pill-tier-inconclusive { color: #c4b5fd; border-color: #5b21b6; }
+
+    /* ── Review panel ───────────────────────────────────── */
+    #review-panel {
+      display: none;
+      flex-direction: column;
+      height: 320px;
+      min-height: 260px;
+      background: #131a25;
+      border-top: 1px solid #2d3748;
+      flex-shrink: 0;
+    }
+    #review-panel.active { display: flex; }
+
+    .review-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.5rem 1rem;
+      border-bottom: 1px solid #2d3748;
+      background: #161b27;
+      gap: 0.75rem;
+    }
+    .review-header-label {
+      font-size: 0.8rem;
+      color: #93c5fd;
+      font-weight: 600;
+    }
+
+    .review-header-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .review-grid {
+      display: grid;
+      grid-template-columns: 1.1fr 0.9fr;
+      gap: 0.8rem;
+      padding: 0.75rem 1rem;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .review-form, .review-summary {
+      background: #0f1117;
+      border: 1px solid #2d3748;
+      border-radius: 6px;
+      padding: 0.65rem;
+      overflow-y: auto;
+    }
+
+    .review-form h3, .review-summary h3 {
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #94a3b8;
+      margin-bottom: 0.45rem;
+    }
+
+    .review-form-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .review-form select,
+    .review-form textarea,
+    .review-form input {
+      width: 100%;
+      background: #0b1020;
+      border: 1px solid #2d3748;
+      color: #e2e8f0;
+      border-radius: 4px;
+      padding: 0.35rem 0.45rem;
+      font-size: 0.76rem;
+      font-family: inherit;
+    }
+
+    .review-form textarea {
+      min-height: 72px;
+      resize: vertical;
+    }
+
+    .review-actions {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.55rem;
+    }
+
+    .review-status {
+      font-size: 0.72rem;
+      color: #93c5fd;
+      margin-top: 0.4rem;
+    }
   </style>
 </head>
 <body>
@@ -371,6 +494,7 @@
       </div>
 
       <button class="apply-btn" onclick="applyFilters()">Apply</button>
+      <button class="apply-btn" style="background:#0f766e;" onclick="startQuickReview()">Quick Review Top N</button>
     </div>
 
     <!-- HTMX-powered ranked table -->
@@ -384,6 +508,9 @@
             <th>Flag</th>
             <th>Score</th>
             <th>Signals</th>
+            <th>Tier</th>
+            <th>Handoff</th>
+            <th>Review</th>
           </tr>
         </thead>
         <tbody
@@ -398,6 +525,77 @@
 
   <!-- Map -->
   <div id="map"></div>
+</div>
+
+<!-- Review panel (bottom) -->
+<div id="review-panel">
+  <div class="review-header">
+    <span class="review-header-label" id="review-vessel-label">Review Decision</span>
+    <div class="review-header-actions">
+      <button class="apply-btn" style="width:auto;padding:0.3rem 0.7rem;font-size:0.75rem;background:#0f766e;" onclick="openNextReviewCandidate()">Next Candidate</button>
+      <button class="chat-close-btn" onclick="closeReviewPanel()" title="Close">&#x2715;</button>
+    </div>
+  </div>
+  <div class="review-grid">
+    <div class="review-form">
+      <h3>Decision Input</h3>
+      <div class="review-form-row">
+        <div>
+          <label>Tier</label>
+          <select id="review-tier-select">
+            <option value="confirmed">Confirmed</option>
+            <option value="probable">Probable</option>
+            <option value="suspect" selected>Suspect</option>
+            <option value="cleared">Cleared</option>
+            <option value="inconclusive">Inconclusive</option>
+          </select>
+        </div>
+        <div>
+          <label>Handoff</label>
+          <select id="review-handoff-select">
+            <option value="queued_review">Queued review</option>
+            <option value="in_review" selected>In review</option>
+            <option value="handoff_recommended">Handoff recommended</option>
+            <option value="handoff_accepted">Handoff accepted</option>
+            <option value="handoff_completed">Handoff completed</option>
+            <option value="closed">Closed</option>
+          </select>
+        </div>
+      </div>
+      <div class="review-form-row">
+        <div>
+          <label>Reviewer</label>
+          <input id="reviewer-id" type="text" placeholder="analyst-id" />
+        </div>
+        <div>
+          <label>Evidence source</label>
+          <input id="evidence-source" type="text" placeholder="ofac_notice" />
+        </div>
+      </div>
+      <div class="review-form-row">
+        <div>
+          <label>Evidence URL</label>
+          <input id="evidence-url" type="text" placeholder="https://..." />
+        </div>
+        <div>
+          <label>Published date</label>
+          <input id="evidence-published" type="text" placeholder="YYYY-MM-DD" />
+        </div>
+      </div>
+      <div>
+        <label>Rationale</label>
+        <textarea id="review-rationale" placeholder="Why this tier / handoff decision was chosen"></textarea>
+      </div>
+      <div class="review-actions">
+        <button class="apply-btn" style="background:#2563eb;" onclick="saveReviewDecision()">Save Review</button>
+      </div>
+      <div class="review-status" id="review-status">Select a vessel to review.</div>
+    </div>
+    <div class="review-summary">
+      <h3>Latest Review Summary</h3>
+      <div id="review-summary-content" style="font-size:0.76rem;line-height:1.45;color:#cbd5e1;">No review loaded.</div>
+    </div>
+  </div>
 </div>
 
 <!-- Chat panel (bottom) -->
@@ -485,6 +683,13 @@ map.on('load', () => {
   loadMetrics();
   loadVesselTypes();
   startAlertStream();
+  setTimeout(refreshReviewBadges, 150);
+});
+
+document.body.addEventListener('htmx:afterSwap', (evt) => {
+  if (evt.target && evt.target.id === 'watchlist-tbody') {
+    refreshReviewBadges();
+  }
 });
 
 // ── Table row click → fly to vessel ───────────────────────────────────────
@@ -588,6 +793,195 @@ function loadVesselTypes() {
       });
     })
     .catch(console.error);
+}
+
+// ── Review workflow panel ─────────────────────────────────────────────────
+let currentReviewMmsi = null;
+let reviewQueue = [];
+let reviewQueueIndex = -1;
+
+async function fetchLatestReview(mmsi) {
+  const r = await fetch(`/api/reviews/${mmsi}`);
+  if (r.status === 404) return null;
+  if (!r.ok) throw new Error(`review fetch failed: ${r.status}`);
+  return r.json();
+}
+
+function _pillForTier(tier) {
+  if (!tier) return '—';
+  const cls = `review-pill review-pill-tier-${tier}`;
+  return `<span class="${cls}">${tier}</span>`;
+}
+
+function _pillForHandoff(handoff) {
+  if (!handoff) return '—';
+  return `<span class="review-pill">${handoff.replaceAll('_', ' ')}</span>`;
+}
+
+function setRowReviewState(mmsi, review) {
+  const tierCell = document.querySelector(`.review-tier[data-mmsi='${mmsi}']`);
+  const handoffCell = document.querySelector(`.review-handoff[data-mmsi='${mmsi}']`);
+  if (!tierCell || !handoffCell) return;
+  if (!review) {
+    tierCell.textContent = '—';
+    handoffCell.textContent = '—';
+    return;
+  }
+  tierCell.innerHTML = _pillForTier(review.review_tier);
+  handoffCell.innerHTML = _pillForHandoff(review.handoff_state);
+}
+
+async function refreshReviewBadges() {
+  const rows = Array.from(document.querySelectorAll('#watchlist-tbody tr.watchlist-row'));
+  await Promise.all(rows.map(async (row) => {
+    const mmsi = row.dataset.mmsi;
+    if (!mmsi) return;
+    try {
+      const review = await fetchLatestReview(mmsi);
+      setRowReviewState(mmsi, review);
+    } catch {
+      setRowReviewState(mmsi, null);
+    }
+  }));
+}
+
+function _escapeHtml(s) {
+  return String(s || '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function renderReviewSummary(review) {
+  const content = document.getElementById('review-summary-content');
+  if (!review) {
+    content.textContent = 'No existing review for this vessel.';
+    return;
+  }
+
+  const refs = (review.evidence_refs || []).map((ref) => {
+    const source = _escapeHtml(ref.source || 'unknown');
+    const url = _escapeHtml(ref.url || '');
+    const date = _escapeHtml(ref.published_at || '');
+    const tail = date ? ` (${date})` : '';
+    return `<li>${source}${tail}${url ? ` — <a href="${url}" target="_blank" style="color:#93c5fd;">link</a>` : ''}</li>`;
+  }).join('');
+
+  content.innerHTML =
+    `<div><strong>Tier:</strong> ${_escapeHtml(review.review_tier)}</div>` +
+    `<div><strong>Handoff:</strong> ${_escapeHtml(review.handoff_state).replaceAll('_', ' ')}</div>` +
+    `<div><strong>Reviewer:</strong> ${_escapeHtml(review.reviewed_by || '—')}</div>` +
+    `<div><strong>Reviewed at:</strong> ${_escapeHtml(review.reviewed_at || '—')}</div>` +
+    `<div style="margin-top:0.4rem;"><strong>Rationale</strong><br/>${_escapeHtml(review.rationale || '—')}</div>` +
+    `<div style="margin-top:0.4rem;"><strong>Evidence</strong><ul style="margin:0.25rem 0 0 1rem;">${refs || '<li>—</li>'}</ul></div>`;
+}
+
+async function openReviewPanel(mmsi, vesselName) {
+  currentReviewMmsi = mmsi;
+  document.getElementById('review-vessel-label').textContent = `${vesselName} (MMSI ${mmsi})`;
+  document.getElementById('review-panel').classList.add('active');
+  document.getElementById('review-status').textContent = 'Loading latest review...';
+
+  try {
+    const review = await fetchLatestReview(mmsi);
+    if (review) {
+      document.getElementById('review-tier-select').value = review.review_tier;
+      document.getElementById('review-handoff-select').value = review.handoff_state;
+      document.getElementById('review-rationale').value = review.rationale || '';
+      document.getElementById('reviewer-id').value = review.reviewed_by || '';
+      const firstRef = (review.evidence_refs || [])[0] || {};
+      document.getElementById('evidence-source').value = firstRef.source || '';
+      document.getElementById('evidence-url').value = firstRef.url || '';
+      document.getElementById('evidence-published').value = firstRef.published_at || '';
+      renderReviewSummary(review);
+      document.getElementById('review-status').textContent = 'Loaded latest review.';
+      setRowReviewState(mmsi, review);
+    } else {
+      document.getElementById('review-tier-select').value = 'suspect';
+      document.getElementById('review-handoff-select').value = 'in_review';
+      document.getElementById('review-rationale').value = '';
+      document.getElementById('reviewer-id').value = '';
+      document.getElementById('evidence-source').value = '';
+      document.getElementById('evidence-url').value = '';
+      document.getElementById('evidence-published').value = '';
+      renderReviewSummary(null);
+      document.getElementById('review-status').textContent = 'No previous review. Fill fields and save.';
+    }
+  } catch {
+    document.getElementById('review-status').textContent = 'Failed to load review.';
+  }
+}
+
+function closeReviewPanel() {
+  document.getElementById('review-panel').classList.remove('active');
+  currentReviewMmsi = null;
+}
+
+async function saveReviewDecision() {
+  if (!currentReviewMmsi) return;
+  const evidenceSource = document.getElementById('evidence-source').value.trim();
+  const evidenceRefs = evidenceSource
+    ? [{
+      source: evidenceSource,
+      url: document.getElementById('evidence-url').value.trim(),
+      published_at: document.getElementById('evidence-published').value.trim(),
+    }]
+    : [];
+
+  const payload = {
+    mmsi: currentReviewMmsi,
+    review_tier: document.getElementById('review-tier-select').value,
+    handoff_state: document.getElementById('review-handoff-select').value,
+    rationale: document.getElementById('review-rationale').value.trim(),
+    reviewed_by: document.getElementById('reviewer-id').value.trim(),
+    evidence_refs: evidenceRefs,
+  };
+
+  document.getElementById('review-status').textContent = 'Saving...';
+  try {
+    const r = await fetch('/api/reviews', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!r.ok) {
+      const body = await r.json().catch(() => ({}));
+      throw new Error(body.detail || `HTTP ${r.status}`);
+    }
+    const saved = await r.json();
+    setRowReviewState(currentReviewMmsi, saved);
+    renderReviewSummary(saved);
+    document.getElementById('review-status').textContent = 'Saved review decision.';
+  } catch (err) {
+    document.getElementById('review-status').textContent = `Save failed: ${err}`;
+  }
+}
+
+function startQuickReview() {
+  const rows = Array.from(document.querySelectorAll('#watchlist-tbody tr.watchlist-row'));
+  reviewQueue = rows.map((r) => ({ mmsi: r.dataset.mmsi, name: r.dataset.name || r.dataset.mmsi })).filter((x) => x.mmsi);
+  reviewQueueIndex = 0;
+  if (reviewQueue.length === 0) {
+    document.getElementById('review-status').textContent = 'No candidates available in current Top-N list.';
+    return;
+  }
+  const cur = reviewQueue[reviewQueueIndex];
+  openReviewPanel(cur.mmsi, cur.name);
+}
+
+function openNextReviewCandidate() {
+  if (reviewQueue.length === 0) {
+    startQuickReview();
+    return;
+  }
+  reviewQueueIndex += 1;
+  if (reviewQueueIndex >= reviewQueue.length) {
+    reviewQueueIndex = reviewQueue.length - 1;
+    document.getElementById('review-status').textContent = 'Reached end of current quick-review queue.';
+    return;
+  }
+  const cur = reviewQueue[reviewQueueIndex];
+  openReviewPanel(cur.mmsi, cur.name);
 }
 
 // ── Chat panel ─────────────────────────────────────────────────────────────

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,6 +89,9 @@ def test_watchlist_top_html(client):
     assert r.status_code == 200
     assert "watchlist-row" in r.text
     assert "OCEAN GLORY" in r.text
+    assert "review-tier" in r.text
+    assert "review-handoff" in r.text
+    assert "Review</button>" in r.text
 
 
 def test_watchlist_top_filtered(client):


### PR DESCRIPTION
## Summary
- implement #57 dashboard review and investigation handoff workflow
- add Tier/Handoff visibility in the top-N watchlist table
- add in-dashboard review panel to update tier, handoff state, rationale, and evidence
- add quick-review flow for current top-N candidates with next-candidate navigation

## Files changed
- src/viz/templates/index.html
- src/api/routes/vessels.py
- tests/test_api.py

## Validation
- uv run --group dev python -m pytest tests/test_api.py tests/test_reviews_api.py -q
- result: 13 passed

## Related
- refs #57

Per requested workflow, issue will remain open until PR is merged.
