### PR TITLE
feat: implement #41 and #42 (C3 auto-calibration & external regimes)

### DIFF
--- a/config/sanction_regimes.yaml
+++ b/config/sanction_regimes.yaml
@@ -1,0 +1,27 @@
+regimes:
+  OFAC_Iran:
+    label: "OFAC Iran"
+    list_source_substr: "us_ofac_sdn"
+    flag_filter: ["IR", ""]
+    announcement_dates:
+      - "2012-03-15"
+      - "2019-05-08"
+      - "2020-01-10"
+
+  OFAC_Russia:
+    label: "OFAC Russia"
+    list_source_substr: "us_ofac_sdn"
+    flag_filter: ["RU", ""]
+    announcement_dates:
+      - "2022-02-24"
+      - "2022-09-15"
+      - "2023-02-24"
+
+  UN_DPRK:
+    label: "UN DPRK"
+    list_source_substr: "un_sc_sanctions"
+    flag_filter: ["KP", ""]
+    announcement_dates:
+      - "2017-08-05"
+      - "2017-09-11"
+      - "2017-12-22"

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -56,7 +56,7 @@ See [Backtracking Runbook](backtracking-runbook.md) for full options, output for
 | Europe / Baltic | `europe` | `europe.duckdb` | 6 h | 45 d | 0.35 / 0.35 / 0.30 |
 | US Gulf | `gulf` | `gulf.duckdb` | 6 h | 14 d | 0.50 / 0.30 / 0.20 |
 
-The preset weights are starting points. The C3 causal model automatically calibrates `w_graph` at the start of each scoring cycle.
+The preset weights are starting points. The pipeline auto-calibrates `w_graph` on every run via `_calibrate_graph_weight()`. Calling `src.score.composite` standalone still requires `--w-graph` (or the new `--auto-calibrate` flag). The calibrated value is printed at the end of Step 8 for reference.
 
 ---
 

--- a/docs/regional-playbooks.md
+++ b/docs/regional-playbooks.md
@@ -50,6 +50,8 @@ uv run python src/features/ais_behavior.py --window 30
 
 Default weights are tuned for this region (`0.4 × anomaly + 0.4 × graph + 0.2 × identity`). No changes needed.
 
+*Note: when running via `scripts/run_pipeline.py`, the C3 causal model automatically calibrates `w_graph` before Step 8. The value above is the fallback if insufficient AIS data is available.*
+
 **A4 — Bunker barge exclusion (Singapore-specific)**
 
 Singapore waters contain a large population of legitimate service craft: bunker barges (AIS type 51–54), pilot tenders (type 51), and harbour tugs (types 31–32). These vessels loiter at low SOG near anchorages and refuelling points — the same behavioural signature as shadow-fleet STS transfers. Without exclusion, including them in the HDBSCAN training baseline compresses anomaly scores for genuine dark-vessel events.
@@ -140,6 +142,8 @@ Run all other feature scripts with `--db data/processed/japansea.duckdb`.
 **A4 — Composite scoring**
 
 The default weight puts `graph_risk_score` at 40%. For DPRK analysis this is correct — ownership graph proximity to UN-listed entities is the strongest signal. No weight change needed.
+
+*Note: when running via `scripts/run_pipeline.py`, the C3 causal model automatically calibrates `w_graph` before Step 8. The value above is the fallback if insufficient AIS data is available.*
 
 **Dashboard — Filters to apply**
 
@@ -247,6 +251,8 @@ uv run python src/score/composite.py \
   --db data/processed/gulf.duckdb \
   --w-anomaly 0.50 --w-graph 0.30 --w-identity 0.20
 ```
+
+*Note: when running via `scripts/run_pipeline.py`, the C3 causal model automatically calibrates `w_graph` before Step 8. The value above is the fallback if insufficient AIS data is available.*
 
 **Dashboard — Filters to apply**
 
@@ -358,6 +364,8 @@ uv run python src/score/composite.py \
   --db data/processed/europe.duckdb \
   --w-anomaly 0.35 --w-graph 0.35 --w-identity 0.30
 ```
+
+*Note: when running via `scripts/run_pipeline.py`, the C3 causal model automatically calibrates `w_graph` before Step 8. The value above is the fallback if insufficient AIS data is available.*
 
 **Dashboard — Filters to apply**
 
@@ -502,6 +510,8 @@ Run all other feature scripts with `--db data/processed/middleeast.duckdb`.
 **A4 — Composite scoring**
 
 For Iranian crude, all three signal categories are strong. The default weights are appropriate. However, `sanctions_distance` carries outsized predictive power here because Iran operates a tightly-connected network where most vessels are within 2–3 hops of an OFAC-listed entity. No weight change required.
+
+*Note: when running via `scripts/run_pipeline.py`, the C3 causal model automatically calibrates `w_graph` before Step 8. The value above is the fallback if insufficient AIS data is available.*
 
 **Dashboard — Filters to apply**
 

--- a/docs/scoring-model.md
+++ b/docs/scoring-model.md
@@ -148,7 +148,13 @@ See `config/geopolitical_events.json` for the sample file format.
 
 ## C3 causal weight calibration (`src/score/causal_sanction.py`)
 
