### PR TITLE
feat: dispatch briefs, mlx-lm backend, and local caching

### DIFF
--- a/docs/local-llm-setup.md
+++ b/docs/local-llm-setup.md
@@ -12,51 +12,83 @@ arktrace supports two LLM providers configured via `.env`. Set `LLM_PROVIDER` to
 | Feature | Prompt shape | Typical output |
 |---|---|---|
 | **Analyst brief** | Vessel profile + top SHAP signals + 3 GDELT events | One paragraph citing a specific event and how it connects to the vessel's risk score |
+| **Dispatch brief** | Vessel data (dark count, ownership hop, flag changes, ATT, p-value, confidence) | Officer-to-commander verbal brief in a fixed format |
 | **Analyst chat** | Fleet overview + optional vessel detail + analyst question | Direct factual answer grounded in the provided data |
 
-Prompts are short (500–1,200 tokens in, 150–300 out). Instruction following matters more than reasoning ability — a 4B model is sufficient.
+Prompts are short (500–1,200 tokens in, 150–300 out). A 4–7B model is sufficient.
 
 ---
 
-## Recommended: mlx-lm local server (Apple Silicon)
+## 🍎 Recommended: Native macOS dev mode (mlx-lm)
 
-mlx-lm runs natively on Apple Silicon via the MLX framework and exposes an OpenAI-compatible REST API. No Docker, no compilation, no GPU driver setup required.
+`mlx-lm` runs natively on Apple Silicon via the MLX framework and exposes an OpenAI-compatible REST endpoint. The dashboard connects to it as a standard `openai` provider.
 
-**1. Install:**
+> **Infra (MinIO) still runs in Docker.** Only the FastAPI process and mlx-lm run on the host.
+
+### One-time setup
+
 ```bash
-pip install mlx-lm
+uv pip install mlx-lm
 ```
 
-**2. Start the server:**
+### Start everything
+
 ```bash
-mlx_lm.server --model mlx-community/Mistral-7B-Instruct-v0.3-4bit
-# or a smaller model:
-mlx_lm.server --model mlx-community/Qwen2.5-3B-Instruct-4bit
+# Recommended — one command starts MinIO, mlx-lm, and the dashboard:
+bash scripts/run_app.sh
+
+# Override the default model:
+bash scripts/run_app.sh --model mlx-community/Qwen2.5-7B-Instruct-4bit
+
+# Skip Docker infra (MinIO already running):
+bash scripts/run_app.sh --no-infra
+
+# Skip mlx-lm (server already running on port 8080):
+bash scripts/run_app.sh --no-llm
+
+# Use Anthropic instead of local LLM:
+bash scripts/run_app.sh --provider anthropic
 ```
 
-The server listens on `http://localhost:8080/v1` by default.
+`scripts/run_app.sh` flag reference:
 
-**3. Configure `.env`** (defaults — no changes needed):
+| Flag | Default | Description |
+|---|---|---|
+| `--model MODEL` | `mlx-community/Qwen2.5-7B-Instruct-4bit` | mlx-community model ID or local path |
+| `--provider NAME` | `openai` | `openai` (mlx-lm or remote) or `anthropic` |
+| `--port PORT` | `8000` | uvicorn port |
+| `--llm-port PORT` | `8080` | mlx-lm server port |
+| `--no-infra` | — | Skip starting Docker infra |
+| `--no-llm` | — | Skip starting mlx-lm server |
+
+### Manual startup (step-by-step)
+
 ```bash
-LLM_PROVIDER=openai
-LLM_BASE_URL=http://localhost:8080/v1
-LLM_API_KEY=local
-LLM_MODEL=gpt-4o-mini   # model name is ignored by mlx-lm; any string works
+# 1. Start MinIO
+docker compose -f docker-compose.infra.yml up -d
+
+# 2. Start mlx-lm server (downloads model on first run — ~4 GB)
+uv run mlx_lm.server --model mlx-community/Qwen2.5-7B-Instruct-4bit --port 8080 &
+
+# 3. Start the dashboard
+S3_ENDPOINT=http://localhost:9000 \
+LLM_PROVIDER=openai \
+LLM_BASE_URL=http://localhost:8080/v1 \
+LLM_API_KEY=local \
+LLM_MODEL=mlx-community/Qwen2.5-7B-Instruct-4bit \
+  uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8000 --reload
 ```
 
-**4. Start the dashboard:**
-```bash
-docker compose -f docker-compose.infra.yml up -d   # MinIO only
-uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8000 --reload
-```
+### Model guide
 
