### PR TITLE
fix: notify_metrics.py reads wrong JSON file — P@50 showed 0.0 in all emails (#222)

### DIFF
--- a/scripts/notify_metrics.py
+++ b/scripts/notify_metrics.py
@@ -29,7 +29,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
 
-_REPORT_PATH = Path("data/processed/backtest_report_public_integration.json")
+_REPORT_PATH = Path("data/processed/backtest_public_integration_summary.json")
 _REGRESSION_THRESHOLD = 0.02
 
 


### PR DESCRIPTION
## Summary

`scripts/notify_metrics.py` was reading `backtest_report_public_integration.json` but expected keys (`metrics_summary`, `regions`, `total_known_cases`, `region_summary`, `generated_at_utc`) that only exist in `backtest_public_integration_summary.json`. This caused every data-publish email to show Precision@50 = 0.0000.

**Fix**: change `_REPORT_PATH` to `backtest_public_integration_summary.json` — one line.

## Root cause

| Key expected | report JSON | summary JSON |
|---|---|---|
| `metrics_summary` | ✗ (is `"summary"`) | ✓ |
| `regions` | ✗ | ✓ |
| `total_known_cases` | ✗ | ✓ |
| `region_summary` | ✗ | ✓ |
| `generated_at_utc` | ✗ (is `"generated_at"`) | ✓ |

## Test plan

- [ ] Next data-publish run email shows correct Precision@50 (expected 1.0 with multi-region watchlist)

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)