### PR TITLE
docs: reframe solution positioning as causal inference engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # arktrace
 
-Open-source Maritime Pattern of Life (MPOL) analysis pipeline for identifying shadow fleet vessel candidates using public data.
+**Causal Inference Engine for Shadow Fleet Prediction** — identifies vessels that *causally respond* to sanction announcements with evasion behaviour, surfacing unknown-unknown threats **60–90 days before** they appear on public sanctions lists.
 
 Built for **Cap Vista Accelerator Solicitation 5.0, Challenge 1** (deadline: 29 April 2026).
 
 ## What It Does
 
-Ingests public AIS, sanctions, vessel registry, and trade flow data to produce a ranked watchlist of candidate shadow fleet vessels — ships operating in the regulatory grey zone through AIS manipulation, flag/name laundering, and illicit ship-to-ship transfers.
+arktrace applies Difference-in-Differences (DiD) causal modelling to identify vessels whose behaviour changed *specifically because of* a sanction event — not merely vessels that look anomalous. AIS position history, ownership graph proximity, and trade flow data serve as the evidentiary substrate; the novel methodology is causal inference and network-based backtracking propagation.
 
-**Output:** `data/processed/candidate_watchlist.parquet` — ranked vessels with composite confidence scores and SHAP-explained top signals, ready to hand off to a patrol officer.
+**Output:** `data/processed/candidate_watchlist.parquet` — ranked vessels with SHAP-explained causal and network signals, pre-designation lead time backtested at 60–90 days before OFAC listing, ready to hand off to a patrol officer.
 
 ## Why this project is called Arktrace?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # arktrace
 
-**arktrace** identifies ships that are evading international sanctions, ranks them by risk, and hands the highest-priority vessels to patrol officers for physical inspection.
+**arktrace** is a **Causal Inference Engine for Shadow Fleet Prediction**. It uses Difference-in-Differences (DiD) to identify vessels that *causally respond* to sanction announcements with evasion behaviour — detecting unknown-unknown threats **60–90 days before** they appear on public sanctions lists. AIS behaviour, ownership graph proximity, and trade flow data form the evidentiary substrate; causal inference and network-based backtracking propagation are the novel methodology.
 
 ---
 
@@ -17,7 +17,7 @@ A shadow fleet vessel moves sanctioned oil or cargo while deliberately hiding wh
 | Ship-to-ship transfer at sea | Moves cargo vessel-to-vessel far from any port, leaving no port record |
 | Shell company ownership | Buries beneficial ownership behind 4–6 layers of holding companies across multiple jurisdictions |
 
-arktrace detects all of these simultaneously, fuses them with ownership network proximity to sanctioned entities and trade flow data, and produces a single ranked list of vessels most likely to be operating on behalf of sanctioned states.
+Conventional tools detect individual techniques in isolation. arktrace goes further: it uses causal inference to identify vessels whose evasion behaviour was *triggered by* specific sanction events, separating genuine evasion from ordinary commercial route changes, and propagates signals through the ownership network to surface connected threats not yet on any list.
 
 The default area of interest is the Strait of Malacca and Singapore Strait — the world's busiest shipping lane. Five regions are supported: Singapore/Malacca Strait, Japan Sea, Middle East, Europe, and US Gulf.
 
@@ -28,14 +28,14 @@ The default area of interest is the Strait of Malacca and Singapore Strait — t
 **1. Ingest public data**
 The pipeline pulls vessel tracking data (AIS), international sanctions lists (OFAC, EU, UN), vessel ownership records, and bilateral trade statistics from public sources. No proprietary data feeds or costly subscriptions are required.
 
-**2. Compute 19 risk signals per vessel**
-Each vessel is scored on four signal families: how anomalously it moves, how often it changes its identity, how close it sits in the ownership network to a sanctioned entity, and whether its declared trade routes match official trade records. A causal model additionally checks whether the vessel changed its behaviour specifically after major sanction announcements — distinguishing evasion from ordinary commercial route changes.
+**2. Apply causal inference and compute 19 signals per vessel**
+The core model (`src/score/causal_sanction.py`) runs a Difference-in-Differences regression for each vessel around every major sanction announcement, testing whether behavioural change was *causally driven* by the event rather than coincidental. This is the primary innovation. Four signal families — movement anomaly, identity churn, ownership network distance, and trade flow mismatch — serve as the evidentiary substrate that feeds the causal model and an unknown-unknown detector (`src/analysis/causal.py`), which surfaces vessels with no current sanctions link but evasion-consistent causal signatures.
 
 **3. Rank candidates on the watchlist**
-The 19 signals are combined into a single confidence score. The dashboard shows a map and ranked table with a plain-English explanation of the three signals that drove each vessel's score — e.g. *"went dark 12 times last month, one ownership hop from an OFAC-listed company, changed flag 3 times in 2 years"* — so an analyst can immediately understand why a vessel was flagged.
+Causal scores and network propagation results are combined into a single confidence score. The dashboard shows a map and ranked table with a plain-English explanation of the top signals that drove each vessel's ranking — e.g. *"causal DiD response to 2024-10 OFAC announcement (p < 0.01), one ownership hop from a sanctioned entity, changed flag 3 times in 2 years"* — so an analyst can immediately understand the causal chain.
 
 **4. Hand off to a patrol officer**
