### PR TITLE
fix: rebalance identity score weights and enable geopolitical filter by default (closes #194, #195)

### DIFF
--- a/scripts/run_operations_shell.sh
+++ b/scripts/run_operations_shell.sh
@@ -387,9 +387,14 @@ run_sar_feature_smoke() {
   echo
   echo "── Scoring (composite + watchlist) ───────────────────────────────────────────"
   local watchlist_path="$PROJECT_ROOT/data/processed/candidate_watchlist.parquet"
+  local geo_filter_arg=()
+  if [[ -f "$PROJECT_ROOT/config/geopolitical_events.json" ]]; then
+    geo_filter_arg=(--geopolitical-event-filter "$PROJECT_ROOT/config/geopolitical_events.json")
+  fi
   if ! run_cmd uv run python src/score/composite.py \
       --db "$db_path" \
-      --output "$watchlist_path"; then
+      --output "$watchlist_path" \
+      "${geo_filter_arg[@]}"; then
     echo "Result: FAILED (composite scoring)"
     return
   fi
@@ -502,9 +507,14 @@ print(f'Exported {df.height} rows to $sample_path')
   echo
   echo "── Composite scoring + watchlist ──────────────────────────────────────────────"
   local watchlist_path="$PROJECT_ROOT/data/processed/candidate_watchlist.parquet"
+  local geo_filter_arg=()
+  if [[ -f "$PROJECT_ROOT/config/geopolitical_events.json" ]]; then
+    geo_filter_arg=(--geopolitical-event-filter "$PROJECT_ROOT/config/geopolitical_events.json")
+  fi
   if ! run_cmd uv run python src/score/composite.py \
       --db "$db_path" \
-      --output "$watchlist_path"; then
+      --output "$watchlist_path" \
+      "${geo_filter_arg[@]}"; then
     echo "Result: FAILED (composite scoring)"
     return
   fi
@@ -734,9 +744,14 @@ run_ingest_custom_feeds() {
   echo
   echo "── Composite scoring + watchlist ──────────────────────────────────────────────"
   local watchlist_path="$PROJECT_ROOT/data/processed/candidate_watchlist.parquet"
+  local geo_filter_arg=()
+  if [[ -f "$PROJECT_ROOT/config/geopolitical_events.json" ]]; then
+    geo_filter_arg=(--geopolitical-event-filter "$PROJECT_ROOT/config/geopolitical_events.json")
+  fi
   if ! run_cmd uv run python src/score/composite.py \
       --db "$db_path" \
-      --output "$watchlist_path"; then
+      --output "$watchlist_path" \
+      "${geo_filter_arg[@]}"; then
     echo "Result: FAILED (composite scoring)"
     return
   fi
@@ -780,9 +795,14 @@ run_ingest_eo_csv() {
   echo
   echo "── Composite scoring + watchlist ──────────────────────────────────────────────"
   local watchlist_path="$PROJECT_ROOT/data/processed/candidate_watchlist.parquet"
+  local geo_filter_arg=()
+  if [[ -f "$PROJECT_ROOT/config/geopolitical_events.json" ]]; then
+    geo_filter_arg=(--geopolitical-event-filter "$PROJECT_ROOT/config/geopolitical_events.json")
+  fi
   if ! run_cmd uv run python src/score/composite.py \
       --db "$db_path" \
-      --output "$watchlist_path"; then
+      --output "$watchlist_path" \
+      "${geo_filter_arg[@]}"; then
     echo "Result: FAILED (composite scoring)"
     return
   fi
@@ -835,9 +855,14 @@ run_eo_feature_smoke() {
   echo
   echo "── Scoring (composite + watchlist) ───────────────────────────────────────────"
   local watchlist_path="$PROJECT_ROOT/data/processed/candidate_watchlist.parquet"
+  local geo_filter_arg=()
+  if [[ -f "$PROJECT_ROOT/config/geopolitical_events.json" ]]; then
+    geo_filter_arg=(--geopolitical-event-filter "$PROJECT_ROOT/config/geopolitical_events.json")
+  fi
   if ! run_cmd uv run python src/score/composite.py \
       --db "$db_path" \
-      --output "$watchlist_path"; then
+      --output "$watchlist_path" \
+      "${geo_filter_arg[@]}"; then
     echo "Result: FAILED (composite scoring)"
     return
   fi

--- a/src/score/composite.py
+++ b/src/score/composite.py
@@ -376,11 +376,13 @@ def _compute_graph_risk(df: pl.DataFrame) -> pl.Series:
 
 
 def _compute_identity_score(df: pl.DataFrame) -> pl.Series:
+    # flag_changes_2y is excluded: vessel_meta stores only the current flag state,
+    # not change history, so this field is always 0. Its former 0.30 weight is
+    # redistributed to the live signals (name_changes, owner_changes, high_risk_flag).
     score = (
-        0.30 * np.clip(df["flag_changes_2y"].to_numpy() / 5.0, 0.0, 1.0)
-        + 0.25 * np.clip(df["name_changes_2y"].to_numpy() / 5.0, 0.0, 1.0)
-        + 0.20 * np.clip(df["owner_changes_2y"].to_numpy() / 5.0, 0.0, 1.0)
-        + 0.15 * np.clip(df["high_risk_flag_ratio"].to_numpy(), 0.0, 1.0)
+        0.40 * np.clip(df["name_changes_2y"].to_numpy() / 5.0, 0.0, 1.0)
+        + 0.30 * np.clip(df["owner_changes_2y"].to_numpy() / 5.0, 0.0, 1.0)
+        + 0.20 * np.clip(df["high_risk_flag_ratio"].to_numpy(), 0.0, 1.0)
         + 0.10 * np.clip(df["ownership_depth"].to_numpy() / 6.0, 0.0, 1.0)
     )
     return pl.Series("identity_score", score.astype(np.float32))


### PR DESCRIPTION
## Summary

- Fixes #194 — removes dead `flag_changes_2y=0` signal from identity score; redistributes its 30% weight to live signals
- Fixes #195 — ops shell now auto-applies `config/geopolitical_events.json` to all composite scoring runs, suppressing false positives from Cape of Good Hope rerouting vessels
- Towards #186 — both changes directly improve Precision@50

## Changes

### `src/score/composite.py` — identity score rebalance (#194)

`vessel_meta` stores only the current flag state, not change history. `flag_changes_2y` is always 0 for every vessel, wasting 30% of the identity component.

| Signal | Before | After |
|---|---|---|
| `flag_changes_2y` | 0.30 | removed |
| `name_changes_2y` | 0.25 | **0.40** |
| `owner_changes_2y` | 0.20 | **0.30** |
| `high_risk_flag_ratio` | 0.15 | **0.20** |
| `ownership_depth` | 0.10 | 0.10 |

### `scripts/run_operations_shell.sh` — geopolitical filter (#195)

`config/geopolitical_events.json` already contained the Cape of Good Hope rerouting corridor (active 2023-11-01 → 2026-12-31, `down_weight=0.5`) but was never passed to `composite.py`. All five composite scoring invocations in the ops shell now auto-detect and pass this file when present. Vessels legitimately rerouting via Cape of Good Hope have their `anomaly_score` halved, reducing false positives in the top-50.

## Test plan

- [x] 288 unit tests pass
- [x] Lint and type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)