-**Model guide:**
+| Model | Size (4-bit) | Min RAM | Licence | Notes |
+|---|---|---|---|---|
+| `mlx-community/Qwen2.5-7B-Instruct-4bit` | ~4.3 GB | 8 GB | Apache 2.0 | Default — good balance of quality and speed |
+| `mlx-community/Qwen2.5-3B-Instruct-4bit` | ~1.9 GB | 6 GB | Apache 2.0 | Faster, lower RAM |
+| `mlx-community/Phi-4-mini-instruct-4bit` | ~2.4 GB | 8 GB | MIT | No restrictions on government or defence use |
+| `mlx-community/Mistral-7B-Instruct-v0.3-4bit` | ~4.1 GB | 10 GB | Apache 2.0 | Highest quality local option |
 
-| Model | Size | Min RAM | Licence |
-|---|---|---|---|
-| `mlx-community/Qwen2.5-3B-Instruct-4bit` | ~2 GB | 8 GB | Apache 2.0 |
-| `mlx-community/Mistral-7B-Instruct-v0.3-4bit` | ~4 GB | 10 GB | Apache 2.0 |
-| `mlx-community/phi-4-mini-instruct-4bit` | ~2.4 GB | 8 GB | MIT |
+All models above are permissively licensed — no restrictions on government or defence use.
 
 ---
 
@@ -70,22 +102,26 @@ LLM_MODEL=claude-haiku-4-5-20251001   # default — fast and cheap for briefs
 
 ---
 
-## Provider: openai (remote or other local servers)
+## Provider: openai — remote or any OpenAI-compatible API
 
 Works with OpenAI, Ollama, LM Studio, or any other OpenAI-compatible endpoint.
 
-**OpenAI:**
 ```bash
+# OpenAI
 LLM_PROVIDER=openai
+LLM_BASE_URL=https://api.openai.com/v1
 LLM_API_KEY=sk-...
 LLM_MODEL=gpt-4o-mini
-LLM_BASE_URL=https://api.openai.com/v1
-```
 
-**Ollama:**
-```bash
+# Ollama
 LLM_PROVIDER=openai
 LLM_BASE_URL=http://localhost:11434/v1
 LLM_API_KEY=local
 LLM_MODEL=qwen2.5:7b
+
+# mlx-lm (already running)
+LLM_PROVIDER=openai
+LLM_BASE_URL=http://localhost:8080/v1
+LLM_API_KEY=local
+LLM_MODEL=mlx-community/Qwen2.5-7B-Instruct-4bit
 ```

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,26 +1,27 @@
 #!/usr/bin/env bash
-# scripts/run_dev.sh
+# scripts/run_app.sh
 #
 # Start arktrace in native macOS dev mode.
 #
 #   • Infra (MinIO) runs in Docker via docker-compose.infra.yml
-#   • Dashboard runs natively on the host — gets Apple Metal / ANE acceleration
-#     for local LLM inference (typically 5–10× faster than inside a Colima VM)
+#   • mlx-lm runs as a local OpenAI-compatible server (Apple Silicon, Metal)
+#   • Dashboard runs natively on the host — connects to the mlx-lm server
 #
 # Prerequisites (one-time):
-#   CMAKE_ARGS="-DGGML_METAL=on" uv pip install llama-cpp-python --force-reinstall
-#   uv run python scripts/download_model.py phi-4-mini-it
+#   uv pip install mlx-lm
 #
 # Usage:
-#   bash scripts/run_dev.sh
-#   bash scripts/run_dev.sh --model ~/models/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf
-#   bash scripts/run_dev.sh --provider anthropic   # skip local LLM entirely
+#   bash scripts/run_app.sh
+#   bash scripts/run_app.sh --model mlx-community/Qwen2.5-7B-Instruct-4bit
+#   bash scripts/run_app.sh --provider anthropic   # skip local LLM entirely
 #
 # Options:
-#   --model PATH      Path to GGUF model file (overrides LLAMACPP_MODEL_PATH)
-#   --provider NAME   LLM provider: llamacpp | anthropic | openai (overrides LLM_PROVIDER)
+#   --model MODEL     mlx-community model ID or local path (overrides LLM_MODEL)
+#   --provider NAME   LLM provider: openai (mlx-lm) | anthropic (overrides LLM_PROVIDER)
 #   --port PORT       Port for uvicorn (default: 8000)
+#   --llm-port PORT   Port for mlx-lm server (default: 8080)
 #   --no-infra        Skip starting Docker infra (assumes MinIO is already up)
+#   --no-llm          Skip starting mlx-lm server (assumes it is already running)
 #   --help            Show this message
 
 set -euo pipefail
@@ -31,15 +32,19 @@ COMPOSE_FILE="${REPO_ROOT}/docker-compose.infra.yml"
 
 # ── Defaults ──────────────────────────────────────────────────────────────────
 PORT="${PORT:-8000}"
+LLM_PORT="${LLM_PORT:-8080}"
 START_INFRA=true