-The default `w_graph = 0.40` is calibrated automatically by the C3 Difference-in-Differences model before each scoring cycle. The model estimates the Average Treatment Effect on the Treated (ATT) for three sanction regimes:
+The default `w_graph = 0.40` is calibrated automatically by the C3 Difference-in-Differences model before each scoring cycle. 
+
+The pipeline auto-calibrates `w_graph` on every run via `_calibrate_graph_weight()`.
+Calling `src.score.composite` standalone still requires `--w-graph` (or the new `--auto-calibrate` flag).
+The calibrated value is printed at the end of Step 8 for reference.
+
+The model estimates the Average Treatment Effect on the Treated (ATT) for three sanction regimes (by default):
 
 | Regime | Announcement dates used |
 |---|---|
@@ -159,6 +165,14 @@ The default `w_graph = 0.40` is calibrated automatically by the C3 Difference-in
 If the ATT is positive and statistically significant (p < 0.05) for a regime, the graph risk dimension is predictive → `w_graph` is increased proportionally, up to a cap of 0.65. The remaining weight is redistributed proportionally between `w_anomaly` and `w_identity`.
 
 The calibrated weight and per-regime effect sizes are written to `<region>_causal_effects.parquet`.
+
+### Adding a new sanction regime
+
+Sanction regimes are configured dynamically in `config/sanction_regimes.yaml`. To add a new regime (e.g. EU 14th sanctions package against Russia) without modifying source code, add a new entry to the `regimes` dictionary with the following required fields:
+- `label`: Human-readable name.
+- `list_source_substr`: The string to match in the `list_source` column of the entities table.
+- `flag_filter`: Fallback list of flag strings (e.g. `["RU", ""]`).
+- `announcement_dates`: List of ISO-8601 string dates.
 
 ---
 

--- a/src/score/causal_sanction.py
+++ b/src/score/causal_sanction.py
@@ -558,6 +558,7 @@ def run_causal_model(
     db_path: str = DEFAULT_DB_PATH,
     regimes: dict[str, dict] | None = None,
     gap_threshold_h: float = 6.0,
+    regimes_path: str | None = "config/sanction_regimes.yaml",
 ) -> list[CausalEffect]:
     """
     Run the DiD causal model for all sanction regimes.
@@ -577,6 +578,15 @@ def run_causal_model(
     """
     if regimes is None:
         regimes = SANCTION_REGIMES
+        if regimes_path and os.path.exists(regimes_path):
+            try:
+                import yaml
+                with open(regimes_path, "r") as f:
+                    data = yaml.safe_load(f)
+                    if data and "regimes" in data:
+                        regimes = data["regimes"]
+            except Exception as e:
+                print(f"Failed to load regimes from {regimes_path}: {e}")
 
     con = duckdb.connect(db_path, read_only=True)
     effects: list[CausalEffect] = []
@@ -680,10 +690,15 @@ def main() -> None:
         default=6.0,
         help="AIS gap threshold in hours (default 6; use 12 for DPRK/Iran)",
     )
+    parser.add_argument(
+        "--regimes",
+        default="config/sanction_regimes.yaml",
+        help="Path to YAML regimes config",
+    )
     args = parser.parse_args()
 
     print("Running C3 causal sanction-response model …")
-    effects = run_causal_model(args.db, gap_threshold_h=args.gap_threshold_hours)
+    effects = run_causal_model(args.db, gap_threshold_h=args.gap_threshold_hours, regimes_path=args.regimes)
 
     df = effects_to_dataframe(effects)
     write_effects(df, args.output)

--- a/src/score/composite.py
+++ b/src/score/composite.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from dataclasses import dataclass, field
 from datetime import date
 
@@ -397,7 +398,18 @@ def compute_composite_scores(
     w_graph: float = 0.4,
     w_identity: float = 0.2,
     geo_filter_path: str | None = None,
+    auto_calibrate: bool = False,
 ) -> pl.DataFrame:
+    if auto_calibrate:
+        print("Auto-calibrating graph risk weight using C3 causal model...")
+        try:
+            from src.score.causal_sanction import run_causal_model, calibrate_graph_weight
+            effects = run_causal_model(db_path)
+            w_graph = calibrate_graph_weight(effects)
+            print(f"C3 auto-calibrated graph_risk_score weight: {w_graph:.3f}")
+        except Exception as e:
+            print(f"Warning: Auto-calibration failed ({e}). Falling back to w_graph={w_graph}")
+
     feature_df = load_feature_frame(db_path)
     context_df = load_watchlist_context(db_path)
     if feature_df.is_empty() or context_df.is_empty():
@@ -469,6 +481,8 @@ def main() -> None:
                         help="Weight for graph risk score (default: 0.4)")
     parser.add_argument("--w-identity", type=float, default=0.2,
                         help="Weight for identity score (default: 0.2)")
+    parser.add_argument("--auto-calibrate", action="store_true",
+                        help="Auto-calibrate graph risk weight using C3 causal model")
     parser.add_argument(
         "--geopolitical-event-filter",
         default=None,
@@ -481,12 +495,19 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    w_graph = args.w_graph
+    auto_calibrate = args.auto_calibrate
+    if auto_calibrate and "--w-graph" in sys.argv:
+        print("Warning: Both --auto-calibrate and --w-graph are specified. Preferring --w-graph.")
+        auto_calibrate = False
+
     df = compute_composite_scores(
         args.db,
         args.w_anomaly,
-        args.w_graph,
+        w_graph,
         args.w_identity,
         geo_filter_path=args.geopolitical_event_filter,
+        auto_calibrate=auto_calibrate,
     )
     write_composite_scores(df, args.output)
     print(f"Composite rows written: {df.height}")


### PR DESCRIPTION
Closes #41 and closes #42. This PR introduces the --auto-calibrate flag and external YAML configurations for the C3 causal model, along with documentation updates clarifying weight override behaviour.