### PR TITLE
Fix #73 and #74: instant filters and map click opens detail panel

### DIFF
--- a/src/viz/templates/index.html
+++ b/src/viz/templates/index.html
@@ -494,20 +494,19 @@
 
       <div>
         <label>Min confidence: <span id="conf-value">0.40</span></label>
-        <input type="range" id="min-conf" min="0" max="1" step="0.05" value="0.40" oninput="document.getElementById('conf-value').textContent=parseFloat(this.value).toFixed(2)" />
+        <input type="range" id="min-conf" min="0" max="1" step="0.05" value="0.40"
+          oninput="document.getElementById('conf-value').textContent=parseFloat(this.value).toFixed(2); applyFilters()" />
       </div>
 
       <div>
         <label>Vessel types</label>
-        <select id="vessel-type-select" multiple></select>
+        <select id="vessel-type-select" multiple onchange="applyFilters()"></select>
       </div>
 
       <div>
         <label>Top N</label>
-        <input type="number" id="top-n" value="50" min="1" max="500" />
+        <input type="number" id="top-n" value="50" min="1" max="500" oninput="debouncedApply()" />
       </div>
-
-      <button class="apply-btn" onclick="applyFilters()">Apply</button>
     </div>
 
     <!-- HTMX-powered ranked table -->
@@ -667,17 +666,25 @@ map.on('load', () => {
   map.on('click', 'vessels-circle', (e) => {
     const p = e.features[0].properties;
     const mmsi = String(p.mmsi);
-    const vesselName = p.vessel_name;
-    new maplibregl.Popup({ closeButton: true, className: 'vessel-popup', maxWidth: '320px' })
-      .setLngLat(e.lngLat)
-      .setHTML(
-        `<strong>${vesselName}</strong><br/>` +
-        `MMSI: ${mmsi}<br/>` +
-        `Flag: ${p.flag} &nbsp;|&nbsp; Type: ${p.vessel_type}<br/>` +
-        `Confidence: <strong>${parseFloat(p.confidence).toFixed(2)}</strong><br/>` +
-        `Last seen: ${p.last_seen}<br/>`
-      )
-      .addTo(map);
+    const vesselName = p.vessel_name || mmsi;
+
+    // Highlight matching table row
+    document.querySelectorAll('tr.watchlist-row.selected').forEach(r => r.classList.remove('selected'));
+    const matchingRow = document.querySelector(`tr.watchlist-row[data-mmsi='${mmsi}']`);
+    if (matchingRow) matchingRow.classList.add('selected');
+
+    // Open review panel with vessel meta
+    const vesselMeta = {
+      mmsi,
+      name: vesselName,
+      vesselType: p.vessel_type || '—',
+      flag: p.flag || '—',
+      confidence: p.confidence || '',
+      lastSeen: p.last_seen || '—',
+      signals: matchingRow ? (matchingRow.dataset.signals || '—') : '—',
+    };
+    openReviewPanel(mmsi, vesselName, vesselMeta);
+    loadBriefForReviewPanel(mmsi, vesselName);
   });
 
   map.on('mouseenter', 'vessels-circle', () => { map.getCanvas().style.cursor = 'pointer'; });
@@ -741,6 +748,12 @@ function buildQueryString({ minConf, topN, types }) {
   params.set('top_n', topN);
   types.forEach(t => params.append('vessel_types', t));
   return params.toString();
+}
+
+let _applyTimer;
+function debouncedApply() {
+  clearTimeout(_applyTimer);
+  _applyTimer = setTimeout(applyFilters, 300);
 }
 
 function applyFilters() {


### PR DESCRIPTION
## Summary
- Closes #73: Remove Apply button — filters (confidence slider, vessel type, top-N) now apply instantly via `oninput`/`onchange` handlers with 300 ms debounce on the numeric input
- Closes #74: Clicking a vessel circle on the MapLibre map now opens the side-panel review detail and loads the LLM brief, matching the table-row click behavior

## Changes
- Removed `<button class="apply-btn">Apply</button>` from filter bar (CSS kept — reused by Save Review button)
- Added `oninput="applyFilters()"` to confidence slider, `onchange="applyFilters()"` to vessel-type select, `oninput="debouncedApply()"` to top-N input
- Added `debouncedApply()` (300 ms) to avoid excessive re-renders on numeric input
- Wired `map.on('click', 'vessels-circle')` to call `openReviewPanel()` and `loadBriefForReviewPanel()` with MMSI from GeoJSON feature properties

## Test plan
- [ ] Adjust confidence slider → table updates without pressing any button
- [ ] Change vessel type dropdown → table updates instantly
- [ ] Click a vessel on the map → side panel opens with vessel details and LLM brief loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)