### PR TITLE
fix(ci): seed demo files for push-demo + wire lead time validation

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -165,6 +165,13 @@ jobs:
           # regenerates it (which happens on every data-publish run).
           uv run python scripts/sync_r2.py push-sanctions-db --force
 
+      - name: Lead time validation (#268)
+        continue-on-error: true
+        run: |
+          uv run python scripts/validate_lead_time_ofac.py \
+            --all-regions \
+            --out data/processed/lead_time_report.json
+
       - name: Send metrics email (#210)
         if: always()
         env:

--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -89,6 +89,62 @@ jobs:
           echo "snapshot_id=$snapshot_id" >> "$GITHUB_OUTPUT"
           echo "snapshot_mb=$snapshot_mb" >> "$GITHUB_OUTPUT"
 
+      - name: Seed demo files for push-demo
+        # push-demo reads from ~/.arktrace/data/; the backtest writes outputs to
+        # data/processed/.  Copy/generate the three required demo files so
+        # push-demo can find them regardless of whether the full pipeline ran.
+        run: |
+          uv run python - <<'EOF'
+          import json, shutil
+          from pathlib import Path
+          import polars as pl
+
+          demo_dir = Path.home() / ".arktrace" / "data"
+          demo_dir.mkdir(parents=True, exist_ok=True)
+          processed = Path("data/processed")
+
+          # composite_scores.parquet — use candidate_watchlist if available
+          src = processed / "candidate_watchlist.parquet"
+          dst = demo_dir / "composite_scores.parquet"
+          if src.exists() and not dst.exists():
+              shutil.copy2(src, dst)
+              print(f"  composite_scores.parquet ← {src}")
+
+          # causal_effects.parquet — empty schema if missing
+          dst_c = demo_dir / "causal_effects.parquet"
+          if not dst_c.exists():
+              df = pl.DataFrame(schema={
+                  "regime": pl.Utf8, "label": pl.Utf8,
+                  "n_treated": pl.Int32, "n_control": pl.Int32,
+                  "att_estimate": pl.Float64, "att_ci_lower": pl.Float64,
+                  "att_ci_upper": pl.Float64, "p_value": pl.Float64,
+                  "is_significant": pl.Boolean, "calibrated_weight": pl.Float64,
+              })
+              df.write_parquet(dst_c)
+              print("  causal_effects.parquet ← empty schema (no full pipeline in CI)")
+
+          # validation_metrics.json — derive from backtest report if missing
+          dst_m = demo_dir / "validation_metrics.json"
+          if not dst_m.exists():
+              report_path = processed / "backtest_report_public_integration.json"
+              metrics = {}
+              if report_path.exists():
+                  report = json.loads(report_path.read_text())
+                  s = report.get("summary", {})
+                  metrics = {
+                      "auroc": s.get("auroc"),
+                      "precision_at_50": s.get("precision_at_50"),
+                      "recall_at_200": s.get("recall_at_200"),
+                      "recall_at_25": s.get("recall_at_25"),
+                      "false_negatives": s.get("false_negatives"),
+                      "calibration_error": s.get("calibration_error"),
+                  }
+              dst_m.write_text(json.dumps(metrics, indent=2))
+              print(f"  validation_metrics.json ← {metrics}")
+
+          print("Seed demo files complete.")
+          EOF
+
       - name: Push demo bundle to R2 (public, no-auth download)
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary

Two changes to \`.github/workflows/data-publish.yml\`:

**1. Fix push-demo failure (present since #258)**

\`push-demo\` requires \`composite_scores.parquet\`, \`causal_effects.parquet\`, and \`validation_metrics.json\` in \`~/.arktrace/data/\`, but the CI workflow only runs \`run_public_backtest_batch.py --skip-pipeline\` (no full pipeline), so these files were never generated.

Adds a "Seed demo files" step before \`push-demo\` that:
- Copies \`data/processed/candidate_watchlist.parquet\` → \`composite_scores.parquet\`
- Writes an empty-schema \`causal_effects.parquet\` (schema matches \`effects_to_dataframe()\`)
- Derives \`validation_metrics.json\` from \`backtest_report_public_integration.json\`

**2. Wire lead time validation script into CI (#268)**

Adds a "Lead time validation" step after \`push-sanctions-db\` (so the OpenSanctions JSONL is available) that runs \`validate_lead_time_ofac.py --all-regions\` and saves the report to \`data/processed/lead_time_report.json\`. Step is \`continue-on-error: true\` so a missing watchlist does not block the email or artifact upload. Report is included in the \`pipeline-artifacts\` upload.

Execution order after this PR:
```
pull-watchlists → backtest → push → seed demo → push-demo → push-sanctions-db → lead time validation → email → upload artifacts
```

## Test plan

- [ ] data-publish workflow completes without "demo files are missing" error
- [ ] \`demo.zip\` in R2 contains the 4 expected files
- [ ] \`lead_time_report.json\` appears in the \`pipeline-artifacts\` upload
- [ ] Lead time step exits cleanly even when watchlists are missing (continue-on-error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)