### PR TITLE
Add review history API, ops shell, and dashboard polish — closes #54

### DIFF
--- a/docs/pipeline-catalog.md
+++ b/docs/pipeline-catalog.md
@@ -8,6 +8,17 @@ It focuses on four questions:
 3. When should it run?
 4. What result should operators expect?
 
+## Scope Clarification: Backend Jobs vs Web UI Operations
+
+The pipeline types in this document refer to backend execution jobs (batch, scheduled, or event-triggered runs), not manual button-by-button work in the web dashboard.
+
+- Backend jobs:
+	- Run by CI/CD, schedulers (cron/orchestrator), long-running services, or operator-triggered CLI/API calls.
+	- Produce and refresh data artifacts such as DuckDB tables, watchlists, scores, and evaluation reports.
+- Web UI operations:
+	- Human review and investigation workflow in the dashboard (filter, inspect vessel detail, submit tier/handoff decisions).
+	- Consume pipeline outputs and write review feedback, but do not replace core ingestion/scoring/evaluation pipeline execution.
+
 For implementation-level commands and flags, see [Pipeline Operations](pipeline-operations.md).
 
 ## Pipeline Types At A Glance
@@ -202,13 +213,13 @@ Provide fast deterministic validation of dashboard and operator flow without ful
 
 ## Suggested Operations Cadence
 
-| Cadence | Pipeline | Goal |
-|---|---|---|
-| Continuous | Continuous Monitoring | Live situational awareness |
-| Daily or per watch | Full Screening (if non-streaming mode) | Fresh candidate ranking |
-| Weekly | Review-Feedback Evaluation | Threshold tuning and drift control |
-| Pre-release | Historical Backtesting + Public Integration Batch | Quality gate before change promotion |
-| On-demand | Demo/Smoke | Fast verification and incident checks |
+| Cadence | Pipeline | Goal | Trigger Type | Triggered By (if Event) |
+|---|---|---|---|---|
+| Continuous | Continuous Monitoring | Live situational awareness | Scheduled (always-on service loop) | N/A |
+| Daily or per watch | Full Screening (if non-streaming mode) | Fresh candidate ranking | Scheduled or Event-triggered | Duty operations officer / shift lead |
+| Weekly | Review-Feedback Evaluation | Threshold tuning and drift control | Scheduled | N/A |
+| Pre-release | Historical Backtesting + Public Integration Batch | Quality gate before change promotion | Event-triggered | Release owner / CI pipeline on release candidate |
+| On-demand | Demo/Smoke | Fast verification and incident checks | Event-triggered | Analyst / operator / incident commander |
 
 ## Decision Guide
 

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -16,6 +16,20 @@ uv run python scripts/run_pipeline.py --region singapore --non-interactive
 
 Prerequisites: a valid `AISSTREAM_API_KEY` in `.env` and Python 3.12+.
 
+### Interactive operations shell
+
+Run a menu-driven shell that lets you execute common operations jobs and prints a result summary after each run.
+
+```bash
+bash scripts/run_operations_shell.sh
+```
+
+Available menu jobs:
+- Full Screening
+- Review-Feedback Evaluation
+- Historical Backtesting + Public Integration Batch
+- Demo/Smoke
+
 ---
 
 ## Region presets

