### PR TITLE
fix: wire label propagation floor into composite + fix HDBSCAN small-group noise (#197, #200)

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -642,9 +642,26 @@ def step_score(
     if geo_filter_path:
         composite_cmd += ["--geopolitical-event-filter", geo_filter_path]
 
+    # Label propagation runs before composite so the floor can be applied.
+    # The output path matches label_propagation.py DEFAULT_OUTPUT_PATH.
+    propagation_path = os.path.join(os.path.dirname(p.db_path), "label_propagation.json")
+    composite_cmd += ["--propagation-path", propagation_path]
+
     cmds = [
         ([sys.executable, "-m", "src.score.mpol_baseline", "--db", p.db_path], "mpol_baseline"),
         ([sys.executable, "-m", "src.score.anomaly", "--db", p.db_path], "anomaly"),
+        (
+            [
+                sys.executable,
+                "-m",
+                "src.analysis.label_propagation",
+                "--db",
+                p.db_path,
+                "--output",
+                propagation_path,
+            ],
+            "label_propagation",
+        ),
         (composite_cmd, "composite"),
         (
             [

--- a/src/score/composite.py
+++ b/src/score/composite.py
@@ -452,6 +452,34 @@ def _compute_top_signals(feature_df: pl.DataFrame, model, scaled_matrix: np.ndar
         return pl.Series("top_signals", _top_signals_fallback(feature_df))
 
 
+def _load_propagation_floor(
+    propagation_path: str,
+) -> tuple[dict[str, float], dict[str, str]]:
+    """Load propagation artifact and return (floor_map, evidence_map).
+
+    floor_map:    {mmsi: max propagated_confidence}
+    evidence_map: {mmsi: evidence_type of highest-confidence path}
+    """
+    import json
+
+    try:
+        with open(propagation_path) as f:
+            report = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}, {}
+
+    floor: dict[str, float] = {}
+    evidence: dict[str, str] = {}
+    for row in report.get("vessels", []):
+        mmsi = row.get("mmsi", "")
+        conf = float(row.get("propagated_confidence", 0.0))
+        etype = row.get("evidence_type", "propagated")
+        if mmsi and conf > 0 and conf > floor.get(mmsi, 0.0):
+            floor[mmsi] = conf
+            evidence[mmsi] = etype
+    return floor, evidence
+
+
 def compute_composite_scores(
     db_path: str = DEFAULT_DB_PATH,
     w_anomaly: float = 0.35,
@@ -459,6 +487,7 @@ def compute_composite_scores(
     w_identity: float = 0.10,
     geo_filter_path: str | None = None,
     auto_calibrate: bool = False,
+    propagation_path: str | None = None,
 ) -> pl.DataFrame:
     if auto_calibrate:
         print("Auto-calibrating graph risk weight using C3 causal model...")
@@ -508,6 +537,39 @@ def compute_composite_scores(
             .alias("vessel_type"),
         ]
     )
+
+    # Apply label-propagation floor: vessels connected to confirmed-black vessels
+    # via ownership or STS edges receive a confidence floor equal to their
+    # propagated_confidence.  This only lifts vessels — never suppresses.
+    if propagation_path:
+        prop_floor, prop_evidence = _load_propagation_floor(propagation_path)
+        if prop_floor:
+            mmsi_list = scored["mmsi"].to_list()
+            floor_series = pl.Series(
+                "prop_floor",
+                [prop_floor.get(m, 0.0) for m in mmsi_list],
+                dtype=pl.Float32,
+            )
+            scored = scored.with_columns(
+                pl.max_horizontal(pl.col("confidence"), floor_series).alias("confidence")
+            )
+            # Annotate top_signals for lifted vessels with the propagation source.
+            old_sigs = scored["top_signals"].to_list()
+            new_sigs = []
+            for m, sig in zip(mmsi_list, old_sigs):
+                floor_val = prop_floor.get(m, 0.0)
+                if floor_val > 0:
+                    etype = prop_evidence.get(m, "propagated")
+                    entry = json.dumps(
+                        {"feature": "label_propagation", "evidence_type": etype, "value": round(floor_val, 3), "contribution": 1.0}
+                    )
+                    existing = json.loads(sig) if sig else []
+                    new_sigs.append(json.dumps([json.loads(entry)] + existing))
+                else:
+                    new_sigs.append(sig)
+            scored = scored.with_columns(pl.Series("top_signals", new_sigs))
+            n_lifted = sum(1 for m in mmsi_list if prop_floor.get(m, 0.0) > 0)
+            print(f"[label propagation] floor applied to {n_lifted} vessels from {propagation_path}")
 
     return scored.select(
         [
@@ -572,6 +634,16 @@ def main() -> None:
             "to reduce false positives from legitimate commercial rerouting."
         ),
     )
+    parser.add_argument(
+        "--propagation-path",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to label_propagation.json produced by src.analysis.label_propagation. "
+            "Vessels connected to confirmed-black vessels receive a confidence floor "
+            "equal to their propagated_confidence (only lifts, never suppresses)."
+        ),
+    )
     args = parser.parse_args()
 
     w_graph = args.w_graph
@@ -587,6 +659,7 @@ def main() -> None:
         args.w_identity,
         geo_filter_path=args.geopolitical_event_filter,
         auto_calibrate=auto_calibrate,
+        propagation_path=args.propagation_path,
     )
     write_composite_scores(df, args.output)
     print(f"Composite rows written: {df.height}")

--- a/src/score/composite.py
+++ b/src/score/composite.py
@@ -561,7 +561,12 @@ def compute_composite_scores(
                 if floor_val > 0:
                     etype = prop_evidence.get(m, "propagated")
                     entry = json.dumps(
-                        {"feature": "label_propagation", "evidence_type": etype, "value": round(floor_val, 3), "contribution": 1.0}
+                        {
+                            "feature": "label_propagation",
+                            "evidence_type": etype,
+                            "value": round(floor_val, 3),
+                            "contribution": 1.0,
+                        }
                     )
                     existing = json.loads(sig) if sig else []
                     new_sigs.append(json.dumps([json.loads(entry)] + existing))
@@ -569,7 +574,9 @@ def compute_composite_scores(
                     new_sigs.append(sig)
             scored = scored.with_columns(pl.Series("top_signals", new_sigs))
             n_lifted = sum(1 for m in mmsi_list if prop_floor.get(m, 0.0) > 0)
-            print(f"[label propagation] floor applied to {n_lifted} vessels from {propagation_path}")
+            print(
+                f"[label propagation] floor applied to {n_lifted} vessels from {propagation_path}"
+            )
 
     return scored.select(
         [

--- a/src/score/mpol_baseline.py
+++ b/src/score/mpol_baseline.py
@@ -112,14 +112,26 @@ def _cluster_group(
             }
         )
 
+    # Minimum group size for reliable HDBSCAN clustering.  Groups smaller than
+    # this produce near-universal noise labels (label=-1, baseline_noise_score=1.0)
+    # that degrade the anomaly component for every vessel indiscriminately.
+    # Fall back to noise=0.0 (Isolation Forest dominates) for tiny groups.
+    _MIN_RELIABLE_GROUP = 5
+
     matrix = group.select(BEHAVIOR_COLUMNS).to_numpy()
-    if len(group) < 3 or np.unique(matrix, axis=0).shape[0] < 2 or HDBSCAN is None:
+    if (
+        len(group) < _MIN_RELIABLE_GROUP
+        or np.unique(matrix, axis=0).shape[0] < 2
+        or HDBSCAN is None
+    ):
         labels = np.zeros(len(group), dtype=np.int32)
         noise = np.zeros(len(group), dtype=np.float32)
     else:
         scaler = StandardScaler()
         scaled = scaler.fit_transform(matrix)
-        min_cluster_size = max(2, min(10, len(group) // 2 or 2))
+        # Use 1/5 of group size (floor 5, cap 15) — avoids aggressive noise
+        # assignment that occurred with the old 1/2 divisor on small groups.
+        min_cluster_size = max(5, min(15, len(group) // 5 or 5))
         model = HDBSCAN(min_cluster_size=min_cluster_size, min_samples=1, allow_single_cluster=True)
         labels = model.fit_predict(scaled).astype(np.int32)
         noise = (labels == -1).astype(np.float32)


### PR DESCRIPTION
## Summary

- **#200** — HDBSCAN `min_cluster_size` was `max(2, len//2)`, causing near-universal noise labeling for any ship_type group ≤ 6 vessels (e.g. 6 tankers → `min_cluster_size=3` → almost every vessel labeled noise → `baseline_noise_score=1.0` for all). Changed to `max(5, len//5)` and added a `< 5` fallback that forces `noise=0.0` so Isolation Forest dominates cleanly for tiny groups.

- **#197** — `propagated_confidence` from `src/analysis/label_propagation.py` was computed but discarded. Now:
  - `compute_composite_scores()` accepts `--propagation-path`
  - Applies `confidence = max(composite, propagated)` — only lifts vessels, never suppresses
  - Annotates `top_signals` with `{"feature":"label_propagation","evidence_type":"shared_owner"|"shared_manager"|"sts_contact"}` for lifted vessels so the analyst sees why a vessel was elevated
  - `run_pipeline.py` step 8 runs `label_propagation` before composite and wires the output path through

## Test plan

- [x] 303 tests pass (excluding event-loop API test unrelated to this PR)
- [x] `test_label_propagation.py` (13 tests) all green
- [x] `test_scoring_pipeline.py` — baseline and composite tests pass with new HDBSCAN params
- [ ] Re-run Singapore pipeline with `vessel_reviews` containing at least one `outcome='black'` to verify propagation floor activates

## Expected metric impact

| Change | Effect |
|--------|--------|
| HDBSCAN floor raised | `baseline_noise_score` no longer saturated at 1.0 for small ship_type groups; anomaly score better calibrated |
| Label propagation floor | Vessels sharing owner/manager/STS with confirmed-black vessel rise to ≥ 0.50–0.65 confidence floor |

Closes #197
Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)