+START_LLM=true
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --model)    export LLAMACPP_MODEL_PATH="$2"; shift 2 ;;
-    --provider) export LLM_PROVIDER="$2";        shift 2 ;;
-    --port)     PORT="$2";                       shift 2 ;;
-    --no-infra) START_INFRA=false;               shift   ;;
+    --model)    export LLM_MODEL="$2";    shift 2 ;;
+    --provider) export LLM_PROVIDER="$2"; shift 2 ;;
+    --port)     PORT="$2";                shift 2 ;;
+    --llm-port) LLM_PORT="$2";            shift 2 ;;
+    --no-infra) START_INFRA=false;        shift   ;;
+    --no-llm)   START_LLM=false;          shift   ;;
     --help|-h)
       sed -n '/^# Usage/,/^[^#]/{ /^[^#]/d; s/^# \{0,2\}//; p }' "$0"
       exit 0
@@ -48,46 +53,22 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# ── Load .env (non-export, just source) ──────────────────────────────────────
+# ── Load .env ─────────────────────────────────────────────────────────────────
 if [[ -f "${REPO_ROOT}/.env" ]]; then
-  # shellcheck disable=SC1091
   set -o allexport
+  # shellcheck disable=SC1091
   source "${REPO_ROOT}/.env"
   set +o allexport
 fi
 
-# ── Resolve python packages ────────────────────────────────────────────────────
-if [[ "${LLM_PROVIDER:-llamacpp}" == "llamacpp" ]]; then
-  if ! uv run python -c "import llama_cpp" 2>/dev/null; then
-    echo "⬇️  llama-cpp-python not found. Compiling with Apple Metal support…"
-    CMAKE_ARGS="-DGGML_METAL=on" uv pip install llama-cpp-python --force-reinstall
-  fi
-fi
-
-# ── Resolve model path if not set ────────────────────────────────────────────
-if [[ -z "${LLAMACPP_MODEL_PATH:-}" ]]; then
-  DEFAULT_MODEL="${HOME}/.cache/arktrace/models/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf"
-  FALLBACK_MODEL="${HOME}/models/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf"
-  if [[ -f "${DEFAULT_MODEL}" ]]; then
-    export LLAMACPP_MODEL_PATH="${DEFAULT_MODEL}"
-  elif [[ -f "${FALLBACK_MODEL}" ]]; then
-    export LLAMACPP_MODEL_PATH="${FALLBACK_MODEL}"
-  elif [[ "${LLM_PROVIDER:-llamacpp}" == "llamacpp" ]]; then
-    echo "⬇️  No GGUF model found. Downloading default model (phi-4-mini-it)…"
-    uv run --with huggingface-hub python scripts/download_model.py phi-4-mini-it --dir "${HOME}/models"
-    export LLAMACPP_MODEL_PATH="${HOME}/models/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf"
-  fi
-fi
-
-# ── Override S3 endpoint for host ────────────────────────────────────────────
-# Inside Docker containers the hostname is 'minio'; on the host it's localhost.
+# ── Override S3 endpoint for host ─────────────────────────────────────────────
 export S3_ENDPOINT="${S3_ENDPOINT:-http://localhost:9000}"
 export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-minioadmin}"
 export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-minioadmin}"
 export AWS_REGION="${AWS_REGION:-us-east-1}"
 export S3_BUCKET="${S3_BUCKET:-arktrace}"
 
-# ── Start infra ───────────────────────────────────────────────────────────────
+# ── Start infra ────────────────────────────────────────────────────────────────
 if [[ "${START_INFRA}" == true ]]; then
   echo "🐳 Starting infra (MinIO)…"
   docker compose -f "${COMPOSE_FILE}" up -d
@@ -95,15 +76,57 @@ if [[ "${START_INFRA}" == true ]]; then
   echo ""
 fi
 
