### PR TITLE
fix(docs): remove broken proposal-draft links, fix custom-feed anchor

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -150,7 +150,7 @@ uv run python scripts/run_pipeline.py --region singapore \
 
 ---
 
-## Custom feed drop-ins (`_inputs/custom_feeds/`)
+## Custom feed drop-ins
 
 Drop any CSV file into `_inputs/custom_feeds/` and it is auto-detected and ingested on the next pipeline run — no code changes required. Step 5 (`step_custom_feeds`) runs before the ownership graph build so proprietary position and detection data is included in feature engineering.
 

--- a/docs/study-guide.md
+++ b/docs/study-guide.md
@@ -28,7 +28,7 @@ A key requirement of the challenge is that the solution must have a "low computa
 
 Understanding the "Annex A" submission requirements is critical. We frame Arktrace as a **TRL 6 baseline** system that is ready for a 7-week trial in the Singapore Strait. Every feature we build must map back to the specific "Shadow Fleet" behaviors named in the Cap Vista solicitation.
 
-- **Internal Docs:** [docs/proposal-draft.md](proposal-draft.md), [docs/trial-specification.md](trial-specification.md).
+- **Internal Docs:** [docs/trial-specification.md](trial-specification.md).
 - **Internal Source:** `../arktrace-commercial/inputs/challenge-statements.md`.
 
 ### Day 3: Tactical Edge Vision & Architecture
@@ -280,7 +280,7 @@ The "Mastery Checklist" at the end of the guide is your final exam. If you can a
 
 Congratulations on completing the 3-week Arktrace Intensive. You are now equipped to help deliver a world-class maritime security solution for the Cap Vista challenge.
 
-- **Internal Docs:** [docs/index.md](index.md), [docs/proposal-draft.md](proposal-draft.md).
+- **Internal Docs:** [docs/index.md](index.md).
 - **Internal Source:** `../arktrace-commercial/outputs/annex-a-submission.md`.
 
 ---


### PR DESCRIPTION
Fixes two `mkdocs --strict` failures in the pages CI:

- **`study-guide.md`**: removed two links to `proposal-draft.md` (file deleted in #271)
- **`pipeline-operations.md`**: renamed heading from `## Custom feed drop-ins (\`_inputs/custom_feeds/\`)` to `## Custom feed drop-ins` so the generated anchor `#custom-feed-drop-ins` matches the link in `technical-solution.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)