### PR TITLE
feat: distribute public_eval.duckdb via R2 (push/pull-sanctions-db) (#224)

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -79,6 +79,16 @@ jobs:
           echo "snapshot_id=$snapshot_id" >> "$GITHUB_OUTPUT"
           echo "snapshot_mb=$snapshot_mb" >> "$GITHUB_OUTPUT"
 
+      - name: Push OpenSanctions DB to R2 (push-sanctions-db)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+        run: |
+          # --force ensures the DB is always refreshed after run_public_backtest_batch.py
+          # regenerates it (which happens on every data-publish run).
+          uv run python scripts/sync_r2.py push-sanctions-db --force
+
       - name: Send metrics email (#210)
         if: always()
         env:

--- a/docs/backtesting-validation.md
+++ b/docs/backtesting-validation.md
@@ -202,9 +202,23 @@ Report output:
 We provide an opt-in integration test that actually downloads public sanctions data,
 loads DuckDB, and evaluates found-vs-missed outcomes against practical positive-label sources.
 
-### Prepare once and reuse DB (recommended)
+The integration test requires **two** local files:
 
-Because OpenSanctions ingestion can take time, prepare a persistent DB once and reuse it in later tests.
+| File | How to get it |
+|---|---|
+| `data/processed/candidate_watchlist.parquet` | `sync_r2.py pull` (included in the generation zip) |
+| `data/processed/public_eval.duckdb` | `sync_r2.py pull-sanctions-db` **or** generate locally (see below) |
+
+`public_eval.duckdb` is distributed as a standalone R2 object (refreshed on every data-publish CI run) and is **not** inside the rotation zip.
+
+### Option A — Pull pre-built DB from R2 (fastest)
+
+```bash
+uv run python scripts/sync_r2.py pull               # pulls candidate_watchlist.parquet
+uv run python scripts/sync_r2.py pull-sanctions-db  # pulls public_eval.duckdb (~50 MB)
+```
+
+### Option B — Generate locally (required to get the freshest data)
 
 ```bash
 uv run python scripts/prepare_public_sanctions_db.py \
@@ -217,7 +231,7 @@ This writes:
 2. Cached raw file: `data/raw/sanctions/opensanctions_entities.jsonl`
 3. Metadata snapshot: `data/processed/public_eval_metadata.json`
 
-To refresh data:
+To refresh an existing DB:
 
 ```bash
 uv run python scripts/prepare_public_sanctions_db.py \
@@ -226,7 +240,7 @@ uv run python scripts/prepare_public_sanctions_db.py \
   --force-reload
 ```
 
-Run manually:
+### Run the test
 
 ```bash
 RUN_PUBLIC_DATA_TESTS=1 \

--- a/docs/r2-data-layout.md
+++ b/docs/r2-data-layout.md
@@ -19,6 +19,8 @@ arktrace-public/                   ← dedicated public bucket (Cloudflare R2)
   gdelt.lance.zip                   ← shared GDELT Lance store (~1.2 GB)
                                       pushed separately; only updated when
                                       GDELT is re-ingested
+  public_eval.duckdb                ← OpenSanctions DB for integration tests (~50 MB)
+                                      pushed separately on every data-publish run
   validation_metrics.json           ← scoring validation metrics (tiny)
 ```
 
@@ -49,6 +51,7 @@ extract only the region(s) they need (controlled by `--region` on pull):
 | `candidate_watchlist.parquet` | **CI** | All region watchlists concatenated by `run_public_backtest_batch.py` |
 | `validation_metrics.json` | **CI** | Computed from labeled watchlist; no external data required |
 | `gdelt.lance` | **CI** | Built from GDELT public HTTP feed (no API key) |
+| `public_eval.duckdb` | **CI** | OpenSanctions DB; pushed via `push-sanctions-db` after every data-publish run |
 | Live AIS data in DuckDB | **Local + upload** | Requires `AISSTREAM_API_KEY`; CI uses synthetic seed instead |
 
 ### By scope
@@ -56,6 +59,7 @@ extract only the region(s) they need (controlled by `--region` on pull):
 | Artifact | Scope | Notes |
 |---|---|---|
 | `gdelt.lance` | **Common** | Single GDELT corpus queried by all regions |
+| `public_eval.duckdb` | **Common** | OpenSanctions DB; standalone R2 object, not in rotation zip |
 | `candidate_watchlist.parquet` | **Common** | Cross-region concat; required for `test_public_data_backtest_integration.py` |
 | `validation_metrics.json` | **Common** | Aggregate metrics across all regions |
 | `{region}.duckdb` | **Regional** | Separate per region |
@@ -104,7 +108,9 @@ full multi-region pipeline on public data and publishes the results.
    (`--stream-duration 0 --seed-dummy`).
 2. `sync_r2.py push --keep 1` — zips all region artifacts into one file,
    uploads to R2, and deletes any previous generation.
-3. `sync_r2.py push-gdelt` — uploads `gdelt.lance.zip` only if it does not
+3. `sync_r2.py push-sanctions-db --force` — uploads `public_eval.duckdb`
+   (refreshed by step 1) as a standalone R2 object.
+4. `sync_r2.py push-gdelt` — uploads `gdelt.lance.zip` only if it does not
    already exist (skipped on most runs; re-run with `--force` after GDELT
    re-ingestion).
 
@@ -126,6 +132,9 @@ uv run python scripts/sync_r2.py pull --region japan
 
 # Pull multiple regions at once
 uv run python scripts/sync_r2.py pull --region singapore,japan
+
+# Pull OpenSanctions DB (~50 MB) — required for the public-data integration test
+uv run python scripts/sync_r2.py pull-sanctions-db
 
 # Also pull the GDELT Lance store (~1.2 GB) for analyst brief / chat context
 uv run python scripts/sync_r2.py pull-gdelt

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -484,8 +484,12 @@ def cmd_pull(args: argparse.Namespace) -> int:
     print(f"\nDone. {downloaded / 1_048_576:.1f} MB downloaded, extracted to {data_dir}/")
     print(f"Region(s): {', '.join(regions)}")
     print("\nOptional extras:")
-    print("  uv run python scripts/sync_r2.py pull-sanctions-db  # OpenSanctions DB for integration tests")
-    print("  uv run python scripts/sync_r2.py pull-gdelt         # GDELT news data (analyst briefs)")
+    print(
+        "  uv run python scripts/sync_r2.py pull-sanctions-db  # OpenSanctions DB for integration tests"
+    )
+    print(
+        "  uv run python scripts/sync_r2.py pull-gdelt         # GDELT news data (analyst briefs)"
+    )
     print("\nStart the app:")
     print(f"  DB_PATH={db_path} uv run uvicorn src.api.main:app --reload")
     print("  open http://localhost:8000")
@@ -653,9 +657,7 @@ def cmd_pull_sanctions_db(args: argparse.Namespace) -> int:
     downloaded = _download_file(fs, r2_path, local_path)
     print(f"Done. {downloaded / 1_048_576:.1f} MB downloaded to {local_path}")
     print("\nYou can now run the public-data integration test:")
-    print(
-        "  RUN_PUBLIC_DATA_TESTS=1 uv run pytest tests/test_public_data_backtest_integration.py"
-    )
+    print("  RUN_PUBLIC_DATA_TESTS=1 uv run pytest tests/test_public_data_backtest_integration.py")
     return 0
 
 

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -36,8 +36,9 @@ Files included in snapshots
     anomaly_scores.parquet, composite_scores.parquet, mpol_baseline.parquet
     mpol_graph/              (used during feature engineering, not serving)
 
-  EXCLUDED  — evaluation / backtest artefacts (not read by the API):
-    backtest_demo.duckdb, public_eval.duckdb
+  EXCLUDED from rotation zip — distributed separately or not at all:
+    public_eval.duckdb       distributed as a standalone R2 object (push/pull-sanctions-db)
+    backtest_demo.duckdb     local test fixture only
     backtest_*.json, evaluation_manifest_*.json, backtracking_report.*
     eval_labels_public_*.csv, prelabel_evaluation.json, public_eval_metadata.json
     *.bak
@@ -48,11 +49,13 @@ Files included in snapshots
 
 Commands
 --------
-  push          upload snapshot as a single zip to R2, prune old zips
-  pull          download + extract latest (or named) snapshot zip → data/processed/
-  push-gdelt    upload gdelt.lance as gdelt.lance.zip (run after re-ingesting GDELT data)
-  pull-gdelt    download + extract gdelt.lance.zip → data/processed/gdelt.lance
-  list          show all snapshot zips in R2
+  push                upload snapshot as a single zip to R2, prune old zips
+  pull                download + extract latest (or named) snapshot zip → data/processed/
+  push-gdelt          upload gdelt.lance as gdelt.lance.zip (run after re-ingesting GDELT data)
+  pull-gdelt          download + extract gdelt.lance.zip → data/processed/gdelt.lance
+  push-sanctions-db   upload public_eval.duckdb (OpenSanctions DB) to R2
+  pull-sanctions-db   download public_eval.duckdb from R2 — needed for integration tests
+  list                show all snapshot zips and shared objects in R2
 
 Env vars (loaded from .env automatically)
 ------------------------------------------
@@ -64,12 +67,14 @@ Env vars (loaded from .env automatically)
 
 Examples
 --------
-  uv run python scripts/sync_r2.py push                     # push new zip, prune old
-  uv run python scripts/sync_r2.py push-gdelt               # upload/update gdelt.lance.zip
-  uv run python scripts/sync_r2.py pull                     # pull latest (no credentials needed)
+  uv run python scripts/sync_r2.py push                      # push new zip, prune old
+  uv run python scripts/sync_r2.py push-gdelt                # upload/update gdelt.lance.zip
+  uv run python scripts/sync_r2.py push-sanctions-db         # upload/update public_eval.duckdb
+  uv run python scripts/sync_r2.py pull                      # pull latest (no credentials needed)
   uv run python scripts/sync_r2.py pull --timestamp 20260411T080000Z
-  uv run python scripts/sync_r2.py pull-gdelt               # pull gdelt.lance.zip
-  uv run python scripts/sync_r2.py list                     # show all generations in R2
+  uv run python scripts/sync_r2.py pull-gdelt                # pull gdelt.lance.zip
+  uv run python scripts/sync_r2.py pull-sanctions-db         # pull public_eval.duckdb for tests
+  uv run python scripts/sync_r2.py list                      # show all generations in R2
 """
 
 from __future__ import annotations
@@ -97,6 +102,7 @@ _DEFAULT_ENDPOINT = "https://b8a0b09feb89390fb6e8cf4ef9294f48.r2.cloudflarestora
 # so no sub-prefix is needed — all objects live at the bucket root.
 _LATEST_KEY = "latest"  # plain-text pointer to newest timestamp
 _GDELT_R2_KEY = "gdelt.lance.zip"  # single zip for gdelt
+_SANCTIONS_DB_R2_KEY = "public_eval.duckdb"  # OpenSanctions DB; separate from rotation zip
 
 # Maps user-facing region name → file prefix used in data/processed/
 # e.g. "japan" → files are japansea.duckdb, japansea_graph/, japansea_watchlist.parquet
@@ -128,7 +134,7 @@ _SNAPSHOT_EXCLUDE: list[str] = [
     "mpol_graph/*",  # Lance graph used during feature engineering only
     # Evaluation / backtest artefacts
     "backtest_demo.duckdb",
-    "public_eval.duckdb",
+    "public_eval.duckdb",  # distributed separately — see push-sanctions-db / pull-sanctions-db
     "backtest_*.json",
     "backtracking_report.*",
     "evaluation_manifest_*.json",
@@ -477,8 +483,9 @@ def cmd_pull(args: argparse.Namespace) -> int:
 
     print(f"\nDone. {downloaded / 1_048_576:.1f} MB downloaded, extracted to {data_dir}/")
     print(f"Region(s): {', '.join(regions)}")
-    print("\nTo also download GDELT news data (analyst briefs and chat):")
-    print("  uv run python scripts/sync_r2.py pull-gdelt")
+    print("\nOptional extras:")
+    print("  uv run python scripts/sync_r2.py pull-sanctions-db  # OpenSanctions DB for integration tests")
+    print("  uv run python scripts/sync_r2.py pull-gdelt         # GDELT news data (analyst briefs)")
     print("\nStart the app:")
     print(f"  DB_PATH={db_path} uv run uvicorn src.api.main:app --reload")
     print("  open http://localhost:8000")
@@ -583,6 +590,75 @@ def cmd_pull_gdelt(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_push_sanctions_db(args: argparse.Namespace) -> int:
+    bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
+    local_path = Path(args.data_dir) / "public_eval.duckdb"
+
+    if not local_path.exists():
+        print(
+            f"Error: {local_path} does not exist. Generate it first:\n"
+            "  uv run python scripts/prepare_public_sanctions_db.py",
+            file=sys.stderr,
+        )
+        return 1
+
+    fs = _build_r2_fs()
+    r2_path = f"{bucket}/{_SANCTIONS_DB_R2_KEY}"
+
+    if not args.force:
+        import pyarrow.fs as pafs
+
+        try:
+            infos = fs.get_file_info([r2_path])
+            if infos[0].type == pafs.FileType.File:
+                print(
+                    f"public_eval.duckdb already exists in R2 ({infos[0].size / 1_048_576:.1f} MB). "
+                    "Use --force to re-upload."
+                )
+                return 0
+        except Exception:
+            pass
+
+    size_mb = local_path.stat().st_size / 1_048_576
+    print(f"Uploading public_eval.duckdb ({size_mb:.1f} MB) → R2 {r2_path} ...")
+    uploaded = _upload_file(fs, local_path, r2_path)
+    print(f"Done. {uploaded / 1_048_576:.1f} MB uploaded.")
+    return 0
+
+
+def cmd_pull_sanctions_db(args: argparse.Namespace) -> int:
+    bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
+    local_path = Path(args.data_dir) / "public_eval.duckdb"
+
+    anon = not (os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY"))
+    fs = _build_r2_fs(anonymous=anon)
+    r2_path = f"{bucket}/{_SANCTIONS_DB_R2_KEY}"
+
+    import pyarrow.fs as pafs
+
+    try:
+        infos = fs.get_file_info([r2_path])
+        if infos[0].type == pafs.FileType.NotFound:
+            raise FileNotFoundError
+        size_mb = infos[0].size / 1_048_576
+    except Exception:
+        print(
+            "No public_eval.duckdb found in R2. Push it first with:\n"
+            "  uv run python scripts/sync_r2.py push-sanctions-db",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Downloading public_eval.duckdb ({size_mb:.1f} MB) ...")
+    downloaded = _download_file(fs, r2_path, local_path)
+    print(f"Done. {downloaded / 1_048_576:.1f} MB downloaded to {local_path}")
+    print("\nYou can now run the public-data integration test:")
+    print(
+        "  RUN_PUBLIC_DATA_TESTS=1 uv run pytest tests/test_public_data_backtest_integration.py"
+    )
+    return 0
+
+
 def cmd_list(args: argparse.Namespace) -> int:
     bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
     anon = not (os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY"))
@@ -609,17 +685,21 @@ def cmd_list(args: argparse.Namespace) -> int:
         note = "<- latest" if ts == latest else ""
         print(f"{ts:<22}  {mb:>8.1f} MB  {note}")
 
-    gdelt_r2_path = f"{bucket}/{_GDELT_R2_KEY}"
     print()
-    try:
-        infos = fs.get_file_info([gdelt_r2_path])
-        if infos[0].type == pafs.FileType.File:
-            gdelt_mb = infos[0].size / 1_048_576
-            print(f"gdelt.lance.zip  {gdelt_mb:.1f} MB  (shared, outside rotation)")
-        else:
-            print("gdelt.lance.zip  (not yet uploaded — run push-gdelt)")
-    except Exception:
-        print("gdelt.lance.zip  (not yet uploaded — run push-gdelt)")
+    for r2_key, label, push_cmd in [
+        (_GDELT_R2_KEY, "gdelt.lance.zip", "push-gdelt"),
+        (_SANCTIONS_DB_R2_KEY, "public_eval.duckdb", "push-sanctions-db"),
+    ]:
+        r2_path = f"{bucket}/{r2_key}"
+        try:
+            infos = fs.get_file_info([r2_path])
+            if infos[0].type == pafs.FileType.File:
+                mb = infos[0].size / 1_048_576
+                print(f"{label:<28}  {mb:>6.1f} MB  (shared, outside rotation)")
+            else:
+                print(f"{label:<28}  (not yet uploaded — run {push_cmd})")
+        except Exception:
+            print(f"{label:<28}  (not yet uploaded — run {push_cmd})")
     return 0
 
 
@@ -690,7 +770,24 @@ def main() -> int:
     )
     pull_gdelt_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
 
-    sub.add_parser("list", help="List snapshot zips and gdelt.lance.zip status in R2")
+    push_sanctions_p = sub.add_parser(
+        "push-sanctions-db",
+        help="Upload public_eval.duckdb (OpenSanctions DB) to R2 — run after prepare_public_sanctions_db.py",
+    )
+    push_sanctions_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
+    push_sanctions_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-upload even if public_eval.duckdb already exists in R2",
+    )
+
+    pull_sanctions_p = sub.add_parser(
+        "pull-sanctions-db",
+        help="Download public_eval.duckdb from R2 — required to run test_public_data_backtest_integration.py",
+    )
+    pull_sanctions_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
+
+    sub.add_parser("list", help="List snapshot zips and shared objects in R2")
 
     args = parser.parse_args()
 
@@ -698,7 +795,7 @@ def main() -> int:
 
     load_dotenv()
 
-    read_only = args.command in ("pull", "pull-gdelt", "list")
+    read_only = args.command in ("pull", "pull-gdelt", "pull-sanctions-db", "list")
     if not _check_env(require_credentials=not read_only):
         return 1
 
@@ -707,6 +804,8 @@ def main() -> int:
         "pull": cmd_pull,
         "push-gdelt": cmd_push_gdelt,
         "pull-gdelt": cmd_pull_gdelt,
+        "push-sanctions-db": cmd_push_sanctions_db,
+        "pull-sanctions-db": cmd_pull_sanctions_db,
         "list": cmd_list,
     }
     return dispatch[args.command](args)

--- a/tests/test_public_data_backtest_integration.py
+++ b/tests/test_public_data_backtest_integration.py
@@ -38,8 +38,10 @@ def test_public_sanctions_download_and_detection_backtest(tmp_path: Path) -> Non
             load_jsonl_to_duckdb(raw_path, str(prepared_db))
         else:
             pytest.skip(
-                "Prepared public-data DB not found. Run `uv run python scripts/prepare_public_sanctions_db.py` "
-                "or set PREPARE_PUBLIC_DATA_IF_MISSING=1."
+                f"public_eval.duckdb not found at {prepared_db}. "
+                "Pull it from R2 with: uv run python scripts/sync_r2.py pull-sanctions-db  "
+                "— or regenerate locally with: uv run python scripts/prepare_public_sanctions_db.py  "
+                "— or set PREPARE_PUBLIC_DATA_IF_MISSING=1 to download automatically."
             )
 
     watchlist = pl.read_parquet(watchlist_path).select(["mmsi", "imo", "confidence"])


### PR DESCRIPTION
## Summary

Implements Option B from #224: the OpenSanctions DB (`public_eval.duckdb`) is now distributed as a standalone R2 object. The complete local integration-test setup is now two commands with no manual generation step:

```bash
uv run python scripts/sync_r2.py pull
uv run python scripts/sync_r2.py pull-sanctions-db
RUN_PUBLIC_DATA_TESTS=1 uv run pytest tests/test_public_data_backtest_integration.py
```

## Changes

- **`scripts/sync_r2.py`**: adds `push-sanctions-db` and `pull-sanctions-db` commands (mirrors the `push-gdelt` / `pull-gdelt` pattern); `cmd_list` now shows `public_eval.duckdb` status; `cmd_pull` output now hints at `pull-sanctions-db`
- **`.github/workflows/data-publish.yml`**: adds `push-sanctions-db --force` step after every pipeline run so R2 is always fresh
- **`tests/test_public_data_backtest_integration.py`**: skip message now names the missing file and the `pull-sanctions-db` command explicitly
- **`docs/backtesting-validation.md`**: documents Option A (pull from R2) vs Option B (generate locally) with a prerequisite table
- **`docs/r2-data-layout.md`**: adds `public_eval.duckdb` to bucket layout diagram, CI steps, generation-method table, scope table, and user pull examples

## Test plan

- [ ] `uv run python scripts/sync_r2.py pull-sanctions-db` downloads the file after the next data-publish run pushes it
- [ ] `uv run python scripts/sync_r2.py list` shows `public_eval.duckdb` line
- [ ] Next data-publish CI run includes `push-sanctions-db` step and succeeds
- [ ] Integration test skip message is clear when file is absent

Closes #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)