--- a/scripts/run_operations_shell.py
+++ b/scripts/run_operations_shell.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import polars as pl
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+DATA_DIR = PROJECT_ROOT / "data" / "processed"
+
+WATCHLIST_BY_REGION = {
+    "singapore": DATA_DIR / "singapore_watchlist.parquet",
+    "japan": DATA_DIR / "japansea_watchlist.parquet",
+    "middleeast": DATA_DIR / "middleeast_watchlist.parquet",
+    "europe": DATA_DIR / "europe_watchlist.parquet",
+    "gulf": DATA_DIR / "gulf_watchlist.parquet",
+}
+
+
+def _prompt(prompt: str, default: str | None = None) -> str:
+    suffix = f" [{default}]" if default is not None else ""
+    value = input(f"{prompt}{suffix}: ").strip()
+    if not value and default is not None:
+        return default
+    return value
+
+
+def _prompt_yes_no(prompt: str, default: bool = False) -> bool:
+    label = "Y/n" if default else "y/N"
+    raw = input(f"{prompt} ({label}): ").strip().lower()
+    if not raw:
+        return default
+    return raw in {"y", "yes"}
+
+
+def _run_command(cmd: list[str]) -> int:
+    print("\nRunning command:")
+    print("  " + " ".join(cmd))
+    print()
+    result = subprocess.run(cmd, cwd=PROJECT_ROOT)
+    return result.returncode
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _print_watchlist_summary(path: Path) -> None:
+    if not path.exists():
+        print(f"Result: watchlist not found at {path}")
+        return
+
+    df = pl.read_parquet(path)
+    count = df.height
+    print(f"Result: watchlist rows = {count}")
+    if count > 0 and {"mmsi", "confidence"}.issubset(set(df.columns)):
+        top = df.sort("confidence", descending=True).head(1)
+        row = top.to_dicts()[0]
+        print(
+            "Top candidate: "
+            f"mmsi={row.get('mmsi')} confidence={row.get('confidence')}"
+        )
+    print(f"Artifact: {path}")
+
+
+def run_full_screening() -> None:
+    print("\n[1] Full Screening")
+    region = _prompt(
+        "Region (singapore/japan/middleeast/europe/gulf)",
+        default="singapore",
+    ).lower()
+    if region not in WATCHLIST_BY_REGION:
+        print(f"Unsupported region: {region}")
+        return
+
+    stream_duration = _prompt("Stream duration seconds (0 to skip)", default="0")
+    seed_dummy = _prompt_yes_no("Seed dummy vessels", default=False)
+
+    cmd = [
+        sys.executable,
+        str((SCRIPTS_DIR / "run_pipeline.py").resolve()),
+        "--region",
+        region,
+        "--non-interactive",
+    ]
+    if stream_duration.isdigit() and int(stream_duration) > 0:
+        cmd.extend(["--stream-duration", stream_duration])
+    if seed_dummy:
+        cmd.append("--seed-dummy")
+
+    rc = _run_command(cmd)
+    if rc != 0:
+        print(f"Result: FAILED (exit code {rc})")
+        return
+
+    print("Result: SUCCESS")
+    _print_watchlist_summary(WATCHLIST_BY_REGION[region])
+
+
+def run_review_feedback_evaluation() -> None:
+    print("\n[2] Review-Feedback Evaluation")
+    db = _prompt("DuckDB path", default="data/processed/mpol.duckdb")
+    output = _prompt(
+        "Output report path",
+        default="data/processed/review_feedback_evaluation.json",
+    )
+
+    cmd = [
+        sys.executable,
+        str((SCRIPTS_DIR / "run_review_feedback_evaluation.py").resolve()),
+        "--db",
+        db,
+        "--output",
+        output,
+    ]
+    rc = _run_command(cmd)
+    if rc != 0:
+        print(f"Result: FAILED (exit code {rc})")
+        return
+
+    report_path = (PROJECT_ROOT / output).resolve()
+    if not report_path.exists():
+        print("Result: SUCCESS, but output report was not found")
+        return
+
+    report = _load_json(report_path)
+    summary = report.get("summary", {}) if isinstance(report, dict) else {}
+    reviewed = summary.get("reviewed_vessel_count", 0)
+    regions = summary.get("regions_evaluated", 0)
+    drift = summary.get("overall_drift_pass", True)
+
+    print("Result: SUCCESS")
+    print(
+        "Summary: "
+        f"reviewed_vessel_count={reviewed}, "
+        f"regions_evaluated={regions}, "
+        f"overall_drift_pass={drift}"
+    )
+    print(f"Artifact: {report_path}")
+
+
+def run_historical_backtesting_public_batch() -> None:
+    print("\n[3] Historical Backtesting + Public Integration Batch")
+    regions = _prompt(
+        "Regions (comma-separated)",
+        default="singapore,japan,middleeast,europe,gulf",
+    )
+    strict_floor = _prompt_yes_no("Enable strict known-case floor", default=False)
+
+    cmd = [
+        sys.executable,
+        str((SCRIPTS_DIR / "run_public_backtest_batch.py").resolve()),
+        "--regions",
+        regions,
+    ]
+    if strict_floor:
+        cmd.append("--strict-known-cases")
+
+    rc = _run_command(cmd)
+    if rc != 0:
+        print(f"Result: FAILED (exit code {rc})")
+        return
+
+    summary_path = (DATA_DIR / "backtest_public_integration_summary.json").resolve()
+    report_path = (DATA_DIR / "backtest_report_public_integration.json").resolve()
+    if not summary_path.exists():
+        print("Result: SUCCESS, but summary report was not found")
+        return
+
+    summary = _load_json(summary_path)
+    total_known = summary.get("total_known_cases", 0)
+    region_list = summary.get("regions", [])
+
+    print("Result: SUCCESS")
+    print(
+        "Summary: "
+        f"regions={region_list}, "
+        f"total_known_cases={total_known}"
+    )
+    print(f"Artifacts: {summary_path}, {report_path}")
+
+
+def run_demo_smoke() -> None:
+    print("\n[4] Demo/Smoke")
+    backup = _prompt_yes_no("Backup existing candidate_watchlist.parquet", default=True)
+
+    cmd = [
+        sys.executable,
+        str((SCRIPTS_DIR / "use_demo_watchlist.py").resolve()),
+    ]
+    if backup:
+        cmd.append("--backup")
+
+    rc = _run_command(cmd)
+    if rc != 0:
+        print(f"Result: FAILED (exit code {rc})")
+        return
+
+    target = (DATA_DIR / "candidate_watchlist.parquet").resolve()
+    print("Result: SUCCESS")
+    _print_watchlist_summary(target)
+
+
+def main() -> None:
+    actions = {
+        "1": run_full_screening,
+        "2": run_review_feedback_evaluation,
+        "3": run_historical_backtesting_public_batch,
+        "4": run_demo_smoke,
+    }
+
+    while True:
+        print("\n=== arktrace Operations Shell ===")
+        print("1) Full Screening")
+        print("2) Review-Feedback Evaluation")
+        print("3) Historical Backtesting + Public Integration Batch")
+        print("4) Demo/Smoke")
+        print("q) Quit")
+
+        choice = input("Select job: ").strip().lower()
+        if choice in {"q", "quit", "exit"}:
+            print("Bye")
+            return
+
+        action = actions.get(choice)
+        if action is None:
+            print("Invalid selection")
+            continue
+
+        try:
+            action()
+        except KeyboardInterrupt:
+            print("\nCanceled by user")
+        except Exception as exc:
+            print(f"Unexpected error: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_operations_shell.sh
+++ b/scripts/run_operations_shell.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+
+set -u
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+prompt() {
+  local label="$1"
+  local default_value="${2-}"
+  local value
+  if [[ -n "$default_value" ]]; then
+    read -r -p "$label [$default_value]: " value
+    if [[ -z "$value" ]]; then
+      value="$default_value"
+    fi
+  else
+    read -r -p "$label: " value
+  fi
+  printf '%s' "$value"
+}
+
+prompt_yes_no() {
+  local label="$1"
+  local default_value="${2-false}"
+  local marker="y/N"
+  local value
+
+  if [[ "$default_value" == "true" ]]; then
+    marker="Y/n"
+  fi
+
+  read -r -p "$label ($marker): " value
+  value="${value,,}"
+
+  if [[ -z "$value" ]]; then
+    [[ "$default_value" == "true" ]] && return 0
+    return 1
+  fi
+
+  [[ "$value" == "y" || "$value" == "yes" ]]
+}
+
+run_cmd() {
+  local cmd=("$@")
+  echo
+  echo "Running command:"
+  echo "  ${cmd[*]}"
+  echo
+  (
+    cd "$PROJECT_ROOT" && "${cmd[@]}"
+  )
+  return $?
+}
+
+print_watchlist_summary() {
+  local watchlist_path="$1"
+  WATCHLIST_PATH="$watchlist_path" uv run python - <<'PY'
+import os
+from pathlib import Path
+import polars as pl
+
+path = Path(os.environ["WATCHLIST_PATH"]).resolve()
+if not path.exists():
+    print(f"Result: watchlist not found at {path}")
+    raise SystemExit(0)
+
+df = pl.read_parquet(path)
+print(f"Result: watchlist rows = {df.height}")
+if df.height > 0 and {"mmsi", "confidence"}.issubset(set(df.columns)):
+    row = df.sort("confidence", descending=True).head(1).to_dicts()[0]
+    print(f"Top candidate: mmsi={row.get('mmsi')} confidence={row.get('confidence')}")
+print(f"Artifact: {path}")
+PY
+}
+
+run_full_screening() {
+  echo
+  echo "[1] Full Screening"
+
+  local region
+  region="$(prompt "Region (singapore/japan/middleeast/europe/gulf)" "singapore")"
+  region="${region,,}"
+
+  case "$region" in
+    singapore|japan|middleeast|europe|gulf) ;;
+    *)
+      echo "Unsupported region: $region"
+      return
+      ;;
+  esac
+
+  local stream_duration
+  stream_duration="$(prompt "Stream duration seconds (0 to skip)" "0")"
+
+  local seed_dummy="false"
+  if prompt_yes_no "Seed dummy vessels" "false"; then
+    seed_dummy="true"
+  fi
+
+  local cmd=(uv run python scripts/run_pipeline.py --region "$region" --non-interactive)
+  if [[ "$stream_duration" =~ ^[0-9]+$ ]] && (( stream_duration > 0 )); then
+    cmd+=(--stream-duration "$stream_duration")
+  fi
+  if [[ "$seed_dummy" == "true" ]]; then
+    cmd+=(--seed-dummy)
+  fi
+
+  if ! run_cmd "${cmd[@]}"; then
+    echo "Result: FAILED"
+    return
+  fi
+
+  echo "Result: SUCCESS"
+  local watchlist
+  case "$region" in
+    singapore) watchlist="$PROJECT_ROOT/data/processed/singapore_watchlist.parquet" ;;
+    japan) watchlist="$PROJECT_ROOT/data/processed/japansea_watchlist.parquet" ;;
+    middleeast) watchlist="$PROJECT_ROOT/data/processed/middleeast_watchlist.parquet" ;;
+    europe) watchlist="$PROJECT_ROOT/data/processed/europe_watchlist.parquet" ;;
+    gulf) watchlist="$PROJECT_ROOT/data/processed/gulf_watchlist.parquet" ;;
+  esac
+  print_watchlist_summary "$watchlist"
+}
+
+run_review_feedback() {
+  echo
+  echo "[2] Review-Feedback Evaluation"
+
+  local db_path
+  db_path="$(prompt "DuckDB path" "data/processed/mpol.duckdb")"
+  local output_path
+  output_path="$(prompt "Output report path" "data/processed/review_feedback_evaluation.json")"
+
+  if ! run_cmd uv run python scripts/run_review_feedback_evaluation.py --db "$db_path" --output "$output_path"; then
+    echo "Result: FAILED"
+    return
+  fi
+
+  local abs_output="$PROJECT_ROOT/$output_path"
+  REPORT_PATH="$abs_output" uv run python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["REPORT_PATH"]).resolve()
+if not path.exists():
+    print("Result: SUCCESS, but output report was not found")
+    raise SystemExit(0)
+
+report = json.loads(path.read_text())
+summary = report.get("summary", {}) if isinstance(report, dict) else {}
+print("Result: SUCCESS")
+print(
+    "Summary: "
+    f"reviewed_vessel_count={summary.get('reviewed_vessel_count', 0)}, "
+    f"regions_evaluated={summary.get('regions_evaluated', 0)}, "
+    f"overall_drift_pass={summary.get('overall_drift_pass', True)}"
+)
+print(f"Artifact: {path}")
+PY
+}
+
+run_backtesting_public_batch() {
+  echo
+  echo "[3] Historical Backtesting + Public Integration Batch"
+
+  local regions
+  regions="$(prompt "Regions (comma-separated)" "singapore,japan,middleeast,europe,gulf")"
+
+  local strict_flag=()
+  if prompt_yes_no "Enable strict known-case floor" "false"; then
+    strict_flag=(--strict-known-cases)
+  fi
+
+  if ! run_cmd uv run python scripts/run_public_backtest_batch.py --regions "$regions" "${strict_flag[@]}"; then
+    echo "Result: FAILED"
+    return
+  fi
+
+  local summary_path="$PROJECT_ROOT/data/processed/backtest_public_integration_summary.json"
+  local report_path="$PROJECT_ROOT/data/processed/backtest_report_public_integration.json"
+  SUMMARY_PATH="$summary_path" REPORT_PATH="$report_path" uv run python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+summary_path = Path(os.environ["SUMMARY_PATH"]).resolve()
+report_path = Path(os.environ["REPORT_PATH"]).resolve()
+if not summary_path.exists():
+    print("Result: SUCCESS, but summary report was not found")
+    raise SystemExit(0)
+
+summary = json.loads(summary_path.read_text())
+print("Result: SUCCESS")
+print(
+    "Summary: "
+    f"regions={summary.get('regions', [])}, "
+    f"total_known_cases={summary.get('total_known_cases', 0)}"
+)
+print(f"Artifacts: {summary_path}, {report_path}")
+PY
+}
+
+run_demo_smoke() {
+  echo
+  echo "[4] Demo/Smoke"
+
+  local cmd=(uv run python scripts/use_demo_watchlist.py)
+  if prompt_yes_no "Backup existing candidate_watchlist.parquet" "true"; then
+    cmd+=(--backup)
+  fi
+
+  if ! run_cmd "${cmd[@]}"; then
+    echo "Result: FAILED"
+    return
+  fi
+
+  echo "Result: SUCCESS"
+  print_watchlist_summary "$PROJECT_ROOT/data/processed/candidate_watchlist.parquet"
+}
+
+main_menu() {
+  while true; do
+    echo
+    echo "=== arktrace Operations Shell ==="
+    echo "1) Full Screening"
+    echo "2) Review-Feedback Evaluation"
+    echo "3) Historical Backtesting + Public Integration Batch"
+    echo "4) Demo/Smoke"
+    echo "q) Quit"
+
+    local choice
+    read -r -p "Select job: " choice
+    choice="${choice,,}"
+
+    case "$choice" in
+      1) run_full_screening ;;
+      2) run_review_feedback ;;
+      3) run_backtesting_public_batch ;;
+      4) run_demo_smoke ;;
+      q|quit|exit)
+        echo "Bye"
+        return
+        ;;
+      *)
+        echo "Invalid selection"
+        ;;
+    esac
+  done
+}
+
+main_menu

