### PR TITLE
feat: extend AIS feature window from 30d to 60d

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -44,7 +44,7 @@ PRESETS: dict[str, RegionPreset] = {
         label="Singapore / Malacca Strait",
         bbox=[-5, 92, 22, 122],
         gap_threshold_h=4,  # #234: 4h captures brief Malacca STS coordination gaps
-        window_days=30,
+        window_days=60,
         w_anomaly=0.40,
         w_graph=0.40,
         w_identity=0.20,
@@ -549,7 +549,18 @@ def step_features(p: RegionPreset, non_interactive: bool, seed_dummy: bool = Fal
             [sys.executable, "-m", "src.features.trade_mismatch", "--db", p.db_path],
             "trade_mismatch",
         ),
-        ([sys.executable, "-m", "src.features.build_matrix", "--db", p.db_path], "build_matrix"),
+        (
+            [
+                sys.executable,
+                "-m",
+                "src.features.build_matrix",
+                "--db",
+                p.db_path,
+                "--window",
+                str(p.window_days),
+            ],
+            "build_matrix",
+        ),
     ]
     for cmd, label in cmds:
         result = _run(cmd, env=env)

--- a/src/features/ais_behavior.py
+++ b/src/features/ais_behavior.py
@@ -224,7 +224,7 @@ def compute_port_call_ratio(df: pl.DataFrame) -> pl.DataFrame:
 
 def compute_ais_features(
     db_path: str = DEFAULT_DB_PATH,
-    window_days: int = 30,
+    window_days: int = 60,
     gap_threshold_h: float = GAP_THRESHOLD_H,
 ) -> pl.DataFrame:
     """Compute all AIS behavioral features. Returns DataFrame one row per MMSI."""
@@ -277,7 +277,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Compute AIS behavioral features")
     parser.add_argument("--db", default=DEFAULT_DB_PATH)
-    parser.add_argument("--window", type=int, default=30, help="Rolling window (days)")
+    parser.add_argument("--window", type=int, default=60, help="Rolling window (days)")
     parser.add_argument(
         "--gap-threshold-hours",
         type=float,

--- a/src/features/build_matrix.py
+++ b/src/features/build_matrix.py
@@ -149,7 +149,7 @@ def _empty_eo() -> pl.DataFrame:
 
 def build_feature_matrix(
     db_path: str = DEFAULT_DB_PATH,
-    window_days: int = 30,
+    window_days: int = 60,
     skip_graph: bool = False,
     skip_eo: bool = False,
 ) -> pl.DataFrame:
@@ -265,7 +265,7 @@ def validate_core_columns_non_null(feature_df: pl.DataFrame) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Build and persist vessel feature matrix")
     parser.add_argument("--db", default=DEFAULT_DB_PATH)
-    parser.add_argument("--window", type=int, default=30)
+    parser.add_argument("--window", type=int, default=60)
     parser.add_argument("--skip-graph", action="store_true")
     parser.add_argument("--skip-eo", action="store_true", help="Skip EO feature computation")
     args = parser.parse_args()

--- a/src/features/eo_fusion.py
+++ b/src/features/eo_fusion.py
@@ -95,7 +95,7 @@ def _load_ais_window(db_path: str, window_days: int) -> pl.DataFrame:
 
 def compute_eo_features(
     db_path: str = DEFAULT_DB_PATH,
-    window_days: int = 30,
+    window_days: int = 60,
     match_radius_deg: float = MATCH_RADIUS_DEG,
     match_window_minutes: int = MATCH_WINDOW_MINUTES,
     gap_threshold_h: float = GAP_THRESHOLD_H,
@@ -204,7 +204,7 @@ def compute_eo_features(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Compute EO fusion features")
     parser.add_argument("--db", default=DEFAULT_DB_PATH)
-    parser.add_argument("--window", type=int, default=30)
+    parser.add_argument("--window", type=int, default=60)
     parser.add_argument("--match-radius-deg", type=float, default=MATCH_RADIUS_DEG)
     parser.add_argument("--match-window-minutes", type=int, default=MATCH_WINDOW_MINUTES)
     parser.add_argument("--gap-threshold-hours", type=float, default=GAP_THRESHOLD_H)

--- a/src/features/sar_detections.py
+++ b/src/features/sar_detections.py
@@ -88,7 +88,7 @@ def _load_ais_window(db_path: str, window_days: int) -> pl.DataFrame:
 
 def compute_unmatched_sar_detections(
     db_path: str = DEFAULT_DB_PATH,
-    window_days: int = 30,
+    window_days: int = 60,
     match_radius_km: float = MATCH_RADIUS_KM,
     match_window_minutes: int = MATCH_WINDOW_MINUTES,
     gap_threshold_h: float = GAP_THRESHOLD_H,
@@ -181,7 +181,7 @@ def compute_unmatched_sar_detections(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Compute SAR-based vessel features")
     parser.add_argument("--db", default=DEFAULT_DB_PATH)
-    parser.add_argument("--window", type=int, default=30, help="Rolling window (days)")
+    parser.add_argument("--window", type=int, default=60, help="Rolling window (days)")
     parser.add_argument("--match-radius-km", type=float, default=MATCH_RADIUS_KM)
     parser.add_argument("--match-window-minutes", type=int, default=MATCH_WINDOW_MINUTES)
     parser.add_argument("--gap-threshold-hours", type=float, default=GAP_THRESHOLD_H)


### PR DESCRIPTION
Closes #202

## Summary

- Default `window_days` raised from **30 → 60** in `ais_behavior.py`, `sar_detections.py`, `eo_fusion.py`, and `build_matrix.py`
- Singapore preset updated 30 → 60 (Japan / Middle East were already at 60)
- `step_features` now passes `--window p.window_days` to `build_matrix`, making the regional preset the single source of truth (previously `build_matrix` silently used its own default, decoupled from the preset)

## Why

Shadow fleet evasion events are sparse — vessels typically conduct 1–2 STS transfers per month. A 30-day window captures 0–1 events, giving the Isolation Forest near-zero variance to discriminate on. A 60-day window doubles the observation period without changing any feature logic, improving `ais_gap_count` variance and `sts_hub_degree` signal quality. This also directly addresses the score compression documented in #243.

## Data prerequisite

Full feature variance requires ≥60 days of continuous AIS collection from the launchd agent (#189, merged 2026-04-12). In the interim the wider window is harmless — it looks further back in `ais_positions` and finds the same dataset. CI continues to run in `--seed-dummy` mode so regression metrics are unaffected.

## Test plan

- [x] 334 tests pass (pre-existing `test_reviews_api` errors require R2 credentials, unrelated)
- [x] Ruff format: 5 files already formatted
- [x] All tests that use `window_days=30` do so explicitly — default change does not affect them

🤖 Generated with [Claude Code](https://claude.com/claude-code)