-# ── Print config summary ──────────────────────────────────────────────────────
-echo "🚀 Starting dashboard natively (Metal-accelerated LLM on Apple Silicon)"
-echo "   LLM_PROVIDER     = ${LLM_PROVIDER:-llamacpp}"
-echo "   LLAMACPP_MODEL   = ${LLAMACPP_MODEL_PATH:-<not set>}"
-echo "   S3_ENDPOINT      = ${S3_ENDPOINT}"
-echo "   Dashboard        → http://localhost:${PORT}"
+# ── Start mlx-lm server ───────────────────────────────────────────────────────
+PROVIDER="${LLM_PROVIDER:-openai}"
+MODEL="${LLM_MODEL:-mlx-community/Qwen2.5-7B-Instruct-4bit}"
+
+if [[ "${START_LLM}" == true && "${PROVIDER}" != "anthropic" ]]; then
+  if ! uv run python -c "import mlx_lm" 2>/dev/null; then
+    echo "⬇️  mlx-lm not found. Installing…"
+    uv pip install mlx-lm
+  fi
+
+  echo "🤖 Starting mlx-lm server on port ${LLM_PORT}…"
+  echo "   Model: ${MODEL}"
+  uv run mlx_lm.server \
+    --model "${MODEL}" \
+    --port "${LLM_PORT}" \
+    &
+  MLX_PID=$!
+  echo "   mlx-lm PID: ${MLX_PID}"
+  echo "   Waiting for server to be ready…"
+  for i in $(seq 1 30); do
+    if curl -sf "http://localhost:${LLM_PORT}/v1/models" > /dev/null 2>&1; then
+      echo "   ✅ mlx-lm ready → http://localhost:${LLM_PORT}/v1"
+      break
+    fi
+    sleep 2
+    if [[ $i -eq 30 ]]; then
+      echo "   ⚠️  mlx-lm did not respond in 60s — dashboard will start anyway"
+    fi
+  done
+  echo ""
+
+  # Point the dashboard at the local mlx-lm server
+  export LLM_PROVIDER="openai"
+  export LLM_BASE_URL="http://localhost:${LLM_PORT}/v1"
+  export LLM_API_KEY="${LLM_API_KEY:-local}"
+  export LLM_MODEL="${MODEL}"
+
+  # Shut down mlx-lm when the script exits
+  trap 'echo ""; echo "Stopping mlx-lm (PID ${MLX_PID})…"; kill "${MLX_PID}" 2>/dev/null || true' EXIT
+fi
+
+# ── Print config summary ───────────────────────────────────────────────────────
+echo "🚀 Starting dashboard"
+echo "   LLM_PROVIDER  = ${LLM_PROVIDER:-openai}"
+echo "   LLM_BASE_URL  = ${LLM_BASE_URL:-http://localhost:${LLM_PORT}/v1}"
+echo "   LLM_MODEL     = ${LLM_MODEL:-${MODEL}}"
+echo "   S3_ENDPOINT   = ${S3_ENDPOINT}"
+echo "   Dashboard     → http://localhost:${PORT}"
 echo ""
 
-# ── Run dashboard ─────────────────────────────────────────────────────────────
+# ── Run dashboard ──────────────────────────────────────────────────────────────
 cd "${REPO_ROOT}"
 exec uv run uvicorn src.api.main:app \
   --host 0.0.0.0 \

--- a/scripts/stop_app.sh
+++ b/scripts/stop_app.sh
@@ -43,6 +43,22 @@ if [[ "${STOP_APP}" == true ]]; then
   else
     echo "   uvicorn is not running."
   fi
+
+  # ── Stop mlx-lm server ─────────────────────────────────────────────────────
+  MLX_PIDS=$(pgrep -f "mlx_lm.server" 2>/dev/null || true)
+  if [[ -n "${MLX_PIDS}" ]]; then
+    echo "🤖 Stopping mlx-lm server (PIDs: ${MLX_PIDS})…"
+    kill ${MLX_PIDS}
+    sleep 1
+    # Force kill if still running
+    REMAINING_MLX=$(pgrep -f "mlx_lm.server" 2>/dev/null || true)
+    if [[ -n "${REMAINING_MLX}" ]]; then
+      echo "   Force-killing mlx-lm…"
+      kill -9 ${REMAINING_MLX} 2>/dev/null || true
+    fi
+    echo "   mlx-lm stopped."
+  fi
+
   # Kill any multiprocessing worker processes spawned by the venv's python
   # (these hold the DuckDB lock and survive the uvicorn parent being killed)
   pkill -9 -f "${REPO_ROOT}/.venv/bin/python" 2>/dev/null || true

--- a/src/api/llm.py
+++ b/src/api/llm.py
@@ -15,10 +15,15 @@ Provider selection via environment variables:
 
 Recommended local backend: mlx-lm (Apple Silicon, OpenAI-compatible server)
 
-    pip install mlx-lm
-    mlx_lm.server --model mlx-community/Mistral-7B-Instruct-v0.3-4bit
+    uv pip install mlx-lm
+    bash scripts/run_app.sh
 
