### PR TITLE
docs: local-first stack — MinIO, Lance S3, Ollama, tactical edge diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,12 +66,35 @@
 │                                                                 │
 │  data/processed/candidate_watchlist.parquet                     │
 │  FastAPI + HTMX dashboard  (src/api/)  → http://localhost:8000  │
+│                                                                 │
+│         ↕  (context window — no external calls)                 │
+│                                                                 │
+│  Ollama / MLX LLM  →  analyst brief + streaming chat           │
 └─────────────────────────────────────────────────────────────────┘
                            │
                            ▼  handoff
 ┌─────────────────────────────────────────────────────────────────┐
 │  PHYSICAL INVESTIGATION  (edgesentry-app / edgesentry-rs)       │
 │  (out of scope for this repo — see roadmap.md)                  │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│  STORAGE LAYER  (cross-cutting; local or S3-compatible)         │
+│                                                                 │
+│  OLAP  — DuckDB + Parquet                                       │
+│    · local:  data/processed/mpol.duckdb                         │
+│    · Parquet outputs: data/processed/*.parquet                  │
+│              or  s3://arktrace/processed/  (MinIO / S3)         │
+│                                                                 │
+│  Graph — Lance (embedded, serverless)                           │
+│    · local:  data/processed/mpol_graph/                         │
+│              data/processed/gdelt.lance                         │
+│    · remote: s3://arktrace/mpol_graph/                          │
+│              s3://arktrace/gdelt.lance  (MinIO / S3)            │
+│                                                                 │
+│  Object store — MinIO  localhost:9000  (docker-compose.yml)     │
+│    · bucket: arktrace  (created by minio_init on first run)     │
+│    · console: localhost:9001                                    │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -83,6 +106,8 @@
 
 DuckDB is the primary analytical store. It runs in-process with no server and queries Parquet files directly. Multi-region deployments use separate DuckDB files per region (e.g. `data/processed/europe.duckdb`) — every script accepts a `--db` flag to target the correct file. See [regional-playbooks.md](regional-playbooks.md) for per-region paths and bbox values.
 
+**Parquet persistence:** all pipeline output files (watchlist, causal effects, validation metrics) are written by `src/storage/config.py`. When `S3_BUCKET` is set, output goes to `s3://<bucket>/processed/<filename>` via MinIO or any S3-compatible store; otherwise it writes to `data/processed/<filename>` on the local filesystem. No code changes are required to switch between the two modes.
+
 | Table | Key columns | Source |
 |---|---|---|
 | `ais_positions` | `mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type` | aisstream.io (all regions); Marine Cadastre Parquet (US waters only) |
@@ -93,7 +118,9 @@ DuckDB is the primary analytical store. It runs in-process with no server and qu
 
 ### Lance Graph (`data/processed/mpol_graph/`)
 
-Lance Graph stores the vessel ownership graph as columnar Lance datasets on disk — no external server or Docker container required. The graph directory sits alongside the DuckDB file and is written by `src/ingest/vessel_registry.py`, read by `src/features/ownership_graph.py` and `src/features/identity.py`.
+Lance Graph stores the vessel ownership graph as columnar Lance datasets — no external server or Docker container required. The graph directory is written by `src/ingest/vessel_registry.py` and read by `src/features/ownership_graph.py` and `src/features/identity.py`.
+
+**Storage backend:** `src/storage/config.py` exposes `lance_graph_uri(stem)` and `lance_db_uri()` which resolve to local paths (`data/processed/mpol_graph/`, `data/processed/gdelt.lance`) when running without S3, and to `s3://arktrace/mpol_graph/` / `s3://arktrace/gdelt.lance` when `S3_BUCKET` is set. Lance's built-in object store support handles the S3 read/write transparently.
 
 **Node datasets** (one Lance file each):
 - `Vessel {mmsi, imo, name}`

--- a/docs/technical-solution.md
+++ b/docs/technical-solution.md
@@ -6,14 +6,63 @@
 |---|---|---|---|
 | Analytical store | **DuckDB** | ≥ 1.1 | In-process columnar OLAP; queries Parquet natively; no server; edge-deployable |
 | DataFrame / feature engineering | **Polars** | ≥ 1.0 | Lazy evaluation; fast AIS window operations; Arrow-native |
-| Graph DB | **Lance Graph** | ≥ 0.5 | Cypher-capable graph engine built in Rust with Python bindings; embedded in-process, serverless, stores data as Lance columnar files |
+| Graph DB | **Lance Graph** | ≥ 0.5 | Embedded in-process graph engine; stores ownership graph as Lance columnar files; local path or S3-compatible (`s3://`) |
+| Object store | **MinIO** | RELEASE.2025-09-07 | S3-compatible local object store; persists Parquet and Lance datasets; port 9000 (API) / 9001 (console) |
 | ML / clustering | **scikit-learn** | ≥ 1.5 | HDBSCAN, Isolation Forest; no GPU required |
 | Explainability | **SHAP** | ≥ 0.46 | TreeExplainer for Isolation Forest; per-vessel feature attribution |
 | Dashboard | **FastAPI + HTMX** | ≥ 0.115 / — | Production-grade API layer + partial-page updates; SSE alerts; MapLibre GL JS |
+| Local LLM | **Ollama / MLX / LM Studio** | — | Local inference for analyst briefs and chat; no cloud dependency; provider selected via `LLM_PROVIDER` env var |
 | AIS streaming | **websockets** + **httpx** | — | aisstream.io WebSocket; Marine Cadastre HTTP download |
 | Causal inference | **numpy / scipy** (built-in) | — | DiD OLS with HC3 robust SEs; no external causal library required |
 | Language | **Python 3.12** | — | Best ecosystem fit for all above |
 | Packaging | **uv** | — | Fast lockfile-based dependency management |
+
+---
+
+## Local-First Deployment
+
+The full stack runs on a single machine — a field laptop, a shipboard server, or a detached tactical edge node — with no cloud dependency during operation. All data remains on-device. Cloud connectivity is optional and used only for upstream AIS streaming or report export.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  TACTICAL EDGE NODE  (patrol vessel / field laptop)             │
+│                                                                 │
+│  AIS stream (aisstream.io WebSocket)                            │
+│  SAR / EO imagery (offline batch or USB import)                 │
+│         │                                                       │
+│         ▼                                                       │
+│  Scoring Engine (DuckDB + Polars + HDBSCAN + Isolation Forest)  │
+│         │                      │                               │
+│         │              Lance Graph (ownership network)          │
+│         │                      │                               │
+│         ▼                      ▼                               │
+│  HTMX Dashboard  ←─────  Composite Score + SHAP signals        │
+│         │                                                       │
+│         ↕  (context window injection — no external calls)       │
+│         │                                                       │
+│  Ollama / MLX LLM  →  Analyst brief / chat response            │
+│         │                                                       │
+│         ▼                                                       │
+│  Duty Officer                                                   │
+│                                                                 │
+│  Persistence: MinIO (localhost:9000) — Parquet + Lance datasets │
+└─────────────────────────────────────────────────────────────────┘
+          │  optional: report upload / AIS backfill
+          ▼
+   Cloud / HQ network
+```
+
+| Component | Local runtime | Default persistence path | S3 path (when `S3_BUCKET` set) |
+|---|---|---|---|
+| OLAP store | DuckDB in-process | `data/processed/mpol.duckdb` | — (DuckDB file stays local; Parquet outputs go to S3) |
+| Parquet outputs | Polars → local or S3 | `data/processed/*.parquet` | `s3://arktrace/processed/*.parquet` |
+| Ownership graph | Lance embedded | `data/processed/mpol_graph/` | `s3://arktrace/mpol_graph/` |
+| Geopolitical index | Lance embedded | `data/processed/gdelt.lance` | `s3://arktrace/gdelt.lance` |
+| Object store | MinIO `localhost:9000` | `minio_data` Docker volume | — (MinIO is the S3 backend) |
+| Web app | FastAPI `localhost:8000` | — | — |
+| LLM inference | Ollama `localhost:11434` or MLX in-process | — | — |
+
+**Storage backend selection** is automatic: when `S3_BUCKET` is set in the environment, `src/storage/config.py` routes all Parquet and Lance I/O to `s3://<bucket>/…` via MinIO (or any S3-compatible store). When unset, everything writes to local `data/processed/` paths. No code changes are required to switch between the two modes.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds **Local-First Deployment** section to `technical-solution.md`: tactical edge ASCII diagram (offline patrol vessel scenario), per-component runtime/persistence table, storage backend switching via `S3_BUCKET`
- Adds **MinIO** and **Ollama / MLX** to Tech Stack table (both already implemented, previously undocumented)
- Updates **Lance Graph** row to document S3 path support
- Adds **Storage Layer** block to system overview in `architecture.md`
- Documents Parquet and Lance S3 persistence paths via `src/storage/config.py`
- Iceberg migration (not yet implemented) is **not included** — tracked in a separate issue

## Cap Vista context

The tactical edge diagram directly addresses the challenge's "low computational cost to maximize edge deployments" criterion, showing the system running fully offline on a patrol vessel.

## Test plan

- [ ] Verify `docs/architecture.md` and `docs/technical-solution.md` render correctly
- [ ] Confirm all local paths (`data/processed/mpol.duckdb`, `mpol_graph/`, etc.) match actual repo layout
- [ ] Confirm S3 paths match `src/storage/config.py` `lance_graph_uri()`, `lance_db_uri()`, `output_uri()`

Partially addresses #70 (docs portion only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)