### PR TITLE
feat(#257): add push-demo/pull-demo for zero-auth R2 demo bundle

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -89,6 +89,16 @@ jobs:
           echo "snapshot_id=$snapshot_id" >> "$GITHUB_OUTPUT"
           echo "snapshot_mb=$snapshot_mb" >> "$GITHUB_OUTPUT"
 
+      - name: Push demo bundle to R2 (public, no-auth download)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+        run: |
+          # Overwrites demo.zip with the latest pipeline outputs so developers can
+          # run `pull-demo` (or fetch_demo_data.sh) without any credentials.
+          uv run python scripts/sync_r2.py push-demo
+
       - name: Push OpenSanctions DB to R2 (push-sanctions-db)
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/docs/demo-data.md
+++ b/docs/demo-data.md
@@ -1,0 +1,135 @@
+# Demo Data — R2 Distribution
+
+arktrace ships a lightweight **demo bundle** to Cloudflare R2 after every
+successful data-publish CI run.  Developers can download it with a single
+command, no credentials required, to explore the dashboard output without
+running the full AIS ingestion and scoring pipeline locally.
+
+---
+
+## For developers — pulling the demo bundle
+
+```bash
+# Option A: convenience shell script (recommended)
+bash scripts/fetch_demo_data.sh
+
+# Option B: Python sync script
+uv run python scripts/sync_r2.py pull-demo
+```
+
+Both commands download `demo.zip` from the public R2 bucket and extract:
+
+| File | Contents |
+|------|----------|
+| `candidate_watchlist.parquet` | Top candidate shadow-fleet vessels, scored and ranked |
+| `composite_scores.parquet` | Full composite score table for all vessels |
+| `causal_effects.parquet` | C3 DiD causal uplift estimates |
+| `validation_metrics.json` | Backtest metrics (AUROC, Recall@200, P@50) |
+
+Files land in `data/processed/`.  After pulling, start the dashboard:
+
+```bash
+uv run streamlit run src/ui/app.py
+open http://localhost:8501
+```
+
+### Optional extras
+
+```bash
+# OpenSanctions DuckDB — needed for integration tests, not the dashboard
+uv run python scripts/sync_r2.py pull-sanctions-db
+
+# Full pipeline snapshot — includes regional DuckDBs and Lance graphs (~500 MB)
+uv run python scripts/sync_r2.py pull --region singapore
+```
+
+---
+
+## For app owners — generating fresh demo data and pushing to R2
+
+The CI job (`data-publish.yml`) pushes the demo bundle automatically after
+every weekly pipeline run.  If you need to push a manually generated batch:
+
+### 1. Run the pipeline locally
+
+```bash
+# Singapore is the primary demo region
+uv run python scripts/run_pipeline.py --region singapore --non-interactive
+
+# Optional: also run Japan and Middle East for a fuller candidate_watchlist
+uv run python scripts/run_pipeline.py --region japan,middleeast --non-interactive
+```
+
+This writes pipeline outputs to `data/processed/`.
+
+### 2. Run the backtest to generate validation_metrics.json
+
+```bash
+uv run python scripts/run_public_backtest_batch.py \
+  --regions singapore \
+  --skip-pipeline \
+  --max-known-cases 200
+```
+
+### 3. Push the demo bundle to R2
+
+```bash
+# Requires R2 write credentials in .env or environment:
+#   AWS_ACCESS_KEY_ID=<key>
+#   AWS_SECRET_ACCESS_KEY=<secret>
+uv run python scripts/sync_r2.py push-demo
+```
+
+This overwrites `demo.zip` in R2 with the current `data/processed/` outputs.
+The push is idempotent — re-running it replaces the previous demo bundle.
+
+### 4. Verify (optional)
+
+```bash
+# Pull in a clean temp directory to confirm the bundle is intact
+mkdir -p /tmp/arktrace-demo-check/data/processed
+uv run python scripts/sync_r2.py pull-demo --data-dir /tmp/arktrace-demo-check/data/processed
+ls -lh /tmp/arktrace-demo-check/data/processed/
+```
+
+---
+
+## R2 credentials setup
+
+R2 credentials are only required for **push** commands.  Pull commands work
+without credentials because the `arktrace-public` bucket has public access
+enabled.
+
+1. Create an R2 API token at Cloudflare Dashboard → R2 → Manage R2 API Tokens
+   with **Object Read & Write** permission scoped to `arktrace-public`.
+2. Add to `.env` (or set as environment variables / CI secrets):
+
+```dotenv
+AWS_ACCESS_KEY_ID=<your-r2-access-key-id>
+AWS_SECRET_ACCESS_KEY=<your-r2-secret-access-key>
+AWS_REGION=auto
+S3_ENDPOINT=https://b8a0b09feb89390fb6e8cf4ef9294f48.r2.cloudflarestorage.com
+S3_BUCKET=arktrace-public
+```
+
+In CI, these are stored as repository secrets (`AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`).
+
+---
+
+## CI integration
+
+The `data-publish.yml` workflow runs every Monday 02:00 UTC and after each
+successful public-backtest-integration run.  The pipeline is:
+
+1. Pull watchlists from R2
+2. Run backtest (`--skip-pipeline`)
+3. **Push demo bundle** (`push-demo`) — overwrites `demo.zip`
+4. Push full snapshot (`push`) — timestamped rotation zip
+5. Push OpenSanctions DB (`push-sanctions-db`)
+6. Send metrics email
+
+Step 3 ensures the public demo bundle is always in sync with the latest
+backtest output, so developers pulling `pull-demo` always get recent data.
+
+See also: [r2-data-layout.md](r2-data-layout.md) for the full R2 bucket structure.

--- a/scripts/fetch_demo_data.sh
+++ b/scripts/fetch_demo_data.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# fetch_demo_data.sh — download the arktrace demo bundle from R2 (no credentials required).
+#
+# Downloads candidate_watchlist.parquet, composite_scores.parquet,
+# causal_effects.parquet, and validation_metrics.json into data/processed/.
+# These files are enough to run the Streamlit dashboard without a local pipeline run.
+#
+# Usage:
+#   bash scripts/fetch_demo_data.sh
+#
+# Requirements: uv must be installed (https://docs.astral.sh/uv/)
+# No R2 credentials are needed — the demo bundle is publicly accessible.
+#
+# To also download the OpenSanctions DuckDB (needed for integration tests):
+#   uv run python scripts/sync_r2.py pull-sanctions-db
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "Fetching arktrace demo data from R2..."
+uv run python scripts/sync_r2.py pull-demo
+
+echo ""
+echo "Start the dashboard:"
+echo "  uv run streamlit run src/ui/app.py"
+echo "  open http://localhost:8501"

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -59,6 +59,13 @@ Commands
                       a real pipeline run so CI can pull real watchlists for the backtest
   pull-watchlists     download watchlists.zip from R2 and extract into data/processed/ — used
                       by data-publish CI job (replaces seeded pipeline run)
+  push-demo           upload fixed-key demo bundle (candidate_watchlist.parquet,
+                      composite_scores.parquet, causal_effects.parquet,
+                      validation_metrics.json) to R2 — requires credentials; run after
+                      a real pipeline run or from the data-publish CI job
+  pull-demo           download the demo bundle from R2 into data/processed/ — no credentials
+                      required; intended for developers who want to run the dashboard
+                      without running the full pipeline locally
   list                show all snapshot zips and shared objects in R2
 
 Env vars (loaded from .env automatically)
@@ -75,11 +82,13 @@ Examples
   uv run python scripts/sync_r2.py push-gdelt                # upload/update gdelt.lance.zip
   uv run python scripts/sync_r2.py push-sanctions-db         # upload/update public_eval.duckdb
   uv run python scripts/sync_r2.py push-watchlists           # upload *_watchlist.parquet (<1 MB)
+  uv run python scripts/sync_r2.py push-demo                 # upload demo bundle (CI runs this)
   uv run python scripts/sync_r2.py pull                      # pull latest (no credentials needed)
   uv run python scripts/sync_r2.py pull --timestamp 20260411T080000Z
   uv run python scripts/sync_r2.py pull-gdelt                # pull gdelt.lance.zip
   uv run python scripts/sync_r2.py pull-sanctions-db         # pull public_eval.duckdb for tests
   uv run python scripts/sync_r2.py pull-watchlists           # pull watchlists.zip (used by CI)
+  uv run python scripts/sync_r2.py pull-demo                 # pull demo bundle (no credentials)
   uv run python scripts/sync_r2.py list                      # show all generations in R2
 """
 
@@ -110,6 +119,16 @@ _LATEST_KEY = "latest"  # plain-text pointer to newest timestamp
 _GDELT_R2_KEY = "gdelt.lance.zip"  # single zip for gdelt
 _SANCTIONS_DB_R2_KEY = "public_eval.duckdb"  # OpenSanctions DB; separate from rotation zip
 _WATCHLISTS_R2_KEY = "watchlists.zip"  # lightweight bundle of *_watchlist.parquet files
+_DEMO_R2_KEY = "demo.zip"  # fixed-key public demo bundle; overwritten on every push-demo
+
+# Files included in the demo bundle — lightweight artifacts that let developers run the
+# dashboard without re-running the full pipeline.  No heavy DuckDB or Lance files.
+_DEMO_FILES = [
+    "candidate_watchlist.parquet",
+    "composite_scores.parquet",
+    "causal_effects.parquet",
+    "validation_metrics.json",
+]
 
 # Maps user-facing region name → file prefix used in data/processed/
 # e.g. "japan" → files are japansea.duckdb, japansea_graph/, japansea_watchlist.parquet
@@ -758,6 +777,104 @@ def cmd_pull_watchlists(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_push_demo(args: argparse.Namespace) -> int:
+    """Upload the fixed-key demo bundle to R2 (requires credentials).
+
+    Overwrites demo.zip on every run — there is no rotation; the file always
+    reflects the most recent pipeline run.  Intended to be called from the
+    data-publish CI job after the main push step.
+    """
+    bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
+    data_dir = Path(args.data_dir)
+    r2_path = f"{bucket}/{_DEMO_R2_KEY}"
+
+    missing = [f for f in _DEMO_FILES if not (data_dir / f).exists()]
+    if missing:
+        print(
+            f"Error: the following demo files are missing from {data_dir}:\n"
+            + "".join(f"  {f}\n" for f in missing)
+            + "Run the pipeline first or check _DEMO_FILES in sync_r2.py.",
+            file=sys.stderr,
+        )
+        return 1
+
+    fs = _build_r2_fs()
+
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        with zipmod.ZipFile(tmp_path, "w", compression=zipmod.ZIP_STORED) as zf:
+            for name in _DEMO_FILES:
+                local = data_dir / name
+                zf.write(local, arcname=name)
+                print(f"  + {name} ({local.stat().st_size / 1024:.1f} KB)")
+        size_mb = tmp_path.stat().st_size / 1_048_576
+        print(f"Uploading demo.zip ({size_mb:.2f} MB) → R2 {r2_path} ...")
+        uploaded = _upload_file(fs, tmp_path, r2_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    print(f"Done. {uploaded / 1_048_576:.2f} MB uploaded.")
+    print(
+        "\nDevelopers can now fetch the demo bundle without credentials:\n"
+        "  uv run python scripts/sync_r2.py pull-demo\n"
+        "  # or: bash scripts/fetch_demo_data.sh"
+    )
+    return 0
+
+
+def cmd_pull_demo(args: argparse.Namespace) -> int:
+    """Download the demo bundle from R2 into data/processed/ (no credentials required).
+
+    Provides a zero-auth path for developers who want to explore the dashboard
+    output without running the full AIS ingestion + scoring pipeline locally.
+    """
+    bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
+    data_dir = Path(args.data_dir)
+    r2_path = f"{bucket}/{_DEMO_R2_KEY}"
+
+    anon = not (os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY"))
+    fs = _build_r2_fs(anonymous=anon)
+
+    import pyarrow.fs as pafs
+
+    try:
+        infos = fs.get_file_info([r2_path])
+        if infos[0].type == pafs.FileType.NotFound:
+            raise FileNotFoundError
+        size_mb = infos[0].size / 1_048_576
+    except Exception:
+        print(
+            "No demo.zip found in R2. The app owner needs to run:\n"
+            "  uv run python scripts/run_pipeline.py --region singapore --non-interactive\n"
+            "  uv run python scripts/sync_r2.py push-demo",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Downloading demo.zip ({size_mb:.2f} MB) ...")
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        downloaded = _download_file(fs, r2_path, tmp_path)
+        data_dir.mkdir(parents=True, exist_ok=True)
+        with zipmod.ZipFile(tmp_path, "r") as zf:
+            names = zf.namelist()
+            zf.extractall(data_dir)
+        print(f"Extracted {len(names)} files to {data_dir}/: {', '.join(names)}")
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    print(f"Done. {downloaded / 1_048_576:.2f} MB downloaded.")
+    print(
+        "\nYou can now run the dashboard without a full pipeline:\n"
+        "  uv run streamlit run src/ui/app.py\n"
+        "  open http://localhost:8501"
+    )
+    return 0
+
+
 def cmd_list(args: argparse.Namespace) -> int:
     bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
     anon = not (os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY"))
@@ -901,6 +1018,24 @@ def main() -> int:
     )
     pull_watchlists_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
 
+    push_demo_p = sub.add_parser(
+        "push-demo",
+        help=(
+            "Upload fixed-key demo bundle (watchlist + scores + causal effects + metrics) "
+            "to R2 — requires credentials; run after a pipeline run or from CI"
+        ),
+    )
+    push_demo_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
+
+    pull_demo_p = sub.add_parser(
+        "pull-demo",
+        help=(
+            "Download demo bundle from R2 into data/processed/ — no credentials required; "
+            "lets developers run the dashboard without a local pipeline run"
+        ),
+    )
+    pull_demo_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
+
     sub.add_parser("list", help="List snapshot zips and shared objects in R2")
 
     args = parser.parse_args()
@@ -914,6 +1049,7 @@ def main() -> int:
         "pull-gdelt",
         "pull-sanctions-db",
         "pull-watchlists",
+        "pull-demo",
         "list",
     )
     if not _check_env(require_credentials=not read_only):
@@ -928,6 +1064,8 @@ def main() -> int:
         "pull-sanctions-db": cmd_pull_sanctions_db,
         "push-watchlists": cmd_push_watchlists,
         "pull-watchlists": cmd_pull_watchlists,
+        "push-demo": cmd_push_demo,
+        "pull-demo": cmd_pull_demo,
         "list": cmd_list,
     }
     return dispatch[args.command](args)


### PR DESCRIPTION
## Summary

- **`scripts/sync_r2.py`**: new `push-demo` command uploads `demo.zip` (fixed stable key) containing `candidate_watchlist.parquet`, `composite_scores.parquet`, `causal_effects.parquet`, `validation_metrics.json`; `pull-demo` downloads it anonymously
- **`.github/workflows/data-publish.yml`**: adds `push-demo` step after the backtest so the bundle is always current after each CI run
- **`scripts/fetch_demo_data.sh`**: one-liner wrapper around `pull-demo` for developers
- **`docs/demo-data.md`**: documents the developer pull workflow and the manual owner push process (run pipeline → `push-demo`)

## Test plan

- [ ] `uv run python scripts/sync_r2.py --help` shows `push-demo` and `pull-demo` in the subcommand list
- [ ] `push-demo` fails gracefully when demo files are missing (pre-pipeline run)
- [ ] After a pipeline run, `push-demo` uploads `demo.zip` and `pull-demo` retrieves it without credentials
- [ ] `fetch_demo_data.sh` runs end-to-end and prints the dashboard start command
- [ ] CI `data-publish` step ordering: `push-demo` fires after backtest, before rotation push

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)