--- a/src/api/routes/reviews.py
+++ b/src/api/routes/reviews.py
@@ -168,3 +168,28 @@ def get_latest_review(mmsi: str) -> ReviewResponse:
         return _row_to_response(rows[0])
     finally:
         con.close()
+
+
+@router.get("/api/reviews/{mmsi}/history")
+def get_review_history(mmsi: str, limit: int = 20) -> dict[str, Any]:
+    safe_limit = max(1, min(int(limit), 200))
+    con = _connect()
+    try:
+        rows = con.execute(
+            """
+            SELECT mmsi, review_tier, handoff_state, rationale, evidence_refs_json, reviewed_by, reviewed_at
+            FROM vessel_reviews
+            WHERE mmsi = ?
+            ORDER BY reviewed_at DESC
+            LIMIT ?
+            """,
+            [mmsi.strip(), safe_limit],
+        ).fetchdf().to_dict("records")
+    finally:
+        con.close()
+
+    return {
+        "mmsi": mmsi.strip(),
+        "count": len(rows),
+        "items": [_row_to_response(r).model_dump() for r in rows],
+    }

--- a/src/api/routes/vessels.py
+++ b/src/api/routes/vessels.py
@@ -98,11 +98,17 @@ def watchlist_top(
             signals_text = ", ".join(f"{s['feature']}" for s in signals[:2]) if signals else "—"
         except Exception:
             signals_text = str(row.get("top_signals", "—"))[:60]
+        safe_signals_attr = str(signals_text).replace("'", "&#39;")
+        safe_type_attr = str(row.get("vessel_type", "")).replace("'", "&#39;")
+        safe_flag_attr = str(row.get("flag", "")).replace("'", "&#39;")
+        safe_last_seen_attr = str(row.get("last_seen", "")).replace("'", "&#39;")
 
         lat = row.get("last_lat") or ""
         lon = row.get("last_lon") or ""
         rows_html.append(
-            f"<tr class='watchlist-row' data-mmsi='{row['mmsi']}' data-lat='{lat}' data-lon='{lon}' data-name='{safe_name_attr}'>"
+            f"<tr class='watchlist-row' data-mmsi='{row['mmsi']}' data-lat='{lat}' data-lon='{lon}' "
+            f"data-name='{safe_name_attr}' data-type='{safe_type_attr}' data-flag='{safe_flag_attr}' "
+            f"data-confidence='{conf:.4f}' data-last-seen='{safe_last_seen_attr}' data-signals='{safe_signals_attr}'>"
             f"<td>{row['mmsi']}</td>"
             f"<td>{vessel_name}</td>"
             f"<td>{row['vessel_type']}</td>"
@@ -111,7 +117,7 @@ def watchlist_top(
             f"<td class='signals'>{signals_text}</td>"
             f"<td class='review-tier' data-mmsi='{row['mmsi']}'>—</td>"
             f"<td class='review-handoff' data-mmsi='{row['mmsi']}'>—</td>"
-            f"<td><button class='brief-btn review-btn' onclick=\"event.stopPropagation(); openReviewPanel('{row['mmsi']}', '{safe_name_attr}');\">Review</button></td>"
+            f"<td><button class='review-btn' onclick=\"event.stopPropagation(); openReviewPanel('{row['mmsi']}', '{safe_name_attr}');\">Review</button></td>"
             f"</tr>"
         )
 

--- a/src/viz/templates/index.html
+++ b/src/viz/templates/index.html
@@ -310,25 +310,19 @@
       line-height: 1;
     }
     .maplibregl-popup-close-button:hover { color: #e2e8f0; }
-    .brief-btn {
-      margin-top: 0.5rem;
+    .review-btn {
+      margin-top: 0;
       padding: 0.25rem 0.6rem;
       background: #3b82f6;
       color: white;
       border: none;
       border-radius: 3px;
       cursor: pointer;
-      font-size: 0.72rem;
-      font-family: inherit;
-    }
-    .brief-btn:hover { background: #2563eb; }
-
-    .review-btn {
-      margin-top: 0;
-      padding: 0.2rem 0.45rem;
       font-size: 0.68rem;
       white-space: nowrap;
+      font-family: inherit;
     }
+    .review-btn:hover { background: #2563eb; }
 
     .review-pill {
       display: inline-block;
@@ -452,7 +446,6 @@
 <header>
   <h1>&#9760; Shadow Fleet Watchlist</h1>
   <span style="color:#718096;font-size:0.75rem;">MPOL &middot; Maritime Pattern of Life</span>
-  <button class="apply-btn" style="width:auto;padding:0.35rem 0.9rem;font-size:0.8rem;margin-left:auto;" onclick="openFleetChat()">Fleet Chat</button>
 </header>
 
 <!-- KPI bar -->
@@ -494,7 +487,6 @@
       </div>
 
       <button class="apply-btn" onclick="applyFilters()">Apply</button>
-      <button class="apply-btn" style="background:#0f766e;" onclick="startQuickReview()">Quick Review Top N</button>
     </div>
 
     <!-- HTMX-powered ranked table -->
@@ -532,7 +524,6 @@
   <div class="review-header">
     <span class="review-header-label" id="review-vessel-label">Review Decision</span>
     <div class="review-header-actions">
-      <button class="apply-btn" style="width:auto;padding:0.3rem 0.7rem;font-size:0.75rem;background:#0f766e;" onclick="openNextReviewCandidate()">Next Candidate</button>
       <button class="chat-close-btn" onclick="closeReviewPanel()" title="Close">&#x2715;</button>
     </div>
   </div>
@@ -592,22 +583,15 @@
       <div class="review-status" id="review-status">Select a vessel to review.</div>
     </div>
     <div class="review-summary">
+      <h3>Selected Vessel</h3>
+      <div id="review-vessel-details" style="font-size:0.76rem;line-height:1.45;color:#cbd5e1;margin-bottom:0.6rem;">Select a vessel from the list.</div>
       <h3>Latest Review Summary</h3>
-      <div id="review-summary-content" style="font-size:0.76rem;line-height:1.45;color:#cbd5e1;">No review loaded.</div>
+      <div id="review-summary-content" style="font-size:0.76rem;line-height:1.45;color:#cbd5e1;margin-bottom:0.6rem;">No review loaded.</div>
+      <h3>Past Feedback Records</h3>
+      <div id="review-history-content" style="font-size:0.74rem;line-height:1.4;color:#cbd5e1;margin-bottom:0.6rem;">No feedback history loaded.</div>
+      <h3>LLM Explanation</h3>
+      <div id="review-brief-content" style="font-size:0.74rem;line-height:1.45;color:#cbd5e1;">No explanation loaded.</div>
     </div>
-  </div>
-</div>
-
-<!-- Chat panel (bottom) -->
-<div id="chat-panel">
-  <div class="chat-header">
-    <span class="chat-header-label" id="chat-vessel-label">Analyst Brief</span>
-    <button class="chat-close-btn" onclick="closeChatPanel()" title="Close">&#x2715;</button>
-  </div>
-  <div class="chat-messages" id="chat-messages"></div>
-  <div class="chat-input-row">
-    <input type="text" id="chat-input" placeholder="Ask a follow-up question…" onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendChatMessage();}" />
-    <button id="chat-send-btn" onclick="sendChatMessage()">Send</button>
   </div>
 </div>
 
@@ -669,8 +653,7 @@ map.on('load', () => {
         `MMSI: ${mmsi}<br/>` +
         `Flag: ${p.flag} &nbsp;|&nbsp; Type: ${p.vessel_type}<br/>` +
         `Confidence: <strong>${parseFloat(p.confidence).toFixed(2)}</strong><br/>` +
-        `Last seen: ${p.last_seen}<br/>` +
-        `<button class="brief-btn" onclick="openAnalystBrief('${mmsi}','${vesselName.replace(/'/g,"\\'")}')">Analyst Brief</button>`
+        `Last seen: ${p.last_seen}<br/>`
       )
       .addTo(map);
   });
@@ -703,9 +686,20 @@ document.getElementById('watchlist-tbody').addEventListener('click', (e) => {
 
   const lat = parseFloat(row.dataset.lat);
   const lon = parseFloat(row.dataset.lon);
+  const vesselMeta = {
+    mmsi: row.dataset.mmsi || '',
+    name: row.dataset.name || row.dataset.mmsi || '',
+    vesselType: row.dataset.type || '—',
+    flag: row.dataset.flag || '—',
+    confidence: row.dataset.confidence || '',
+    lastSeen: row.dataset.lastSeen || '—',
+    signals: row.dataset.signals || '—',
+  };
   if (isNaN(lat) || isNaN(lon)) return;
 
   map.flyTo({ center: [lon, lat], zoom: 8, duration: 1000 });
+  openReviewPanel(vesselMeta.mmsi, vesselMeta.name, vesselMeta);
+  loadBriefForReviewPanel(vesselMeta.mmsi, vesselMeta.name);
 });
 
 // ── Filter state ───────────────────────────────────────────────────────────
@@ -797,14 +791,20 @@ function loadVesselTypes() {
 
 // ── Review workflow panel ─────────────────────────────────────────────────
 let currentReviewMmsi = null;
-let reviewQueue = [];
-let reviewQueueIndex = -1;
+const briefCache = new Map();
 
 async function fetchLatestReview(mmsi) {
   const r = await fetch(`/api/reviews/${mmsi}`);
   if (r.status === 404) return null;
   if (!r.ok) throw new Error(`review fetch failed: ${r.status}`);
   return r.json();
+}
+
+async function fetchReviewHistory(mmsi, limit = 20) {
+  const r = await fetch(`/api/reviews/${mmsi}/history?limit=${limit}`);
+  if (!r.ok) throw new Error(`review history fetch failed: ${r.status}`);
+  const body = await r.json();
+  return Array.isArray(body.items) ? body.items : [];
 }
 
 function _pillForTier(tier) {
@@ -876,14 +876,102 @@ function renderReviewSummary(review) {
     `<div style="margin-top:0.4rem;"><strong>Evidence</strong><ul style="margin:0.25rem 0 0 1rem;">${refs || '<li>—</li>'}</ul></div>`;
 }
 
-async function openReviewPanel(mmsi, vesselName) {
+function renderVesselDetails(meta) {
+  const box = document.getElementById('review-vessel-details');
+  if (!meta) {
+    box.textContent = 'Select a vessel from the list.';
+    return;
+  }
+  const score = meta.confidence ? Number(meta.confidence).toFixed(2) : '—';
+  box.innerHTML =
+    `<div><strong>Name:</strong> ${_escapeHtml(meta.name)}</div>` +
+    `<div><strong>MMSI:</strong> ${_escapeHtml(meta.mmsi)}</div>` +
+    `<div><strong>Type:</strong> ${_escapeHtml(meta.vesselType)} &nbsp; <strong>Flag:</strong> ${_escapeHtml(meta.flag)}</div>` +
+    `<div><strong>Score:</strong> ${_escapeHtml(score)} &nbsp; <strong>Last seen:</strong> ${_escapeHtml(meta.lastSeen)}</div>` +
+    `<div><strong>Signals:</strong> ${_escapeHtml(meta.signals)}</div>`;
+}
+
+function renderReviewHistory(items) {
+  const box = document.getElementById('review-history-content');
+  if (!items || items.length === 0) {
+    box.textContent = 'No feedback history for this vessel.';
+    return;
+  }
+  const rows = items.slice(0, 10).map((it) => {
+    const when = _escapeHtml(it.reviewed_at || '—');
+    const tier = _escapeHtml(it.review_tier || '—');
+    const handoff = _escapeHtml((it.handoff_state || '—').replaceAll('_', ' '));
+    const by = _escapeHtml(it.reviewed_by || '—');
+    const rationale = _escapeHtml(it.rationale || '');
+    return `<li><strong>${tier}</strong> / ${handoff} by ${by}<br/><span style="color:#94a3b8;">${when}</span>${rationale ? `<br/>${rationale}` : ''}</li>`;
+  }).join('');
+  box.innerHTML = `<ul style="margin:0.15rem 0 0 1rem;display:grid;gap:0.35rem;">${rows}</ul>`;
+}
+
+async function loadBriefForReviewPanel(mmsi, vesselName) {
+  const box = document.getElementById('review-brief-content');
+  if (!mmsi) {
+    box.textContent = 'No explanation loaded.';
+    return;
+  }
+
+  if (briefCache.has(mmsi)) {
+    box.textContent = briefCache.get(mmsi);
+    return;
+  }
+
+  box.textContent = 'Loading LLM explanation...';
+  try {
+    const cachedResp = await fetch(`/api/briefs/${mmsi}/cached`);
+    if (cachedResp.ok) {
+      const cachedBody = await cachedResp.json();
+      if (cachedBody.available && cachedBody.brief) {
+        briefCache.set(mmsi, cachedBody.brief);
+        box.textContent = cachedBody.brief;
+        return;
+      }
+    }
+
+    const resp = await fetch(`/api/briefs/${mmsi}`);
+    if (!resp.ok || !resp.body) throw new Error(`HTTP ${resp.status}`);
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let fullText = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const raw = decoder.decode(value, { stream: true });
+      for (const line of raw.split('\n')) {
+        if (!line.startsWith('data: ')) continue;
+        const chunk = line.slice(6);
+        if (chunk === '[DONE]') break;
+        fullText += chunk;
+      }
+      box.textContent = fullText || 'Loading LLM explanation...';
+    }
+    const normalized = fullText.trim() || `Brief unavailable for ${vesselName || mmsi}.`;
+    briefCache.set(mmsi, normalized);
+    box.textContent = normalized;
+  } catch {
+    box.textContent = 'Brief unavailable — check LLM configuration in .env';
+  }
+}
+
+async function openReviewPanel(mmsi, vesselName, vesselMeta = null) {
   currentReviewMmsi = mmsi;
   document.getElementById('review-vessel-label').textContent = `${vesselName} (MMSI ${mmsi})`;
   document.getElementById('review-panel').classList.add('active');
   document.getElementById('review-status').textContent = 'Loading latest review...';
+  renderVesselDetails(vesselMeta);
+  document.getElementById('review-history-content').textContent = 'Loading feedback history...';
 
   try {
-    const review = await fetchLatestReview(mmsi);
+    const [review, history] = await Promise.all([
+      fetchLatestReview(mmsi),
+      fetchReviewHistory(mmsi),
+    ]);
+    renderReviewHistory(history);
     if (review) {
       document.getElementById('review-tier-select').value = review.review_tier;
       document.getElementById('review-handoff-select').value = review.handoff_state;
@@ -909,6 +997,7 @@ async function openReviewPanel(mmsi, vesselName) {
     }
   } catch {
     document.getElementById('review-status').textContent = 'Failed to load review.';
+    document.getElementById('review-history-content').textContent = 'Failed to load feedback history.';
   }
 }
 
@@ -951,163 +1040,12 @@ async function saveReviewDecision() {
     const saved = await r.json();
     setRowReviewState(currentReviewMmsi, saved);
     renderReviewSummary(saved);
+    const history = await fetchReviewHistory(currentReviewMmsi);
+    renderReviewHistory(history);
     document.getElementById('review-status').textContent = 'Saved review decision.';
   } catch (err) {
     document.getElementById('review-status').textContent = `Save failed: ${err}`;
   }
-}
-
-function startQuickReview() {
-  const rows = Array.from(document.querySelectorAll('#watchlist-tbody tr.watchlist-row'));
-  reviewQueue = rows.map((r) => ({ mmsi: r.dataset.mmsi, name: r.dataset.name || r.dataset.mmsi })).filter((x) => x.mmsi);
-  reviewQueueIndex = 0;
-  if (reviewQueue.length === 0) {
-    document.getElementById('review-status').textContent = 'No candidates available in current Top-N list.';
-    return;
-  }
-  const cur = reviewQueue[reviewQueueIndex];
-  openReviewPanel(cur.mmsi, cur.name);
-}
-
-function openNextReviewCandidate() {
-  if (reviewQueue.length === 0) {
-    startQuickReview();
-    return;
-  }
-  reviewQueueIndex += 1;
-  if (reviewQueueIndex >= reviewQueue.length) {
-    reviewQueueIndex = reviewQueue.length - 1;
-    document.getElementById('review-status').textContent = 'Reached end of current quick-review queue.';
-    return;
-  }
-  const cur = reviewQueue[reviewQueueIndex];
-  openReviewPanel(cur.mmsi, cur.name);
-}
-
-// ── Chat panel ─────────────────────────────────────────────────────────────
-let currentChatMmsi = null;   // null = fleet / cross-vessel mode
-let chatHistory = [];          // [{role, content}, ...]
-let chatStreaming = false;
-
-function openAnalystBrief(mmsi, vesselName) {
-  document.querySelectorAll('.maplibregl-popup').forEach(p => p.remove());
-  currentChatMmsi = mmsi;
-  chatHistory = [];
-  document.getElementById('chat-vessel-label').textContent = `${vesselName} (MMSI ${mmsi})`;
-  document.getElementById('chat-messages').innerHTML = '';
-  document.getElementById('chat-panel').classList.add('active');
-  document.getElementById('chat-input').focus();
-
-  // Stream initial brief via existing cached GET endpoint
-  _streamBriefInitial(mmsi);
-}
-
-function openFleetChat() {
-  currentChatMmsi = null;
-  chatHistory = [];
-  document.getElementById('chat-vessel-label').textContent = 'Fleet Chat (cross-vessel)';
-  document.getElementById('chat-messages').innerHTML = '';
-  document.getElementById('chat-input').placeholder = 'Ask a cross-vessel question…';
-  document.getElementById('chat-panel').classList.add('active');
-  document.getElementById('chat-input').focus();
-}
-
-function closeChatPanel() {
-  document.getElementById('chat-panel').classList.remove('active');
-  currentChatMmsi = null;
-  chatHistory = [];
-  document.getElementById('chat-input').placeholder = 'Ask a follow-up question…';
-}
-
-function appendChatMessage(role, text) {
-  const msgs = document.getElementById('chat-messages');
-  const wrapper = document.createElement('div');
-  wrapper.className = `chat-msg ${role}`;
-  const label = document.createElement('div');
-  label.className = 'chat-msg-label';
-  label.textContent = role === 'user' ? 'You' : 'Analyst';
-  const bubble = document.createElement('div');
-  bubble.className = 'chat-msg-bubble';
-  bubble.textContent = text;
-  wrapper.appendChild(label);
-  wrapper.appendChild(bubble);
-  msgs.appendChild(wrapper);
-  msgs.scrollTop = msgs.scrollHeight;
-  return bubble;
-}
-
-async function _streamSse(resp, bubble) {
-  let fullText = '';
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    const raw = decoder.decode(value, { stream: true });
-    for (const line of raw.split('\n')) {
-      if (!line.startsWith('data: ')) continue;
-      const chunk = line.slice(6);
-      if (chunk === '[DONE]') break;
-      fullText += chunk;
-      bubble.textContent = fullText;
-      document.getElementById('chat-messages').scrollTop = document.getElementById('chat-messages').scrollHeight;
-    }
-  }
-  return fullText;
-}
-
-async function _streamBriefInitial(mmsi) {
-  if (chatStreaming) return;
-  chatStreaming = true;
-  document.getElementById('chat-send-btn').disabled = true;
-  const bubble = appendChatMessage('assistant', '');
-  try {
-    const resp = await fetch(`/api/briefs/${mmsi}`);
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    const fullText = await _streamSse(resp, bubble);
-    if (fullText) chatHistory.push({ role: 'assistant', content: fullText });
-  } catch (err) {
-    bubble.textContent = 'Brief unavailable — check LLM configuration in .env';
-  }
-  chatStreaming = false;
-  document.getElementById('chat-send-btn').disabled = false;
-  document.getElementById('chat-input').focus();
-}
-
-async function streamChatResponse(message) {
-  if (chatStreaming) return;
-  chatStreaming = true;
-  document.getElementById('chat-send-btn').disabled = true;
-  const bubble = appendChatMessage('assistant', '');
-  try {
-    const body = { message, history: chatHistory.slice(0, -1) };
-    if (currentChatMmsi) body.mmsi = currentChatMmsi;
-    const resp = await fetch('/api/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    const fullText = await _streamSse(resp, bubble);
-    if (fullText) chatHistory.push({ role: 'assistant', content: fullText });
-  } catch (err) {
-    bubble.textContent = 'Answer unavailable — check LLM configuration in .env';
-    chatHistory.pop(); // remove the user turn we pushed speculatively
-  }
-  chatStreaming = false;
-  document.getElementById('chat-send-btn').disabled = false;
-  document.getElementById('chat-input').focus();
-}
-
-async function sendChatMessage() {
-  if (chatStreaming) return;
-  const input = document.getElementById('chat-input');
-  const text = input.value.trim();
-  if (!text) return;
-  input.value = '';
-  appendChatMessage('user', text);
-  chatHistory.push({ role: 'user', content: text });
-  await streamChatResponse(text);
 }
 
 // ── SSE alert stream ───────────────────────────────────────────────────────

--- a/tests/test_reviews_api.py
+++ b/tests/test_reviews_api.py
@@ -98,3 +98,35 @@ def test_invalid_tier_rejected(review_client: TestClient) -> None:
 def test_get_missing_review_returns_404(review_client: TestClient) -> None:
     r = review_client.get("/api/reviews/999999999")
     assert r.status_code == 404
+
+
+def test_review_history_returns_all_records(review_client: TestClient) -> None:
+    review_client.post(
+        "/api/reviews",
+        json={
+            "mmsi": "555555555",
+            "review_tier": "suspect",
+            "handoff_state": "in_review",
+            "rationale": "Initial suspicion.",
+            "reviewed_by": "analyst-a",
+        },
+    )
+    review_client.post(
+        "/api/reviews",
+        json={
+            "mmsi": "555555555",
+            "review_tier": "confirmed",
+            "handoff_state": "handoff_recommended",
+            "rationale": "Escalated with corroborating signals.",
+            "reviewed_by": "analyst-b",
+        },
+    )
+
+    r = review_client.get("/api/reviews/555555555/history?limit=10")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mmsi"] == "555555555"
+    assert body["count"] == 2
+    assert len(body["items"]) == 2
+    assert body["items"][0]["review_tier"] == "confirmed"
+    assert body["items"][1]["review_tier"] == "suspect"


### PR DESCRIPTION
## Summary

- **New API**: `GET /api/reviews/{mmsi}/history?limit=N` returns paginated review history for a vessel, ordered newest-first; tests added
- **Operations shell**: `scripts/run_operations_shell.sh` (bash) and `scripts/run_operations_shell.py` (Python) provide a menu-driven shell to run Full Screening, Review-Feedback Evaluation, Backtesting, and Demo/Smoke jobs with result summaries
- **Dashboard refactor**: removed fleet chat panel and quick-review queue; review panel now shows vessel details, past feedback records, and LLM explanation side-by-side
- **XSS hardening**: HTML attribute escaping for `type`, `flag`, `signals`, and `last-seen` data attributes in watchlist rows
- **Docs**: pipeline-catalog clarifies backend-job vs web-UI scope and adds trigger-type columns to cadence table; pipeline-operations documents the new ops shell

Closes #54 — all four phases of the evidence-based shadow-fleet detection workflow are now implemented and documented.

## Test plan

- [ ] `uv run --group dev python -m pytest tests/test_reviews_api.py -q` — new history test passes
- [ ] `bash scripts/run_operations_shell.sh` — menu renders and each job option executes without error
- [ ] Load dashboard, click a watchlist row — review panel shows vessel details, feedback history, and LLM explanation sections
- [ ] Submit a review decision — feedback history refreshes in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)