### PR TITLE
feat: _inputs/custom_feeds/ auto-detected drop-in ingestion (#139)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,9 @@ data/processed/     # DuckDB files, Parquet outputs, Neo4j database
 site/               # MkDocs build output
 .env                # API keys (aisstream.io, Equasis)
 _inputs/
+!_inputs/custom_feeds/
+!_inputs/custom_feeds/.gitkeep
+_inputs/custom_feeds/*.csv
 _outputs/
 .DS_Store
 

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -32,6 +32,8 @@ Available menu jobs:
 - SAR Feature Smoke Test (job 11)
 - EO Feature Smoke Test (job 12)
 - Ingest EO Detections from CSV (job 13) — load a local EO CSV into `eo_detections` without a GFW API token, then optionally run feature matrix + scoring to verify in the dashboard
+- Ingest AIS CSV / NMEA file (job 14) — load a provider CSV or NMEA 0183 file into `ais_positions`
+- Ingest custom feed drop-ins (job 15) — run all CSV files in `_inputs/custom_feeds/` through the auto-detector
 
 ### Delayed-label intelligence loop (backtracking)
 
@@ -65,7 +67,7 @@ The preset weights are starting points. The pipeline auto-calibrates `w_graph` o
 
 ## Pipeline steps
 
-The pipeline runs 9 steps in sequence. Each step prints a status line; in interactive mode, failed steps prompt retry or skip.
+The pipeline runs 10 steps in sequence. Each step prints a status line; in interactive mode, failed steps prompt retry or skip.
 
 | # | Step | Key modules |
 |---|---|---|
@@ -73,11 +75,12 @@ The pipeline runs 9 steps in sequence. Each step prints a status line; in intera
 | 2 | Marine Cadastre historical backfill | `src/ingest/marine_cadastre.py` |
 | 3 | Live AIS streaming | `src/ingest/ais_stream.py` |
 | 4 | Sanctions loading | `src/ingest/sanctions.py` |
-| 5 | Ownership graph | `src/ingest/vessel_registry.py` (→ Lance Graph) + `src/features/ownership_graph.py` |
-| 6 | Feature engineering | `src/features/ais_behavior.py` + `identity.py` + `trade_mismatch.py` + `build_matrix.py` |
-| 7 | Scoring | `src/score/causal_sanction.py` + `mpol_baseline.py` + `anomaly.py` + `composite.py` + `watchlist.py` |
-| 8 | GDELT ingestion | `src/ingest/gdelt.py` |
-| 9 | Dashboard | `src/api/main.py` (uvicorn) |
+| 5 | Custom feed drop-ins | `src/ingest/custom_feeds.py` |
+| 6 | Ownership graph | `src/ingest/vessel_registry.py` (→ Lance Graph) + `src/features/ownership_graph.py` |
+| 7 | Feature engineering | `src/features/ais_behavior.py` + `identity.py` + `trade_mismatch.py` + `build_matrix.py` |
+| 8 | Scoring | `src/score/causal_sanction.py` + `mpol_baseline.py` + `anomaly.py` + `composite.py` + `watchlist.py` |
+| 9 | GDELT ingestion | `src/ingest/gdelt.py` |
+| 10 | Dashboard | `src/api/main.py` (uvicorn) |
 
 ---
 
@@ -143,6 +146,63 @@ Injects four realistic shadow fleet vessels (PETROVSKY ZVEZDA, SARI NOUR, OCEAN 
 ```bash
 uv run python scripts/run_pipeline.py --region singapore \
   --non-interactive --seed-dummy
+```
+
+---
+
+## Custom feed drop-ins (`_inputs/custom_feeds/`)
+
+Drop any CSV file into `_inputs/custom_feeds/` and it is auto-detected and ingested on the next pipeline run — no code changes required. Step 5 (`step_custom_feeds`) runs before the ownership graph build so proprietary position and detection data is included in feature engineering.
+
+### Supported feed types
+
+| Feed type | Required columns | Target table |
+|---|---|---|
+| AIS positions | `mmsi` (or `MMSI`), `lat` (or `LAT`), `lon` (or `LON`), `timestamp` (or `BaseDateTime`) | `ais_positions` |
+| SAR detections | `lat`, `lon`, `detected_at` | `sar_detections` |
+| Cargo manifest | `reporter`, `partner`, `hs_code`, `period` | `trade_flow` |
+| Custom sanctions | `name`, `list_source` | `sanctions_entities` |
+
+Detection is column-first; if columns are ambiguous, the filename prefix is used (`ais_*`, `sar_*`, `cargo_*`, `manifest_*`, `sanctions_*`).
+
+### Optional columns
+
+| Feed | Optional columns | Default when absent |
+|---|---|---|
+| SAR | `detection_id`, `length_m`, `source_scene`, `confidence` | UUID / null / filename stem / 1.0 |
+| Cargo | `trade_value_usd`, `route_key` | null |
+| Sanctions | `entity_id`, `mmsi`, `imo`, `flag`, `type` | UUID / null |
+
+### AIS column-map sidecar
+
+For AIS feeds with non-standard column names, create a JSON sidecar alongside the CSV:
+
+```
+_inputs/custom_feeds/spire_feed.csv
+_inputs/custom_feeds/spire_feed.columnmap.json
+```
+
+```json
+{"mmsi": "vessel_id", "lat": "latitude", "lon": "longitude", "timestamp": "time_utc"}
+```
+
+### Run standalone
+
+```bash
+# Ingest all pending files
+uv run python src/ingest/custom_feeds.py
+
+# Dry-run (detect types without inserting)
+uv run python src/ingest/custom_feeds.py --dry-run
+
+# Custom directory
+uv run python src/ingest/custom_feeds.py --dir /path/to/feeds
+```
+
+Or use the operations shell:
+
+```bash
+bash scripts/run_operations_shell.sh   # → job 15: Ingest custom feed drop-ins
 ```
 
 ---

--- a/scripts/run_operations_shell.sh
+++ b/scripts/run_operations_shell.sh
@@ -517,6 +517,66 @@ print(f'Exported {df.height} rows to $sample_path')
   echo "  3. API:  curl http://localhost:8000/api/vessels"
 }
 
+run_ingest_custom_feeds() {
+  echo
+  echo "[15] Ingest custom feed drop-ins (_inputs/custom_feeds/)"
+
+  local feeds_dir
+  feeds_dir="$(prompt "Feeds directory" "_inputs/custom_feeds")"
+
+  local db_path
+  db_path="$(prompt "DuckDB path" "data/processed/mpol.duckdb")"
+
+  local dry_run_flag=""
+  if prompt_yes_no "Dry-run (detect feed types without inserting rows)" "false"; then
+    dry_run_flag="--dry-run"
+  fi
+
+  local cmd=(uv run python src/ingest/custom_feeds.py --dir "$feeds_dir" --db "$db_path")
+  if [[ -n "$dry_run_flag" ]]; then
+    cmd+=("$dry_run_flag")
+  fi
+
+  if ! run_cmd "${cmd[@]}"; then
+    echo "Result: FAILED"
+    return
+  fi
+
+  echo "Result: SUCCESS"
+
+  if [[ -n "$dry_run_flag" ]]; then
+    return
+  fi
+
+  if ! prompt_yes_no "Run feature matrix + scoring to verify in dashboard" "true"; then
+    return
+  fi
+
+  echo
+  echo "── Building feature matrix ────────────────────────────────────────────────────"
+  if ! run_cmd uv run python src/features/build_matrix.py --db "$db_path" --skip-graph; then
+    echo "Result: FAILED (build_matrix)"
+    return
+  fi
+
+  echo
+  echo "── Composite scoring + watchlist ──────────────────────────────────────────────"
+  local watchlist_path="$PROJECT_ROOT/data/processed/candidate_watchlist.parquet"
+  if ! run_cmd uv run python src/score/composite.py \
+      --db "$db_path" \
+      --output "$watchlist_path"; then
+    echo "Result: FAILED (composite scoring)"
+    return
+  fi
+
+  print_watchlist_summary "$watchlist_path"
+  echo
+  echo "── To verify in the dashboard ────────────────────────────────────────────────"
+  echo "  1. Start the app:  uv run uvicorn src.api.main:app --reload"
+  echo "  2. Open: http://localhost:8000"
+  echo "  3. API:  curl http://localhost:8000/api/vessels"
+}
+
 run_ingest_eo_csv() {
   echo
   echo "[13] Ingest EO Detections from CSV"
@@ -732,8 +792,15 @@ main_menu() {
     echo "           or NMEA 0183 VDM/VDO sentence file into ais_positions; then optionally"
     echo "           re-run feature matrix + scoring so new vessels appear on the dashboard"
     echo "     When: testing a new S-AIS provider feed (Spire, exactEarth, Orbcomm, etc.)"
-    echo "           or verifying issue #138 acceptance criteria"
     echo "      Who: developer, data engineer"
+    echo
+    echo "15) Ingest custom feed drop-ins"
+    echo "     What: run all CSV files in _inputs/custom_feeds/ through the auto-detector;"
+    echo "           auto-routes AIS/SAR/cargo/sanctions feeds to the appropriate DuckDB table;"
+    echo "           then optionally re-run feature matrix + scoring"
+    echo "     When: loading proprietary AIS, SAR detections, cargo manifests, or sanctions"
+    echo "           lists without writing any ingestion code"
+    echo "      Who: analyst, developer, data engineer"
     echo
     echo "────────────────────────────────────────────────────────────────────────────────"
     echo "q) Quit"
@@ -757,6 +824,7 @@ main_menu() {
       12) run_eo_feature_smoke ;;
       13) run_ingest_eo_csv ;;
       14) run_ingest_ais_csv ;;
+      15) run_ingest_custom_feeds ;;
       q|quit|exit)
         echo "Bye"
         return

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -348,7 +348,7 @@ def _print_region_summary(p: RegionPreset) -> None:
 # Pipeline steps
 # ---------------------------------------------------------------------------
 
-TOTAL_STEPS = 9
+TOTAL_STEPS = 10
 
 
 def step_schema(p: RegionPreset, non_interactive: bool) -> bool:
@@ -485,8 +485,27 @@ def step_sanctions(p: RegionPreset, non_interactive: bool) -> bool:
     return False
 
 
+def step_custom_feeds(p: RegionPreset, non_interactive: bool) -> bool:
+    _step(5, TOTAL_STEPS, "Ingesting custom feeds...")
+    from src.ingest.custom_feeds import ingest_custom_feeds
+
+    try:
+        results = ingest_custom_feeds(db_path=p.db_path)
+        total = sum(results.values())
+        if results:
+            _ok(f"{len(results)} file(s), {total} rows inserted")
+        else:
+            _ok("no files in _inputs/custom_feeds/")
+        return True
+    except Exception as exc:
+        _fail(str(exc))
+        if non_interactive:
+            return False
+        return _ask_retry_skip("custom_feeds") == "skip"
+
+
 def step_ownership_graph(p: RegionPreset, non_interactive: bool) -> bool:
-    _step(5, TOTAL_STEPS, "Building ownership graph...")
+    _step(6, TOTAL_STEPS, "Building ownership graph...")
     # vessel_registry builds Lance datasets from DuckDB vessel_meta
     reg = _run([sys.executable, "-m", "src.ingest.vessel_registry", "--db", p.db_path])
     if reg.returncode != 0:
@@ -508,7 +527,7 @@ def step_ownership_graph(p: RegionPreset, non_interactive: bool) -> bool:
 
 
 def step_features(p: RegionPreset, non_interactive: bool, seed_dummy: bool = False) -> bool:
-    _step(6, TOTAL_STEPS, "Computing features...")
+    _step(7, TOTAL_STEPS, "Computing features...")
     env = {"DB_PATH": p.db_path}
     cmds = [
         (
@@ -582,7 +601,7 @@ def step_score(
     non_interactive: bool,
     geo_filter_path: str | None = None,
 ) -> bool:
-    _step(7, TOTAL_STEPS, "Scoring...")
+    _step(8, TOTAL_STEPS, "Scoring...")
     env = {"DB_PATH": p.db_path}
 
     # C3: calibrate graph_risk_score weight before composite scoring
@@ -648,7 +667,7 @@ def step_score(
 
 
 def step_gdelt(p: RegionPreset, non_interactive: bool, gdelt_days: int = 3) -> bool:
-    _step(8, TOTAL_STEPS, f"Ingesting GDELT context ({gdelt_days}d)...")
+    _step(9, TOTAL_STEPS, f"Ingesting GDELT context ({gdelt_days}d)...")
     result = _run([sys.executable, "-m", "src.ingest.gdelt", "--days", str(gdelt_days)])
     if result.returncode == 0:
         count_line = next((l for l in result.stdout.splitlines() if "total" in l.lower()), "")
@@ -661,7 +680,7 @@ def step_gdelt(p: RegionPreset, non_interactive: bool, gdelt_days: int = 3) -> b
 
 
 def step_dashboard(p: RegionPreset, non_interactive: bool) -> bool:
-    _step(9, TOTAL_STEPS, "Launching dashboard...")
+    _step(10, TOTAL_STEPS, "Launching dashboard...")
     if non_interactive:
         print(_dim("(skipped in non-interactive mode)"))
         return True
@@ -798,6 +817,7 @@ def main() -> None:
         lambda p, ni: step_marine_cadastre(p, ni, marine_cadastre_years),
         lambda p, ni: step_ais_stream(p, ni, stream_duration),
         step_sanctions,
+        step_custom_feeds,
         step_ownership_graph,
         lambda p, ni: step_features(p, ni, seed_dummy),
         lambda p, ni: step_score(p, ni, geo_filter_path),
@@ -815,6 +835,7 @@ def main() -> None:
         import time
 
         rescore_steps = [
+            step_custom_feeds,
             lambda p, ni: step_features(p, ni, seed_dummy),
             lambda p, ni: step_score(p, ni, geo_filter_path),
         ]

--- a/src/ingest/custom_feeds.py
+++ b/src/ingest/custom_feeds.py
@@ -1,0 +1,350 @@
+"""Auto-detected drop-in ingestion for proprietary data feeds.
+
+Drop any CSV file into ``_inputs/custom_feeds/`` and it will be automatically
+schema-mapped and ingested into the appropriate DuckDB table on the next
+pipeline run — no code changes required.
+
+Supported feed types (detected by column signature):
+
+    AIS positions feed
+        Required columns: mmsi (or MMSI), lat (or LAT), lon (or LON), timestamp (or BaseDateTime)
+        Target table:     ais_positions
+        Column map:       same as MarineCadastre defaults; override with a
+                          <stem>.columnmap.json sidecar file
+
+    SAR detection feed
+        Required columns: lat, lon, detected_at
+        Target table:     sar_detections
+        Optional columns: detection_id, length_m, source_scene, confidence
+
+    Cargo manifest feed
+        Required columns: reporter, partner, hs_code, period
+        Target table:     trade_flow
+        Optional columns: trade_value_usd, route_key
+
+    Custom sanctions feed
+        Required columns: name, list_source
+        Target table:     sanctions_entities
+        Optional columns: entity_id, mmsi, imo, flag, type
+
+Filename convention (used when column detection is ambiguous):
+    ais_*.csv          → AIS positions
+    sar_*.csv          → SAR detections
+    cargo_*.csv  /  manifest_*.csv  → Cargo manifest
+    sanctions_*.csv    → Custom sanctions
+
+Column-map sidecar (optional, for AIS feeds with non-standard column names):
+    Create a JSON file alongside your CSV with the same stem:
+        _inputs/custom_feeds/my_feed.csv
+        _inputs/custom_feeds/my_feed.columnmap.json   ← {"mmsi": "vessel_id", ...}
+
+Usage:
+    # Run standalone to ingest all pending files:
+    uv run python src/ingest/custom_feeds.py
+
+    # Specify a custom directory:
+    uv run python src/ingest/custom_feeds.py --dir /path/to/feeds
+
+    # Dry-run (detect and log without ingesting):
+    uv run python src/ingest/custom_feeds.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import uuid
+from pathlib import Path
+
+import duckdb
+import polars as pl
+from dotenv import load_dotenv
+
+from src.ingest.ais_csv import ingest_csv
+from src.ingest.schema import init_schema
+
+load_dotenv()
+
+DEFAULT_DB_PATH = os.getenv("DB_PATH", "data/processed/mpol.duckdb")
+DEFAULT_FEEDS_DIR = Path("_inputs/custom_feeds")
+
+# ---------------------------------------------------------------------------
+# Feed type signatures — (required_cols, feed_type)
+# ---------------------------------------------------------------------------
+
+_FEED_SIGNATURES: list[tuple[set[str], str]] = [
+    # Order matters: most specific first
+    ({"lat", "lon", "detected_at"}, "sar"),
+    ({"reporter", "partner", "hs_code", "period"}, "cargo"),
+    ({"name", "list_source"}, "sanctions"),
+    ({"mmsi", "lat", "lon"}, "ais"),
+    # MarineCadastre uppercase variant
+    ({"MMSI", "LAT", "LON"}, "ais"),
+]
+
+_FILENAME_HINTS: dict[str, str] = {
+    "sar": "sar",
+    "cargo": "cargo",
+    "manifest": "cargo",
+    "sanctions": "sanctions",
+    "ais": "ais",
+}
+
+
+def _detect_feed_type(columns: list[str], stem: str) -> str | None:
+    """Infer feed type from column names, falling back to filename prefix."""
+    col_set = set(columns)
+
+    # Column-based detection
+    for required, feed_type in _FEED_SIGNATURES:
+        if required.issubset(col_set):
+            return feed_type
+
+    # Filename-based fallback
+    stem_lower = stem.lower()
+    for hint, feed_type in _FILENAME_HINTS.items():
+        if stem_lower.startswith(hint) or f"_{hint}_" in stem_lower:
+            return feed_type
+
+    return None
+
+
+def _load_column_map(csv_path: Path) -> dict[str, str] | None:
+    """Load optional <stem>.columnmap.json sidecar file."""
+    sidecar = csv_path.with_suffix(".columnmap.json")
+    if sidecar.exists():
+        with open(sidecar) as fh:
+            return json.load(fh)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Per-feed-type ingestors
+# ---------------------------------------------------------------------------
+
+
+def _ingest_ais(csv_path: Path, db_path: str) -> int:
+    col_map = _load_column_map(csv_path)
+    return ingest_csv(csv_path, db_path=db_path, column_map=col_map)
+
+
+def _ingest_sar(csv_path: Path, db_path: str) -> int:
+    df = pl.read_csv(csv_path, infer_schema_length=1000, try_parse_dates=False)
+
+    # Normalise column names to lowercase
+    df = df.rename({c: c.lower() for c in df.columns})
+
+    # Parse detected_at
+    if df["detected_at"].dtype == pl.Utf8:
+        df = df.with_columns(
+            pl.col("detected_at")
+            .str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f", strict=False)
+            .fill_null(
+                pl.col("detected_at").str.strptime(pl.Datetime, "%Y-%m-%d %H:%M:%S", strict=False)
+            )
+            .dt.replace_time_zone("UTC")
+            .alias("detected_at")
+        )
+
+    # Synthesise missing optional columns
+    if "detection_id" not in df.columns:
+        df = df.with_columns(
+            pl.Series("detection_id", [str(uuid.uuid4()) for _ in range(df.height)])
+        )
+    if "length_m" not in df.columns:
+        df = df.with_columns(pl.lit(None).cast(pl.Float32).alias("length_m"))
+    if "source_scene" not in df.columns:
+        df = df.with_columns(pl.lit(csv_path.stem).alias("source_scene"))
+    if "confidence" not in df.columns:
+        df = df.with_columns(pl.lit(1.0).cast(pl.Float32).alias("confidence"))
+
+    df = df.select(
+        ["detection_id", "detected_at", "lat", "lon", "length_m", "source_scene", "confidence"]
+    )
+    df = df.with_columns(
+        pl.col("lat").cast(pl.Float64),
+        pl.col("lon").cast(pl.Float64),
+        pl.col("length_m").cast(pl.Float32),
+        pl.col("confidence").cast(pl.Float32),
+    )
+    df = df.drop_nulls(subset=["detection_id", "detected_at", "lat", "lon"])
+
+    con = duckdb.connect(db_path)
+    try:
+        con.execute("INSERT OR IGNORE INTO sar_detections SELECT * FROM df")
+        return df.height
+    finally:
+        con.close()
+
+
+def _ingest_cargo(csv_path: Path, db_path: str) -> int:
+    df = pl.read_csv(csv_path, infer_schema_length=1000, try_parse_dates=False)
+    df = df.rename({c: c.lower() for c in df.columns})
+
+    if "trade_value_usd" not in df.columns:
+        df = df.with_columns(pl.lit(None).cast(pl.Float64).alias("trade_value_usd"))
+    if "route_key" not in df.columns:
+        df = df.with_columns(pl.lit(None).cast(pl.Utf8).alias("route_key"))
+
+    df = df.select(["reporter", "partner", "hs_code", "period", "trade_value_usd", "route_key"])
+    df = df.with_columns(
+        pl.col("reporter").cast(pl.Utf8),
+        pl.col("partner").cast(pl.Utf8),
+        pl.col("hs_code").cast(pl.Utf8),
+        pl.col("period").cast(pl.Utf8),
+        pl.col("trade_value_usd").cast(pl.Float64),
+    )
+    df = df.drop_nulls(subset=["reporter", "partner", "hs_code", "period"])
+
+    con = duckdb.connect(db_path)
+    try:
+        con.execute("INSERT OR IGNORE INTO trade_flow SELECT * FROM df")
+        return df.height
+    finally:
+        con.close()
+
+
+def _ingest_sanctions(csv_path: Path, db_path: str) -> int:
+    df = pl.read_csv(csv_path, infer_schema_length=1000, try_parse_dates=False)
+    df = df.rename({c: c.lower() for c in df.columns})
+
+    if "entity_id" not in df.columns:
+        df = df.with_columns(pl.Series("entity_id", [str(uuid.uuid4()) for _ in range(df.height)]))
+    for col in ("mmsi", "imo", "flag", "type"):
+        if col not in df.columns:
+            df = df.with_columns(pl.lit(None).cast(pl.Utf8).alias(col))
+
+    df = df.select(["entity_id", "name", "mmsi", "imo", "flag", "type", "list_source"])
+    df = df.drop_nulls(subset=["entity_id", "name", "list_source"])
+
+    con = duckdb.connect(db_path)
+    try:
+        con.execute("INSERT OR IGNORE INTO sanctions_entities SELECT * FROM df")
+        return df.height
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Schema requirement strings (for error messages)
+# ---------------------------------------------------------------------------
+
+_SCHEMA_REQUIREMENTS = {
+    "ais": "mmsi (or MMSI), lat (or LAT), lon (or LON), timestamp (or BaseDateTime)",
+    "sar": "lat, lon, detected_at",
+    "cargo": "reporter, partner, hs_code, period",
+    "sanctions": "name, list_source",
+}
+
+_INGESTORS = {
+    "ais": _ingest_ais,
+    "sar": _ingest_sar,
+    "cargo": _ingest_cargo,
+    "sanctions": _ingest_sanctions,
+}
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def ingest_custom_feeds(
+    feeds_dir: Path = DEFAULT_FEEDS_DIR,
+    db_path: str = DEFAULT_DB_PATH,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Scan feeds_dir for CSV files and ingest each into the appropriate table.
+
+    Returns a dict mapping filename → rows inserted (or 0 for dry-run).
+    Raises no exceptions — errors are printed and the file is skipped.
+    """
+    results: dict[str, int] = {}
+
+    if not feeds_dir.exists():
+        return results
+
+    csv_files = sorted(feeds_dir.glob("*.csv"))
+    if not csv_files:
+        return results
+
+    init_schema(db_path)
+
+    for csv_path in csv_files:
+        try:
+            header = pl.read_csv(csv_path, n_rows=0)
+            columns = header.columns
+        except Exception as exc:
+            print(f"  [custom_feeds] SKIP {csv_path.name} — cannot read header: {exc}")
+            results[csv_path.name] = 0
+            continue
+
+        feed_type = _detect_feed_type(columns, csv_path.stem)
+
+        if feed_type is None:
+            print(
+                f"  [custom_feeds] UNKNOWN SCHEMA: {csv_path.name}\n"
+                f"    Columns found: {', '.join(columns)}\n"
+                f"    Supported feed types and required columns:\n"
+                + "\n".join(f"      {ft}: {req}" for ft, req in _SCHEMA_REQUIREMENTS.items())
+            )
+            results[csv_path.name] = 0
+            continue
+
+        print(f"  [custom_feeds] {csv_path.name} → {feed_type} feed")
+
+        if dry_run:
+            print("    (dry-run — skipping ingest)")
+            results[csv_path.name] = 0
+            continue
+
+        try:
+            n = _INGESTORS[feed_type](csv_path, db_path)
+            print(f"    {n} rows inserted into {_target_table(feed_type)}")
+            results[csv_path.name] = n
+        except Exception as exc:
+            print(f"    ERROR: {exc}")
+            results[csv_path.name] = 0
+
+    return results
+
+
+def _target_table(feed_type: str) -> str:
+    return {
+        "ais": "ais_positions",
+        "sar": "sar_detections",
+        "cargo": "trade_flow",
+        "sanctions": "sanctions_entities",
+    }[feed_type]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Ingest all CSV files from _inputs/custom_feeds/ into DuckDB"
+    )
+    parser.add_argument(
+        "--dir",
+        type=Path,
+        default=DEFAULT_FEEDS_DIR,
+        help=f"Custom feeds directory (default: {DEFAULT_FEEDS_DIR})",
+    )
+    parser.add_argument("--db", default=DEFAULT_DB_PATH)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Detect feed types and log without ingesting",
+    )
+    args = parser.parse_args()
+
+    results = ingest_custom_feeds(args.dir, args.db, dry_run=args.dry_run)
+    total = sum(results.values())
+
+    if not results:
+        print(f"No CSV files found in {args.dir}")
+    else:
+        print(f"\nCustom feeds summary: {len(results)} file(s), {total} rows inserted")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_custom_feeds.py
+++ b/tests/test_custom_feeds.py
@@ -1,0 +1,348 @@
+"""Tests for src/ingest/custom_feeds.py — auto-detected drop-in feed ingestion."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from src.ingest.custom_feeds import (
+    _detect_feed_type,
+    ingest_custom_feeds,
+)
+from src.ingest.schema import init_schema
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_csv(tmp_path: Path, content: str, name: str = "feed.csv") -> Path:
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(content))
+    return p
+
+
+def _db(tmp_path: Path) -> str:
+    db_path = str(tmp_path / "test.duckdb")
+    init_schema(db_path)
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# _detect_feed_type
+# ---------------------------------------------------------------------------
+
+
+class TestDetectFeedType:
+    def test_sar_by_columns(self):
+        assert _detect_feed_type(["lat", "lon", "detected_at"], "feed") == "sar"
+
+    def test_cargo_by_columns(self):
+        cols = ["reporter", "partner", "hs_code", "period", "trade_value_usd"]
+        assert _detect_feed_type(cols, "feed") == "cargo"
+
+    def test_sanctions_by_columns(self):
+        assert _detect_feed_type(["name", "list_source", "mmsi"], "feed") == "sanctions"
+
+    def test_ais_lowercase(self):
+        assert _detect_feed_type(["mmsi", "lat", "lon", "timestamp"], "feed") == "ais"
+
+    def test_ais_uppercase(self):
+        assert _detect_feed_type(["MMSI", "LAT", "LON", "BaseDateTime"], "feed") == "ais"
+
+    def test_filename_fallback_ais(self):
+        assert _detect_feed_type(["a", "b", "c"], "ais_2024_01") == "ais"
+
+    def test_filename_fallback_sar(self):
+        assert _detect_feed_type(["a", "b", "c"], "sar_feed") == "sar"
+
+    def test_filename_fallback_cargo(self):
+        assert _detect_feed_type(["a", "b", "c"], "cargo_export") == "cargo"
+
+    def test_filename_fallback_manifest(self):
+        assert _detect_feed_type(["a", "b", "c"], "manifest_q1") == "cargo"
+
+    def test_filename_fallback_sanctions(self):
+        assert _detect_feed_type(["a", "b", "c"], "sanctions_ofac") == "sanctions"
+
+    def test_unknown_returns_none(self):
+        assert _detect_feed_type(["foo", "bar"], "unknown_feed") is None
+
+    def test_sar_wins_over_ais_on_column_match(self):
+        # SAR signature is checked before AIS; a file with both sets → sar
+        cols = ["lat", "lon", "detected_at", "mmsi"]
+        assert _detect_feed_type(cols, "feed") == "sar"
+
+
+# ---------------------------------------------------------------------------
+# SAR ingest
+# ---------------------------------------------------------------------------
+
+
+class TestIngestSar:
+    def test_basic(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            """\
+            lat,lon,detected_at
+            1.2,103.8,2024-01-15T08:30:00
+            1.3,103.9,2024-01-15T09:00:00
+            """,
+            "sar_feed.csv",
+        )
+        db_path = _db(tmp_path)
+        results = ingest_custom_feeds(tmp_path, db_path)
+        assert results["sar_feed.csv"] == 2
+
+        con = duckdb.connect(db_path)
+        rows = con.execute("SELECT COUNT(*) FROM sar_detections").fetchone()[0]
+        con.close()
+        assert rows == 2
+
+    def test_optional_columns_synthesised(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            """\
+            lat,lon,detected_at
+            1.2,103.8,2024-01-15T08:30:00
+            """,
+            "sar_minimal.csv",
+        )
+        db_path = _db(tmp_path)
+        ingest_custom_feeds(tmp_path, db_path)
+
+        con = duckdb.connect(db_path)
+        row = con.execute("SELECT confidence, source_scene FROM sar_detections LIMIT 1").fetchone()
+        con.close()
+        assert row[0] == pytest.approx(1.0)
+        assert row[1] == "sar_minimal"  # stem used as source_scene
+
+    def test_duplicate_ignored(self, tmp_path):
+        # Deduplication via INSERT OR IGNORE requires a stable detection_id.
+        # Provide one explicitly so re-ingestion doesn't create duplicate rows.
+        content = """\
+        detection_id,lat,lon,detected_at
+        aaa-111,1.2,103.8,2024-01-15T08:30:00
+        """
+        _write_csv(tmp_path, content, "sar_feed.csv")
+        db_path = _db(tmp_path)
+        ingest_custom_feeds(tmp_path, db_path)
+        ingest_custom_feeds(tmp_path, db_path)
+
+        con = duckdb.connect(db_path)
+        rows = con.execute("SELECT COUNT(*) FROM sar_detections").fetchone()[0]
+        con.close()
+        assert rows == 1
+
+
+# ---------------------------------------------------------------------------
+# Cargo ingest
+# ---------------------------------------------------------------------------
+
+
+class TestIngestCargo:
+    def test_basic(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            """\
+            reporter,partner,hs_code,period,trade_value_usd
+            SG,CN,8703,2024-01,500000
+            SG,US,8703,2024-01,300000
+            """,
+            "cargo_q1.csv",
+        )
+        db_path = _db(tmp_path)
+        results = ingest_custom_feeds(tmp_path, db_path)
+        assert results["cargo_q1.csv"] == 2
+
+        con = duckdb.connect(db_path)
+        rows = con.execute("SELECT COUNT(*) FROM trade_flow").fetchone()[0]
+        con.close()
+        assert rows == 2
+
+    def test_optional_columns_synthesised(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            """\
+            reporter,partner,hs_code,period
+            SG,CN,8703,2024-01
+            """,
+            "manifest_q1.csv",
+        )
+        db_path = _db(tmp_path)
+        ingest_custom_feeds(tmp_path, db_path)
+
+        con = duckdb.connect(db_path)
+        row = con.execute("SELECT trade_value_usd, route_key FROM trade_flow LIMIT 1").fetchone()
+        con.close()
+        assert row[0] is None
+        assert row[1] is None
+
+
+# ---------------------------------------------------------------------------
+# Sanctions ingest
+# ---------------------------------------------------------------------------
+
+
+class TestIngestSanctions:
+    def test_basic(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            """\
+            name,list_source,mmsi
+            Vessel Alpha,OFAC,123456789
+            Vessel Beta,EU,987654321
+            """,
+            "sanctions_ofac.csv",
+        )
+        db_path = _db(tmp_path)
+        results = ingest_custom_feeds(tmp_path, db_path)
+        assert results["sanctions_ofac.csv"] == 2
+
+        con = duckdb.connect(db_path)
+        rows = con.execute("SELECT COUNT(*) FROM sanctions_entities").fetchone()[0]
+        con.close()
+        assert rows == 2
+
+    def test_entity_id_synthesised(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            """\
+            name,list_source
+            Vessel Alpha,OFAC
+            """,
+            "sanctions_test.csv",
+        )
+        db_path = _db(tmp_path)
+        ingest_custom_feeds(tmp_path, db_path)
+
+        con = duckdb.connect(db_path)
+        row = con.execute("SELECT entity_id FROM sanctions_entities LIMIT 1").fetchone()
+        con.close()
+        # Should be a UUID string
+        assert len(row[0]) == 36
+        assert row[0].count("-") == 4
+
+
+# ---------------------------------------------------------------------------
+# AIS ingest via custom_feeds (uses ais_csv.ingest_csv internally)
+# ---------------------------------------------------------------------------
+
+
+class TestIngestAis:
+    def test_basic_marinecadastre(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            """\
+            MMSI,BaseDateTime,LAT,LON,SOG,COG,Status,VesselType
+            123456789,2024-01-15T08:00:00,1.2,103.8,5.0,180,0,70
+            """,
+            "ais_2024.csv",
+        )
+        db_path = _db(tmp_path)
+        results = ingest_custom_feeds(tmp_path, db_path)
+        assert results["ais_2024.csv"] == 1
+
+        con = duckdb.connect(db_path)
+        rows = con.execute("SELECT COUNT(*) FROM ais_positions").fetchone()[0]
+        con.close()
+        assert rows == 1
+
+    def test_columnmap_sidecar(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            """\
+            vessel_id,time_utc,latitude,longitude
+            123456789,2024-01-15T08:00:00,1.2,103.8
+            """,
+            "ais_spire.csv",
+        )
+        sidecar = tmp_path / "ais_spire.columnmap.json"
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "mmsi": "vessel_id",
+                    "timestamp": "time_utc",
+                    "lat": "latitude",
+                    "lon": "longitude",
+                }
+            )
+        )
+        db_path = _db(tmp_path)
+        results = ingest_custom_feeds(tmp_path, db_path)
+        assert results["ais_spire.csv"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Error handling / edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_directory(self, tmp_path):
+        db_path = _db(tmp_path)
+        feeds_dir = tmp_path / "feeds"
+        feeds_dir.mkdir()
+        results = ingest_custom_feeds(feeds_dir, db_path)
+        assert results == {}
+
+    def test_nonexistent_directory(self, tmp_path):
+        db_path = _db(tmp_path)
+        results = ingest_custom_feeds(tmp_path / "no_such_dir", db_path)
+        assert results == {}
+
+    def test_unknown_schema_skipped(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            """\
+            foo,bar,baz
+            1,2,3
+            """,
+            "unknown_feed.csv",
+        )
+        db_path = _db(tmp_path)
+        results = ingest_custom_feeds(tmp_path, db_path)
+        assert results["unknown_feed.csv"] == 0
+
+    def test_dry_run_no_rows_inserted(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            """\
+            lat,lon,detected_at
+            1.2,103.8,2024-01-15T08:30:00
+            """,
+            "sar_feed.csv",
+        )
+        db_path = _db(tmp_path)
+        results = ingest_custom_feeds(tmp_path, db_path, dry_run=True)
+        assert results["sar_feed.csv"] == 0
+
+        con = duckdb.connect(db_path)
+        rows = con.execute("SELECT COUNT(*) FROM sar_detections").fetchone()[0]
+        con.close()
+        assert rows == 0
+
+    def test_multiple_files(self, tmp_path):
+        _write_csv(
+            tmp_path,
+            "lat,lon,detected_at\n1.2,103.8,2024-01-15T08:30:00\n",
+            "sar_a.csv",
+        )
+        _write_csv(
+            tmp_path,
+            "lat,lon,detected_at\n1.3,103.9,2024-01-16T09:00:00\n",
+            "sar_b.csv",
+        )
+        db_path = _db(tmp_path)
+        results = ingest_custom_feeds(tmp_path, db_path)
+        assert results["sar_a.csv"] == 1
+        assert results["sar_b.csv"] == 1
+
+        con = duckdb.connect(db_path)
+        rows = con.execute("SELECT COUNT(*) FROM sar_detections").fetchone()[0]
+        con.close()
+        assert rows == 2


### PR DESCRIPTION
Closes #139

## Summary

- **`src/ingest/custom_feeds.py`** — auto-detects feed type from column signature (SAR / cargo / sanctions / AIS), falls back to filename prefix (`sar_*`, `cargo_*`, `manifest_*`, `sanctions_*`, `ais_*`), and routes each CSV to the correct DuckDB table. Optional `.columnmap.json` sidecar lets AIS feeds with non-standard columns map without code changes.
- **`scripts/run_pipeline.py`** — new `step_custom_feeds` inserted as step 5 of 10 (after sanctions, before ownership graph); also runs on every cadence rescore loop so live drop-ins are picked up automatically.
- **`scripts/run_operations_shell.sh`** — job 15: interactive prompt for feeds directory + dry-run option + optional feature matrix + scoring.
- **`docs/pipeline-operations.md`** — new *Custom feed drop-ins* section with interface contract table (required/optional columns per feed type), `.columnmap.json` format, and standalone CLI usage.
- **`tests/test_custom_feeds.py`** — 26 unit tests covering all four feed types, column-map sidecar, dry-run, unknown schema skip, deduplication, and edge cases.

## Required columns per feed type

| Feed type | Required columns | Target table |
|---|---|---|
| AIS positions | `mmsi`/`MMSI`, `lat`/`LAT`, `lon`/`LON`, `timestamp`/`BaseDateTime` | `ais_positions` |
| SAR detections | `lat`, `lon`, `detected_at` | `sar_detections` |
| Cargo manifest | `reporter`, `partner`, `hs_code`, `period` | `trade_flow` |
| Custom sanctions | `name`, `list_source` | `sanctions_entities` |

## Test plan

- [x] `uv run pytest tests/test_custom_feeds.py` — 26 passed
- [x] `uv run ruff check src/ingest/custom_feeds.py tests/test_custom_feeds.py scripts/run_pipeline.py` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)