-Then set LLM_BASE_URL=http://localhost:8080/v1 (default) and LLM_PROVIDER=openai (default).
+Then set:
+
+    LLM_PROVIDER=openai
+    LLM_BASE_URL=http://localhost:8080/v1
+    LLM_API_KEY=local
+    LLM_MODEL=mlx-community/Qwen2.5-7B-Instruct-4bit
 """
 
 from __future__ import annotations
@@ -143,5 +148,5 @@ def get_llm_client() -> LLMClient:
     return OpenAICompatClient(
         base_url=os.getenv("LLM_BASE_URL", "http://localhost:8080/v1"),
         api_key=os.getenv("LLM_API_KEY", "local"),
-        model=os.getenv("LLM_MODEL", "gpt-4o-mini"),
+        model=os.getenv("LLM_MODEL", "mlx-community/Qwen2.5-7B-Instruct-4bit"),
     )

--- a/src/api/routes/briefs.py
+++ b/src/api/routes/briefs.py
@@ -52,6 +52,29 @@ _USER_TEMPLATE = (
     "Cite at least one geopolitical event above."
 )
 
+_DISPATCH_SYSTEM_TEMPLATE = """\
+You are a maritime patrol officer producing a verbal dispatch brief to relay to a commander. \
+Output exactly one paragraph in the following structure — no headings, no bullet points, no markdown:
+
+"Vessel [VESSEL_NAME] (MMSI [MMSI]) is recommended for priority dispatch. \
+It went dark [DARK_COUNT] times in the past 30 days, is [HOP_DISTANCE] ownership hop(s) from a designated entity, \
+and changed flag [FLAG_CHANGES] time(s) in the past 2 years. \
+Causal analysis confirms its evasion behaviour began within the window of a sanction event \
+(ATT = [ATT_ESTIMATE], p < [P_VALUE]) — this is not coincidental route variation. \
+Confidence score: [CONFIDENCE_SCORE]."
+
+Replace the bracketed placeholders with the values below. Do not add any text outside this format.
+
+VESSEL DATA:
+Name: {vessel_name} | MMSI: {mmsi}
+AIS dark periods (30d): {dark_count}
+Ownership hops to sanctioned entity: {hop_distance}
+Flag changes (2y): {flag_changes}
+ATT estimate: {att_estimate} | p-value: {p_value}
+Confidence score: {confidence:.2f}"""
+
+_DISPATCH_USER_TEMPLATE = "Generate the officer-to-commander dispatch brief for {vessel_name} (MMSI {mmsi})."
+
 
 def _load_vessel(mmsi: str) -> dict | None:
     df = read_parquet_uri(DEFAULT_WATCHLIST_PATH)
@@ -188,6 +211,102 @@ async def _generate_brief_tokens(vessel: dict) -> list[str]:
     async for token in llm.chat(system, user):
         tokens.append(token)
     return tokens
+
+
+def _extract_dispatch_fields(vessel: dict) -> dict:
+    """Extract numeric fields needed for the officer-to-commander dispatch brief."""
+    dark_count = int(vessel.get("ais_gap_count_30d") or 0)
+    flag_changes = int(vessel.get("flag_changes_2y") or 0)
+
+    # sanctions_distance is the shortest ownership path to a sanctioned entity (0 = direct match)
+    raw_dist = vessel.get("sanctions_distance")
+    if raw_dist is None:
+        hop_distance = "unknown"
+    else:
+        hops = int(raw_dist)
+        hop_distance = str(hops) if hops > 0 else "direct"
+
+    # Pull the strongest significant causal regime
+    att_estimate: float | None = None
+    p_value: float | None = None
+    effects_df = read_parquet_uri(
+        os.getenv("CAUSAL_EFFECTS_OUTPUT_PATH") or output_uri("causal_effects.parquet")
+    )
+    if effects_df is not None and not effects_df.is_empty():
+        import polars as _pl
+
+        sig = effects_df.filter(_pl.col("is_significant")).sort("att_estimate", descending=True)
+        if not sig.is_empty():
+            er = sig.row(0, named=True)
+            att_estimate = float(er.get("att_estimate", 0.0))
+            p_value = float(er.get("p_value", 1.0))
+
+    att_str = f"{att_estimate:+.2f}" if att_estimate is not None else "n/a"
+    p_str = f"{p_value:.4f}" if p_value is not None else "n/a"
+
+    return {
+        "dark_count": dark_count,
+        "hop_distance": hop_distance,
+        "flag_changes": flag_changes,
+        "att_estimate": att_str,
+        "p_value": p_str,
+    }
+
+
+@router.get("/api/briefs/{mmsi}/dispatch")
+async def vessel_dispatch_brief_stream(mmsi: str) -> StreamingResponse:
+    """Stream an officer-to-commander dispatch brief for a vessel.
+
+    Produces a single paragraph in a fixed verbal format suitable for relaying
+    directly from a patrol officer to a commander without referencing raw data.
+    Returns SSE lines of the form ``data: <token>\\n\\n``.
+    """
+    vessel = _load_vessel(mmsi)
+    if vessel is None:
+
+        async def _not_found():
+            yield "data: Vessel not found in watchlist.\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(
+            _not_found(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    dispatch = _extract_dispatch_fields(vessel)
+    vessel_name = str(vessel.get("vessel_name") or vessel.get("mmsi", ""))
+
+    system = _DISPATCH_SYSTEM_TEMPLATE.format(
+        vessel_name=vessel_name,
+        mmsi=vessel.get("mmsi", ""),
+        dark_count=dispatch["dark_count"],
+        hop_distance=dispatch["hop_distance"],
+        flag_changes=dispatch["flag_changes"],
+        att_estimate=dispatch["att_estimate"],
+        p_value=dispatch["p_value"],
+        confidence=float(vessel.get("confidence", 0)),
+    )
+    user = _DISPATCH_USER_TEMPLATE.format(
+        vessel_name=vessel_name,
+        mmsi=vessel.get("mmsi", ""),
+    )
+
+    async def _stream():
+        try:
+            llm = get_llm_client()
+            async for token in llm.chat(system, user):
+                yield f"data: {token}\n\n"
+        except Exception as exc:
+            yield f"data: Brief unavailable — {exc}\n\n"
+        finally:
+            yield "data: [DONE]\n\n"
+
+    return StreamingResponse(
+        _stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 @router.get("/api/briefs/{mmsi}")

--- a/src/api/routes/briefs.py
+++ b/src/api/routes/briefs.py
@@ -73,7 +73,9 @@ Flag changes (2y): {flag_changes}
 ATT estimate: {att_estimate} | p-value: {p_value}
 Confidence score: {confidence:.2f}"""
 
