### PR TITLE
fix: normalize IMO prefix in sanctions ingest (fixes #215)

### DIFF
--- a/src/ingest/sanctions.py
+++ b/src/ingest/sanctions.py
@@ -84,6 +84,21 @@ def download_opensanctions(
 # ---------------------------------------------------------------------------
 
 
+def _normalize_imo(raw: str | None) -> str | None:
+    """Strip the 'IMO' prefix used by OpenSanctions FtM imoNumber values.
+
+    OpenSanctions stores IMO numbers as e.g. 'IMO9305609'; vessel_meta and
+    all downstream joins use the bare 7-digit form '9305609'.  Normalising
+    at ingest keeps every consumer consistent without per-query workarounds.
+    """
+    if not raw:
+        return None
+    stripped = raw.strip()
+    if stripped.upper().startswith("IMO"):
+        stripped = stripped[3:]
+    return stripped or None
+
+
 def parse_ftm_entity(entity: dict) -> dict | None:
     """Extract a flat sanctions_entities row from an OpenSanctions FtM entity.
 
@@ -112,7 +127,7 @@ def parse_ftm_entity(entity: dict) -> dict | None:
         "entity_id": entity_id,
         "name": name,
         "mmsi": first("mmsi"),
-        "imo": first("imoNumber"),
+        "imo": _normalize_imo(first("imoNumber")),
         "flag": first("flag") or first("country"),
         "type": schema,
         "list_source": list_source,

--- a/tests/test_sanctions.py
+++ b/tests/test_sanctions.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 import duckdb
 
-from src.ingest.sanctions import _flush_batch, _normalize_imo, load_jsonl_to_duckdb, parse_ftm_entity
+from src.ingest.sanctions import (
+    _flush_batch,
+    _normalize_imo,
+    load_jsonl_to_duckdb,
+    parse_ftm_entity,
+)
 
 # ---------------------------------------------------------------------------
 # parse_ftm_entity

--- a/tests/test_sanctions.py
+++ b/tests/test_sanctions.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import duckdb
 
-from src.ingest.sanctions import _flush_batch, load_jsonl_to_duckdb, parse_ftm_entity
+from src.ingest.sanctions import _flush_batch, _normalize_imo, load_jsonl_to_duckdb, parse_ftm_entity
 
 # ---------------------------------------------------------------------------
 # parse_ftm_entity
@@ -48,7 +48,7 @@ def test_parse_vessel():
     assert row["entity_id"] == "ofac-vessel-001"
     assert row["name"] == "OCEAN GLORY"
     assert row["mmsi"] == "123456789"
-    assert row["imo"] == "IMO9876543"
+    assert row["imo"] == "9876543"
     assert row["flag"] == "KP"
     assert row["type"] == "Vessel"
     assert row["list_source"] == "ofac_sdn"
@@ -103,6 +103,39 @@ def test_parse_uses_caption_as_fallback_name():
     row = parse_ftm_entity(entity)
     assert row is not None
     assert row["name"] == "CAPTION NAME"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_imo
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_imo_strips_upper_prefix():
+    assert _normalize_imo("IMO9305609") == "9305609"
+
+
+def test_normalize_imo_strips_lower_prefix():
+    assert _normalize_imo("imo9305609") == "9305609"
+
+
+def test_normalize_imo_strips_mixed_prefix():
+    assert _normalize_imo("Imo9305609") == "9305609"
+
+
+def test_normalize_imo_bare_number_unchanged():
+    assert _normalize_imo("9305609") == "9305609"
+
+
+def test_normalize_imo_none_returns_none():
+    assert _normalize_imo(None) is None
+
+
+def test_normalize_imo_empty_returns_none():
+    assert _normalize_imo("") is None
+
+
+def test_normalize_imo_prefix_only_returns_none():
+    assert _normalize_imo("IMO") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `_normalize_imo()` to `src/ingest/sanctions.py` to strip the `IMO` prefix (case-insensitive) from `imoNumber` values at parse time
- Treats empty string as `None` for consistent null handling downstream
- Fixes the broken `(mmsi, imo)` join in the backtest that caused Precision@50 to return 0 even when sanctioned vessels were present in the scored data

## Root cause

OpenSanctions FtM JSON stores IMO numbers as `IMO9305609`; `vessel_meta` stores the bare 7-digit form `9305609`. The mismatch meant 16 MMSI-matching sanctioned vessels in the Singapore dataset all failed the `(mmsi AND imo)` join in the backtest, producing zero `source_positive_coverage` hits.

## What changes

**`src/ingest/sanctions.py`**
- New `_normalize_imo(raw)` helper — strips `IMO`/`imo`/`Imo` prefix, returns `None` for empty/prefix-only input
- `parse_ftm_entity` now calls `_normalize_imo(first("imoNumber"))` instead of `first("imoNumber")` directly

**`tests/test_sanctions.py`**
- 7 new tests for `_normalize_imo` (upper/lower/mixed prefix, bare number, None, empty, prefix-only)
- Updated `test_parse_vessel` assertion: `"IMO9876543"` → `"9876543"`

## Note on existing data

Re-ingest is required for any DB loaded before this fix — `sanctions_entities.imo` will still contain the `IMO` prefix in those databases. Run `uv run python src/ingest/sanctions.py` to reload.

## Test plan

- [x] `uv run pytest tests/test_sanctions.py tests/test_validate.py` — 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)