### PR TITLE
docs: fix three stale scoring formulas (anomaly blend, identity weights, composite defaults)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,7 +248,7 @@ confidence = w_anomaly × anomaly_score
            + w_identity × identity_volatility_score
 ```
 
-Default weights: `w_anomaly = 0.4`, `w_graph = 0.4`, `w_identity = 0.2`. All three are configurable via `--w-anomaly`, `--w-graph`, `--w-identity` CLI flags on `src/score/composite.py`. The C3 causal model provides a data-driven `w_graph` calibration (see section above and [roadmap.md](roadmap.md) Phase C, C3).
+Standalone `composite.py` defaults: `w_anomaly = 0.35`, `w_graph = 0.55`, `w_identity = 0.10`. The pipeline (`scripts/run_pipeline.py`) applies region-specific presets before C3 auto-calibration overrides `w_graph` — see [regional-playbooks.md](regional-playbooks.md) for per-region values. All three weights are configurable via `--w-anomaly`, `--w-graph`, `--w-identity` CLI flags. The C3 causal model provides a data-driven `w_graph` calibration (see section above and [roadmap.md](roadmap.md) Phase C, C3).
 
 Per-region weight tuning recommendations are in [regional-playbooks.md](regional-playbooks.md).
 

--- a/docs/scoring-model.md
+++ b/docs/scoring-model.md
@@ -71,10 +71,10 @@ The model trains only on vessels with `sanctions_distance ≥ 3` — far enough 
 
 ```python
 raw = -model.decision_function(scaled)   # higher = more anomalous
-anomaly_score = 0.75 * norm(raw) + 0.25 * baseline_noise_score
+anomaly_score = 0.65 * norm(raw) + 0.35 * baseline_noise_score
 ```
 
-The isolation forest raw score is min-max normalised to [0, 1], then blended 75/25 with the HDBSCAN baseline noise score. The blend ensures that a vessel whose behaviour is globally anomalous (Isolation Forest) AND locally anomalous relative to its ship-type peer group (HDBSCAN noise) receives the highest possible anomaly score.
+The isolation forest raw score is min-max normalised to [0, 1], then blended 65/35 with the HDBSCAN baseline noise score. The blend ensures that a vessel whose behaviour is globally anomalous (Isolation Forest) AND locally anomalous relative to its ship-type peer group (HDBSCAN noise) receives the highest possible anomaly score.
 
 ### Hyperparameters
 
@@ -129,12 +129,13 @@ graph_risk = 0.55 × sanctions_component
 Weighted combination of identity volatility signals:
 
 ```python
-identity = 0.30 × clip(flag_changes_2y / 5, 0, 1)
-         + 0.25 × clip(name_changes_2y / 5, 0, 1)
-         + 0.20 × clip(owner_changes_2y / 5, 0, 1)
-         + 0.15 × clip(high_risk_flag_ratio, 0, 1)
+identity = 0.40 × clip(name_changes_2y / 5, 0, 1)
+         + 0.30 × clip(owner_changes_2y / 5, 0, 1)
+         + 0.20 × clip(high_risk_flag_ratio, 0, 1)
          + 0.10 × clip(ownership_depth / 6, 0, 1)
 ```
+
+`flag_changes_2y` is excluded: `vessel_meta` stores only the current flag state, not change history, so this field is always 0. Its former weight is redistributed to the live signals above.
 
 #### `anomaly_score`
 


### PR DESCRIPTION
## Summary

Three formula/weight mismatches between docs and code, found during a doc audit against the current codebase.

- **Anomaly blend ratio** (`scoring-model.md`): `75/25 IF/HDBSCAN` → `65/35` to match `anomaly.py:146`
- **Identity formula** (`scoring-model.md`): removed `flag_changes_2y` term (always 0 — `vessel_meta` stores only current flag, not history); redistributed its 0.30 weight to `name_changes_2y` (0.40), `owner_changes_2y` (0.30), `high_risk_flag_ratio` (0.20), `ownership_depth` (0.10) — matches `composite.py:378–388`
- **Composite weight defaults** (`architecture.md`): stale `0.4/0.4/0.2` → `0.35/0.55/0.10` (standalone `composite.py` defaults); added clarification that `run_pipeline.py` applies region-specific presets before C3 auto-calibration overrides `w_graph`

No code changes. `regional-playbooks.md` pipeline presets (0.40/0.40/0.20 for SG/JP/ME) are correct and untouched — they reflect `run_pipeline.py` defaults accurately.

## Test plan

- [ ] Read `docs/scoring-model.md` anomaly blend formula matches `src/score/anomaly.py` line 146
- [ ] Read `docs/scoring-model.md` identity formula matches `src/score/composite.py` lines 378–388
- [ ] Read `docs/architecture.md` composite weight defaults match `src/score/composite.py` function signature defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)