### PR TITLE
feat: infer STS_CONTACT edges from AIS H3 co-location

### DIFF
--- a/src/ingest/vessel_registry.py
+++ b/src/ingest/vessel_registry.py
@@ -7,6 +7,8 @@ Builds the ownership graph as Lance datasets from two sources:
 2. **Company, ownership, and sanctions relationships** derived from DuckDB
    sanctions_entities (populated by src/ingest/sanctions.py).
 3. **Equasis-style ownership chains** from an optional CSV export.
+4. **STS_CONTACT edges** inferred from AIS co-location (vessels in the same
+   H3 resolution-8 cell within the same 30-minute bucket, at least twice).
 
 No external graph server required — data is stored as Lance files on disk.
 
@@ -22,6 +24,7 @@ import csv
 import os
 
 import duckdb
+import polars as pl
 import pyarrow as pa
 from dotenv import load_dotenv
 
@@ -43,6 +46,88 @@ def _rows_to_table(rows: list[dict], schema: pa.Schema) -> pa.Table:
         return schema.empty_table()
     arrays = {field.name: [r.get(field.name) for r in rows] for field in schema}
     return pa.table(arrays, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# STS co-location inference
+# ---------------------------------------------------------------------------
+
+H3_RESOLUTION = 8  # ~0.74 km² cells — appropriate for STS proximity detection
+STS_MIN_CO_LOCATIONS = 2  # require ≥2 bucket overlaps to exclude transient proximity
+
+
+def _geo_to_h3(lat: float, lon: float, res: int = H3_RESOLUTION) -> str:
+    """H3 cell index — compatible with h3-py 3.x and 4.x (mirrors ais_behavior.py)."""
+    import h3
+
+    try:
+        return h3.latlng_to_cell(lat, lon, res)  # h3-py >= 4
+    except AttributeError:
+        return h3.geo_to_h3(lat, lon, res)  # h3-py < 4
+
+
+def build_sts_contacts_from_ais(db_path: str) -> list[dict]:
+    """Infer STS contact pairs from AIS H3 co-location.
+
+    Two vessels are co-located when they share the same H3 resolution-8 cell
+    within the same 30-minute time bucket.  Pairs must co-locate at least
+    STS_MIN_CO_LOCATIONS times to filter out transient proximity (port
+    approaches, traffic lane crossings).
+
+    H3 cells are computed with the Python h3 library (already a project
+    dependency via ais_behavior.py) rather than the DuckDB h3 community
+    extension, which requires a separate install step.
+
+    Returns a list of {"src_id": mmsi_a, "dst_id": mmsi_b} dicts ready to be
+    written to the STS_CONTACT Lance table.  Each pair appears once
+    (src_id < dst_id lexicographically).
+    """
+    con = duckdb.connect(db_path, read_only=True)
+    try:
+        # Use .pl() to avoid the pytz dependency that fetchall() requires for
+        # TIMESTAMP WITH TIME ZONE columns.
+        pos_df = con.execute(
+            "SELECT mmsi, timestamp, lat, lon FROM ais_positions "
+            "WHERE lat IS NOT NULL AND lon IS NOT NULL AND mmsi IS NOT NULL"
+        ).pl()
+    finally:
+        con.close()
+
+    if pos_df.is_empty():
+        return []
+
+    # Compute H3 cells and 30-minute floor buckets in Python
+    mmsis = pos_df["mmsi"].to_list()
+    lats = pos_df["lat"].to_list()
+    lons = pos_df["lon"].to_list()
+    # Cast to UTC-naive milliseconds for bucket arithmetic
+    ts_ms = pos_df["timestamp"].cast(pl.Datetime("ms")).to_list()
+
+    cells: list[str] = []
+    buckets: list[str] = []
+    for ts, lat, lon in zip(ts_ms, lats, lons):
+        cells.append(_geo_to_h3(lat, lon))
+        # Floor to the nearest 30-minute boundary
+        bucket = ts.replace(minute=(ts.minute // 30) * 30, second=0, microsecond=0)
+        buckets.append(bucket.isoformat())
+
+    bucketed_df = pl.DataFrame({"mmsi": mmsis, "cell": cells, "bucket": buckets})
+
+    mem = duckdb.connect()
+    mem.register("bucketed", bucketed_df)
+    result = mem.execute(f"""
+        SELECT a.mmsi AS src_id, b.mmsi AS dst_id
+        FROM bucketed a
+        JOIN bucketed b
+          ON a.cell = b.cell
+         AND a.bucket = b.bucket
+         AND a.mmsi < b.mmsi
+        GROUP BY a.mmsi, b.mmsi
+        HAVING COUNT(*) >= {STS_MIN_CO_LOCATIONS}
+    """).fetchall()
+    mem.close()
+
+    return [{"src_id": r[0], "dst_id": r[1]} for r in result]
 
 
 # ---------------------------------------------------------------------------
@@ -260,8 +345,10 @@ def build_graph_tables(
         "REGISTERED_AT": _rows_to_table(registered_at, REL_SCHEMAS["REGISTERED_AT"]),
         # CONTROLLED_BY is populated externally (e.g. company hierarchy data)
         "CONTROLLED_BY": REL_SCHEMAS["CONTROLLED_BY"].empty_table(),
-        # STS_CONTACT is populated by the AIS behavior pipeline
-        "STS_CONTACT": REL_SCHEMAS["STS_CONTACT"].empty_table(),
+        # STS_CONTACT: inferred from AIS co-location (H3 res-8, 30-min buckets)
+        "STS_CONTACT": _rows_to_table(
+            build_sts_contacts_from_ais(db_path), REL_SCHEMAS["STS_CONTACT"]
+        ),
     }
 
 

--- a/tests/test_vessel_registry.py
+++ b/tests/test_vessel_registry.py
@@ -266,3 +266,122 @@ def test_sanctioned_mmsi_not_in_vessel_meta_has_no_vessel_node(tmp_db):
     # SANCTIONED_BY edge still exists for use by other graph lookups
     sb_src = tables["SANCTIONED_BY"]["src_id"].to_pylist()
     assert "256869000" in sb_src
+
+
+# ---------------------------------------------------------------------------
+# build_sts_contacts_from_ais
+# ---------------------------------------------------------------------------
+
+
+def _seed_ais_positions(db_path: str, rows: list[tuple]) -> None:
+    """Insert (mmsi, timestamp, lat, lon) rows into ais_positions."""
+    con = duckdb.connect(db_path)
+    for mmsi, ts, lat, lon in rows:
+        con.execute(
+            "INSERT INTO ais_positions (mmsi, timestamp, lat, lon) VALUES (?, ?, ?, ?)",
+            [mmsi, ts, lat, lon],
+        )
+    con.close()
+
+
+def test_sts_contacts_empty_db(tmp_db):
+    from src.ingest.vessel_registry import build_sts_contacts_from_ais
+
+    assert build_sts_contacts_from_ais(tmp_db) == []
+
+
+def test_sts_contacts_pair_detected(tmp_db):
+    """Two vessels in the same H3 cell at the same 30-min bucket ≥2 times → STS contact."""
+    from src.ingest.vessel_registry import build_sts_contacts_from_ais
+
+    # Anchor point in Singapore Strait
+    lat, lon = 1.26, 103.85
+    _seed_ais_positions(
+        tmp_db,
+        [
+            # Bucket 1: both vessels at the same spot
+            ("111111111", "2026-01-01 02:05:00+00", lat, lon),
+            ("222222222", "2026-01-01 02:10:00+00", lat, lon),
+            # Bucket 2 (different 30-min window): both vessels again
+            ("111111111", "2026-01-01 02:35:00+00", lat, lon),
+            ("222222222", "2026-01-01 02:40:00+00", lat, lon),
+        ],
+    )
+    contacts = build_sts_contacts_from_ais(tmp_db)
+    pairs = {(r["src_id"], r["dst_id"]) for r in contacts}
+    assert ("111111111", "222222222") in pairs
+
+
+def test_sts_contacts_single_overlap_excluded(tmp_db):
+    """Only 1 bucket overlap → below STS_MIN_CO_LOCATIONS → not a contact."""
+    from src.ingest.vessel_registry import build_sts_contacts_from_ais
+
+    lat, lon = 1.26, 103.85
+    _seed_ais_positions(
+        tmp_db,
+        [
+            ("111111111", "2026-01-01 02:05:00+00", lat, lon),
+            ("222222222", "2026-01-01 02:10:00+00", lat, lon),
+            # Second position: each vessel departs to a completely different area
+            ("111111111", "2026-01-01 03:05:00+00", 5.0, 110.0),  # South China Sea
+            ("222222222", "2026-01-01 03:10:00+00", 35.0, 139.0),  # Tokyo Bay
+        ],
+    )
+    contacts = build_sts_contacts_from_ais(tmp_db)
+    assert contacts == []
+
+
+def test_sts_contacts_pair_ordering(tmp_db):
+    """src_id < dst_id lexicographically — each pair appears exactly once."""
+    from src.ingest.vessel_registry import build_sts_contacts_from_ais
+
+    lat, lon = 1.26, 103.85
+    _seed_ais_positions(
+        tmp_db,
+        [
+            ("333333333", "2026-01-01 02:05:00+00", lat, lon),
+            ("111111111", "2026-01-01 02:08:00+00", lat, lon),
+            ("333333333", "2026-01-01 02:35:00+00", lat, lon),
+            ("111111111", "2026-01-01 02:38:00+00", lat, lon),
+        ],
+    )
+    contacts = build_sts_contacts_from_ais(tmp_db)
+    assert len(contacts) == 1
+    assert contacts[0]["src_id"] < contacts[0]["dst_id"]
+
+
+def test_sts_contacts_different_cells_not_paired(tmp_db):
+    """Vessels in different H3 cells must not be paired even in the same time bucket."""
+    from src.ingest.vessel_registry import build_sts_contacts_from_ais
+
+    _seed_ais_positions(
+        tmp_db,
+        [
+            # Far apart — clearly different H3 cells
+            ("111111111", "2026-01-01 02:05:00+00", 1.26, 103.85),
+            ("222222222", "2026-01-01 02:07:00+00", 35.0, 139.0),
+            ("111111111", "2026-01-01 02:35:00+00", 1.26, 103.85),
+            ("222222222", "2026-01-01 02:37:00+00", 35.0, 139.0),
+        ],
+    )
+    assert build_sts_contacts_from_ais(tmp_db) == []
+
+
+def test_build_graph_tables_includes_sts_contacts(tmp_db):
+    """build_graph_tables() populates STS_CONTACT from AIS data."""
+    lat, lon = 1.26, 103.85
+    _seed_ais_positions(
+        tmp_db,
+        [
+            ("111111111", "2026-01-01 02:05:00+00", lat, lon),
+            ("222222222", "2026-01-01 02:10:00+00", lat, lon),
+            ("111111111", "2026-01-01 02:35:00+00", lat, lon),
+            ("222222222", "2026-01-01 02:40:00+00", lat, lon),
+        ],
+    )
+    tables = build_graph_tables(tmp_db)
+    sts = tables["STS_CONTACT"]
+    assert len(sts) >= 1
+    src_ids = sts["src_id"].to_pylist()
+    dst_ids = sts["dst_id"].to_pylist()
+    assert "111111111" in src_ids or "111111111" in dst_ids


### PR DESCRIPTION
## Summary
- Adds `build_sts_contacts_from_ais()` to `src/ingest/vessel_registry.py`: reads `ais_positions`, computes H3 resolution-8 cells + 30-minute bucket keys in Python (avoids DuckDB community extension network install), self-joins in-memory DuckDB to find vessel pairs co-located ≥2 times
- `build_graph_tables()` now populates `STS_CONTACT` Lance table from live AIS data (previously always empty), fixing `sts_hub_degree` feature which was always 0
- 6 new unit tests covering: empty DB, pair detected, single overlap excluded, pair ordering, different cells, and end-to-end table inclusion

## Test plan
- [x] `uv run python -m pytest tests/test_vessel_registry.py -v` → 20/20 passed
- [x] `uv run ruff check . && uv run ruff format --check .` → clean
- [x] Full test suite: 333 passed (5 pre-existing errors in `test_reviews_api.py` unrelated to this PR)

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)