### PR TITLE
fix: skip *_sample.csv fixtures in custom_feeds loader

### DIFF
--- a/src/ingest/custom_feeds.py
+++ b/src/ingest/custom_feeds.py
@@ -33,6 +33,11 @@ Filename convention (used when column detection is ambiguous):
     cargo_*.csv  /  manifest_*.csv  → Cargo manifest
     sanctions_*.csv    → Custom sanctions
 
+Sample files (skipped automatically):
+    Files whose stem ends with ``_sample`` (e.g. ``ais_sample.csv``,
+    ``sanctions_sample.csv``) are always skipped so smoke-test fixtures
+    in ``_inputs/custom_feeds/`` never pollute the live pipeline DB.
+
 Column-map sidecar (optional, for AIS feeds with non-standard column names):
     Create a JSON file alongside your CSV with the same stem:
         _inputs/custom_feeds/my_feed.csv
@@ -272,6 +277,9 @@ def ingest_custom_feeds(
     init_schema(db_path)
 
     for csv_path in csv_files:
+        if csv_path.stem.endswith("_sample"):
+            print(f"  [custom_feeds] SKIP {csv_path.name} — sample fixture, not for live pipeline")
+            continue
         try:
             header = pl.read_csv(csv_path, n_rows=0)
             columns = header.columns

--- a/tests/test_custom_feeds.py
+++ b/tests/test_custom_feeds.py
@@ -326,6 +326,30 @@ class TestEdgeCases:
         con.close()
         assert rows == 0
 
+    def test_sample_files_skipped(self, tmp_path):
+        # Smoke-test fixtures (e.g. ais_sample.csv) must never touch the live DB
+        _write_csv(
+            tmp_path,
+            "lat,lon,detected_at\n1.2,103.8,2024-01-15T08:30:00\n",
+            "sar_sample.csv",
+        )
+        _write_csv(
+            tmp_path,
+            "lat,lon,detected_at\n1.3,103.9,2024-01-16T09:00:00\n",
+            "sar_real.csv",
+        )
+        db_path = _db(tmp_path)
+        results = ingest_custom_feeds(tmp_path, db_path)
+        # sample file must be absent from results
+        assert "sar_sample.csv" not in results
+        # real file is ingested normally
+        assert results["sar_real.csv"] == 1
+
+        con = duckdb.connect(db_path)
+        rows = con.execute("SELECT COUNT(*) FROM sar_detections").fetchone()[0]
+        con.close()
+        assert rows == 1
+
     def test_multiple_files(self, tmp_path):
         _write_csv(
             tmp_path,


### PR DESCRIPTION
Closes #242

## Summary

- `ingest_custom_feeds` now skips any CSV file whose stem ends with `_sample` (e.g. `ais_sample.csv`, `sanctions_sample.csv`, `sar_sample.csv`, `cargo_sample.csv`)
- Skipped files emit a log line so operators see what was filtered
- Module docstring updated to document the naming convention

## Root cause

`_inputs/custom_feeds/` is both the drop-in directory for live custom feeds and the home of smoke-test fixtures.  The loader had no way to distinguish them, so fixtures were ingested into the live pipeline DB on every run — placing synthetic MMSI `123456789` at rank #1 and `567891234` at rank #19 in the Singapore watchlist.

## Test plan

- [x] `test_sample_files_skipped` — asserts `sar_sample.csv` is absent from results dict and zero rows reach `sar_detections`
- [x] Non-sample file alongside a sample file is still ingested normally
- [x] Full `test_custom_feeds.py` suite: 27 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)