-_DISPATCH_USER_TEMPLATE = "Generate the officer-to-commander dispatch brief for {vessel_name} (MMSI {mmsi})."
+_DISPATCH_USER_TEMPLATE = (
+    "Generate the officer-to-commander dispatch brief for {vessel_name} (MMSI {mmsi})."
+)
 
 
 def _load_vessel(mmsi: str) -> dict | None:

--- a/src/api/routes/briefs.py
+++ b/src/api/routes/briefs.py
@@ -144,13 +144,15 @@ def _watchlist_version() -> str:
         return "0"
 
 
-def _read_cached_brief(mmsi: str, version: str, db_path: str | None = None) -> str | None:
+def _read_cached_brief(
+    mmsi: str, version: str, table: str = "analyst_briefs", db_path: str | None = None
+) -> str | None:
     try:
         with get_conn() as con:
             if con is None:
                 return None
             rows = con.execute(
-                "SELECT brief FROM analyst_briefs WHERE mmsi = ? AND watchlist_version = ?",
+                f"SELECT brief FROM {table} WHERE mmsi = ? AND watchlist_version = ?",
                 [mmsi, version],
             ).fetchall()
             return rows[0][0] if rows else None
@@ -158,21 +160,24 @@ def _read_cached_brief(mmsi: str, version: str, db_path: str | None = None) -> s
         return None
 
 