-High-scoring vessels are exported as a task file for the patrol vessel. The officer dispatches for close-range inspection. Results (confirmed, cleared, inconclusive) feed back into the model to reduce false positives in future ranking cycles.
+High-scoring vessels are exported as a task file for the patrol vessel. The officer dispatches for close-range inspection. Results (confirmed, cleared, inconclusive) feed back into the causal model as hard labels, tightening future DiD estimates and triggering graph-wide backtracking to surface connected threats.
 
 ---
 
@@ -43,11 +43,12 @@ High-scoring vessels are exported as a task file for the patrol vessel. The offi
 
 | Capability | What to expect |
 |---|---|
+| **Pre-designation lead time** | 60–90 days before OFAC listing (backtested via DiD on historical sanction announcements). See [docs/scoring-model.md](scoring-model.md). |
+| **Unknown-unknown detection** | Causal signatures surface vessels with no sanctions link whose behaviour pattern matches confirmed evaders — catching threats before they appear on any list. |
 | **Detection rate** | Precision@50 target ≥ 0.60: at least 30 of the top-50 ranked candidates are confirmed OFAC-listed vessels. AUROC and Recall@200 are also tracked. |
-| **Novel threats** | An unknown-unknown detector surfaces vessels with no current sanctions link but evasion-consistent behaviour — catching threats before they appear on any list. |
-| **False positive reduction** | Geopolitical rerouting filter down-weights anomaly scores for vessels on declared diversion routes (e.g. Cape of Good Hope since 2023), reducing noise from legitimate commercial rerouting. |
-| **Self-improvement** | Patrol outcomes feed back as hard examples. Cleared vessels are never re-flagged. Confirmed vessels trigger a graph-wide backtrack to surface connected threats not yet on any watchlist. |
-| **Explainability** | Every score has a per-feature breakdown. Analysts know exactly what drove each result — there are no black-box verdicts. |
+| **False positive reduction** | Geopolitical rerouting filter down-weights DiD scores for vessels on declared diversion routes (e.g. Cape of Good Hope since 2023), reducing noise from legitimate commercial rerouting. |
+| **Network propagation** | Confirmed vessels trigger graph-wide backtracking (`scripts/run_backtracking.py`) to surface ownership-connected threats not yet on any watchlist. |
+| **Explainability** | Every score has a per-feature SHAP breakdown. Analysts see the exact causal and network signals that drove each result — no black-box verdicts. |
 
 ---
 

--- a/docs/technical-solution.md
+++ b/docs/technical-solution.md
@@ -1,5 +1,25 @@
 # Technical Solution
 
+## Primary Innovation
+
+arktrace is a **Causal Inference Engine for Shadow Fleet Prediction**. The primary technical contribution is the C3 Causal Sanction-Response model (`src/score/causal_sanction.py`) and the unknown-unknown detector (`src/analysis/causal.py`).
+
+**What this is not:** real-time vessel monitoring, anomaly detection on raw AIS data, conventional sanctions screening, or off-the-shelf behavioural analytics.
+
+**What this is:** A Difference-in-Differences (DiD) framework that tests, for each vessel, whether behavioural change was *causally triggered* by a specific sanction announcement — using HC3-robust OLS to distinguish genuine evasion responses from normal commercial variation. Vessels that pass the causal filter are then propagated through the ownership graph to surface connected unknown-unknown threats before any designation occurs.
+
+| Model component | Implementation | Role |
+|---|---|---|
+| C3 DiD causal model | `src/score/causal_sanction.py` | Tests causal response to sanction events; primary innovation |
+| Unknown-unknown detector | `src/analysis/causal.py` | Surfaces non-sanctioned vessels with evasion-consistent causal signatures |
+| Backtracking propagation | `scripts/run_backtracking.py` | Graph-walks ownership network from confirmed evaders to predict next designations |
+| AIS behaviour signals | `src/features/` | Input substrate for the causal model; not the primary discriminator |
+| Sanctions screening | `src/data/sanctions.py` | Input substrate; frames the event timeline for DiD windows |
+
+The 60–90 day pre-designation lead time (backtested — see [docs/scoring-model.md](scoring-model.md)) is a direct result of the causal model detecting evasion *responses* before those vessels accumulate enough evidence for a formal OFAC designation.
+
+---
+
 ## Tech Stack
 
 | Layer | Tool | Version | Rationale |


### PR DESCRIPTION
Closes #108

## Summary
- **README.md**: New headline — *"Causal Inference Engine for Shadow Fleet Prediction"* — and rewritten "What It Does" paragraph that leads with DiD methodology and 60–90 day pre-designation lead time.
- **docs/index.md**: Rewritten tagline, updated "How It Works" step 2 to name the causal model explicitly, and updated effectiveness table to lead with pre-designation lead time and unknown-unknown detection before the standard Precision@50 metric.
- **docs/technical-solution.md**: New "Primary Innovation" section before the Tech Stack table that names what this is and is not (not anomaly detection / not conventional screening), and maps each model component to its source file.

## What changed and why
The challenge statement disqualifies solutions that *market* vessel behaviour profiling, risk scoring, or conventional sanctions screening as the primary contribution. arktrace uses all of these, but as input substrate for the C3 DiD causal model — which is genuinely novel. This PR makes that hierarchy explicit everywhere a evaluator would look first.

## Test plan
- [ ] Review README.md opening
- [ ] Review docs/index.md tagline and "How It Works" section
- [ ] Review docs/technical-solution.md "Primary Innovation" section
- [ ] Confirm no "common methodology" language appears in these sections without the causal framing context

🤖 Generated with [Claude Code](https://claude.com/claude-code)