-def _write_cached_brief(mmsi: str, version: str, brief: str, db_path: str | None = None) -> None:
+def _write_cached_brief(
+    mmsi: str, version: str, brief: str, table: str = "analyst_briefs", db_path: str | None = None
+) -> None:
     try:
         with get_conn() as con:
             if con is None:
                 return
             con.execute(
-                """
-                INSERT OR REPLACE INTO analyst_briefs (mmsi, watchlist_version, brief)
+                f"""
+                INSERT OR REPLACE INTO {table} (mmsi, watchlist_version, brief)
                 VALUES (?, ?, ?)
                 """,
                 [mmsi, version, brief],
             )
     except Exception:
         logger.exception(
-            "Failed to write cached brief to DuckDB (mmsi=%s, version=%s)",
+            "Failed to write cached brief to DuckDB (table=%s, mmsi=%s, version=%s)",
+            table,
             mmsi,
             version,
         )
@@ -274,6 +279,24 @@ async def vessel_dispatch_brief_stream(mmsi: str) -> StreamingResponse:
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
+    version = _watchlist_version()
+    cached = _read_cached_brief(mmsi, version, table="dispatch_briefs")
+    if cached:
+
+        async def _cached_stream():
+            # Stream cached brief word by word so the UI sees progressive output
+            words = cached.split(" ")
+            for i, word in enumerate(words):
+                chunk = word if i == 0 else " " + word
+                yield f"data: {chunk}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(
+            _cached_stream(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
     dispatch = _extract_dispatch_fields(vessel)
     vessel_name = str(vessel.get("vessel_name") or vessel.get("mmsi", ""))
 
@@ -293,14 +316,23 @@ async def vessel_dispatch_brief_stream(mmsi: str) -> StreamingResponse:
     )
 
     async def _stream():
+        tokens: list[str] = []
         try:
             llm = get_llm_client()
             async for token in llm.chat(system, user):
+                tokens.append(token)
                 yield f"data: {token}\n\n"
         except Exception as exc:
             yield f"data: Brief unavailable — {exc}\n\n"
         finally:
             yield "data: [DONE]\n\n"
+            full = "".join(tokens)
+            if (
+                full
+                and not full.startswith("LLM not configured")
+                and not full.startswith("Brief unavailable")
+            ):
+                _write_cached_brief(mmsi, version, full, table="dispatch_briefs")
 
     return StreamingResponse(
         _stream(),
@@ -331,7 +363,7 @@ async def vessel_brief(mmsi: str) -> StreamingResponse:
         )
 
     version = _watchlist_version()
-    cached = _read_cached_brief(mmsi, version)
+    cached = _read_cached_brief(mmsi, version, table="analyst_briefs")
     if cached:
 
         async def _cached_stream():
@@ -391,7 +423,7 @@ async def vessel_brief(mmsi: str) -> StreamingResponse:
                 and not full.startswith("LLM not configured")
                 and not full.startswith("Brief unavailable")
             ):
-                _write_cached_brief(mmsi, version, full)
+                _write_cached_brief(mmsi, version, full, table="analyst_briefs")
 
     return StreamingResponse(
         _stream(),
@@ -471,7 +503,17 @@ async def vessel_chat(mmsi: str, body: _ChatRequest) -> StreamingResponse:
 def vessel_brief_cached(mmsi: str) -> JSONResponse:
     """Return the cached analyst brief for a vessel, if available."""
     version = _watchlist_version()
-    cached = _read_cached_brief(mmsi, version)
+    cached = _read_cached_brief(mmsi, version, table="analyst_briefs")
+    if cached is None:
+        return JSONResponse({"available": False, "mmsi": mmsi})
+    return JSONResponse({"available": True, "mmsi": mmsi, "brief": cached})
+
+
+@router.get("/api/briefs/{mmsi}/dispatch/cached")
+def vessel_dispatch_brief_cached(mmsi: str) -> JSONResponse:
+    """Return the cached officer-to-commander dispatch brief for a vessel, if available."""
+    version = _watchlist_version()
+    cached = _read_cached_brief(mmsi, version, table="dispatch_briefs")
     if cached is None:
         return JSONResponse({"available": False, "mmsi": mmsi})
     return JSONResponse({"available": True, "mmsi": mmsi, "brief": cached})

--- a/src/ingest/schema.py
+++ b/src/ingest/schema.py
@@ -79,6 +79,15 @@ def init_schema(db_path: str = DEFAULT_DB_PATH) -> None:
             )
         """)
         con.execute("""
+            CREATE TABLE IF NOT EXISTS dispatch_briefs (
+                mmsi                VARCHAR NOT NULL,
+                watchlist_version   VARCHAR NOT NULL,
+                brief               TEXT NOT NULL,
+                generated_at        TIMESTAMPTZ DEFAULT now(),
+                PRIMARY KEY (mmsi, watchlist_version)
+            )
+        """)
+        con.execute("""
             CREATE TABLE IF NOT EXISTS chat_cache (
                 cache_key           VARCHAR PRIMARY KEY,
                 mmsi                VARCHAR,

--- a/src/viz/templates/index.html
+++ b/src/viz/templates/index.html
@@ -1035,6 +1035,10 @@
         <button onclick="document.getElementById('dispatch-modal').style.display='none'" style="padding:0.25rem 0.7rem;background:#1e2a3a;border:1px solid #334155;border-radius:4px;color:#94a3b8;cursor:pointer;font-size:0.72rem;">&#x2715; Close</button>
       </div>
     </div>
+    <div id="dispatch-verbal-brief" style="margin-bottom:1.2rem;padding:1rem;background:#0c2340;border:1px solid #1e4d6b;border-radius:6px;display:none;">
+      <div style="font-size:0.68rem;font-weight:700;letter-spacing:0.08em;color:#38bdf8;margin-bottom:0.5rem;text-transform:uppercase;">Verbal Brief — Officer to Commander</div>
+      <div id="dispatch-verbal-text" style="color:#e2e8f0;font-size:0.82rem;line-height:1.7;font-style:italic;"></div>
+    </div>
     <div id="dispatch-brief-body">Loading…</div>
   </div>
 </div>
@@ -1883,6 +1887,8 @@ function openDispatchBrief() {
   const modal = document.getElementById('dispatch-modal');
   modal.style.display = 'block';
   document.getElementById('dispatch-brief-body').innerHTML = 'Loading…';
+
+  // Load structured brief data
   fetch(`/api/vessels/${encodeURIComponent(currentReviewMmsi)}/dispatch-brief`)
     .then(r => r.json())
     .then(data => {
@@ -1893,6 +1899,21 @@ function openDispatchBrief() {
       document.getElementById('dispatch-brief-body').innerHTML =
         '<span style="color:#f87171;">Failed to load dispatch brief.</span>';
     });
+
+  // Stream officer-to-commander verbal brief
+  const verbalBox = document.getElementById('dispatch-verbal-brief');
+  const verbalText = document.getElementById('dispatch-verbal-text');
+  verbalBox.style.display = 'block';
+  verbalText.textContent = '';
+  const es = new EventSource(`/api/briefs/${encodeURIComponent(currentReviewMmsi)}/dispatch`);
+  es.onmessage = e => {
+    if (e.data === '[DONE]') { es.close(); return; }
+    verbalText.textContent += e.data;
+  };
+  es.onerror = () => {
+    es.close();
+    if (!verbalText.textContent) verbalText.textContent = 'Verbal brief unavailable — LLM not configured.';
+  };
 }
 
 function renderDispatchBrief() {

--- a/src/viz/templates/index.html
+++ b/src/viz/templates/index.html
@@ -1900,20 +1900,33 @@ function openDispatchBrief() {
         '<span style="color:#f87171;">Failed to load dispatch brief.</span>';
     });
 
-  // Stream officer-to-commander verbal brief
+  // Stream officer-to-commander verbal brief (check cache first)
   const verbalBox = document.getElementById('dispatch-verbal-brief');
   const verbalText = document.getElementById('dispatch-verbal-text');
   verbalBox.style.display = 'block';
-  verbalText.textContent = '';
-  const es = new EventSource(`/api/briefs/${encodeURIComponent(currentReviewMmsi)}/dispatch`);
-  es.onmessage = e => {
-    if (e.data === '[DONE]') { es.close(); return; }
-    verbalText.textContent += e.data;
-  };
-  es.onerror = () => {
-    es.close();
-    if (!verbalText.textContent) verbalText.textContent = 'Verbal brief unavailable — LLM not configured.';
-  };
+  verbalText.textContent = 'Loading…';
+
+  fetch(`/api/briefs/${encodeURIComponent(currentReviewMmsi)}/dispatch/cached`)
+    .then(r => r.json())
+    .then(data => {
+      if (data.available && data.brief) {
+        verbalText.textContent = data.brief;
+      } else {
+        verbalText.textContent = '';
+        const es = new EventSource(`/api/briefs/${encodeURIComponent(currentReviewMmsi)}/dispatch`);
+        es.onmessage = e => {
+          if (e.data === '[DONE]') { es.close(); return; }
+          verbalText.textContent += e.data;
+        };
+        es.onerror = () => {
+          es.close();
+          if (!verbalText.textContent) verbalText.textContent = 'Verbal brief unavailable — LLM not configured.';
+        };
+      }
+    })
+    .catch(() => {
+      verbalText.textContent = 'Verbal brief unavailable — cache check failed.';
+    });
 }
 
 function renderDispatchBrief() {

--- a/tests/test_briefs.py
+++ b/tests/test_briefs.py
@@ -245,3 +245,48 @@ def test_brief_with_no_gdelt_still_generates(client):
     assert resp.status_code == 200
     lines = [l for l in resp.text.split("\n") if l.startswith("data: ")]
     assert any(l != "data: [DONE]" for l in lines)
+
+
+# ── /api/briefs/{mmsi}/dispatch ────────────────────────────────────────────
+
+
+def test_dispatch_brief_streams_and_caches(client):
+    mock_llm = MagicMock()
+    mock_llm.chat = _fake_chat
+
+    with patch("src.api.routes.briefs.get_llm_client", return_value=mock_llm):
+        # 1. Initially not cached
+        resp = client.get("/api/briefs/123456789/dispatch/cached")
+        assert resp.json()["available"] is False
+
+        # 2. Stream and cache
+        resp = client.get("/api/briefs/123456789/dispatch")
+        assert resp.status_code == 200
+        # Check for tokens in SSE stream
+        assert "data: Test " in resp.text
+        assert "data: brief " in resp.text
+        assert "data: text." in resp.text
+
+        # 3. Now it should be cached
+        resp = client.get("/api/briefs/123456789/dispatch/cached")
+        body = resp.json()
+        assert body["available"] is True
+        assert body["brief"] == "Test brief text."
+
+
+def test_dispatch_brief_served_from_cache(client):
+    mock_llm = MagicMock()
+    call_count = 0
+
+    async def _counting_chat(system: str, user: str):
+        nonlocal call_count
+        call_count += 1
+        yield "dispatch cached."
+
+    mock_llm.chat = _counting_chat
+
+    with patch("src.api.routes.briefs.get_llm_client", return_value=mock_llm):
+        client.get("/api/briefs/123456789/dispatch")  # call 1: LLM
+        client.get("/api/briefs/123456789/dispatch")  # call 2: Cache
+
+    assert call_count == 1

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -14,6 +14,7 @@ def test_all_tables_created(tmp_db):
         "trade_flow",
         "vessel_features",
         "analyst_briefs",
+        "dispatch_briefs",
         "chat_cache",
         "cleared_vessels",
         "vessel_reviews",


### PR DESCRIPTION
## Summary

- Add officer-to-commander dispatch brief endpoint and UI (#141)
- Replace llama-cpp-python with mlx-lm as local LLM backend (closes #167)
- Implement local caching for officer-to-commander dispatch briefs
- Ensure mlx-lm server is stopped cleanly in `scripts/stop_app.sh`

## Test plan

- [ ] Start stack with `bash scripts/run_app.sh` — confirm mlx-lm server starts and stops on exit
- [ ] Generate a dispatch brief from the UI and verify output format
- [ ] Generate a second brief for the same vessel — confirm cached response is returned
- [ ] Stop the app and confirm mlx-lm process is not left running (`pgrep mlx_lm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)