### PR TITLE
fix(ci): resolve watchlist dir from ~/.arktrace/data/ in backtest and lead-time scripts

### DIFF
--- a/scripts/validate_lead_time_ofac.py
+++ b/scripts/validate_lead_time_ofac.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -55,14 +56,19 @@ import polars as pl
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 JSONL_PATH = REPO_ROOT / "data" / "raw" / "sanctions" / "opensanctions_entities.jsonl"
-PROCESSED = REPO_ROOT / "data" / "processed"
+
+# Watchlists are pulled from R2 to the canonical user data directory.
+# Pipeline operators can override with ARKTRACE_DATA_DIR or DATA_DIR.
+_watchlist_dir = Path(
+    os.getenv("ARKTRACE_DATA_DIR") or os.getenv("DATA_DIR") or (Path.home() / ".arktrace" / "data")
+)
 
 WATCHLIST_BY_REGION = {
-    "singapore": PROCESSED / "singapore_watchlist.parquet",
-    "japan": PROCESSED / "japansea_watchlist.parquet",
-    "europe": PROCESSED / "europe_watchlist.parquet",
-    "gulf": PROCESSED / "gulf_watchlist.parquet",
-    "middleeast": PROCESSED / "middleeast_watchlist.parquet",
+    "singapore": _watchlist_dir / "singapore_watchlist.parquet",
+    "japan": _watchlist_dir / "japansea_watchlist.parquet",
+    "europe": _watchlist_dir / "europe_watchlist.parquet",
+    "gulf": _watchlist_dir / "gulf_watchlist.parquet",
+    "middleeast": _watchlist_dir / "middleeast_watchlist.parquet",
 }
 
 # Score threshold above which a vessel is considered "flagged" by the model


### PR DESCRIPTION
## Root cause

`pull-watchlists` extracts `*_watchlist.parquet` files to `~/.arktrace/data/` (the canonical user data directory). Two scripts hardcoded `data/processed/` for `WATCHLIST_BY_REGION`, causing watchlists to never be found in CI:

- `run_public_backtest_batch.py` → all regions skipped silently, backtest produced empty results
- `validate_lead_time_ofac.py` → "No watchlist data found" → exit 1

Found by log inspection of https://github.com/edgesentry/arktrace/actions/runs/24409239837

## Fix

Both scripts now resolve `_watchlist_dir` dynamically:
`ARKTRACE_DATA_DIR` → `DATA_DIR` → `~/.arktrace/data/`

Consistent with `bootstrap.py`, `sync_r2.py`, and `src/storage/config.py`.

`WATCHLIST_BY_REGION` in `run_public_backtest_batch.py` is now typed as `dict[str, Path]` (absolute), so the `project_root /` prefix is dropped from the two path usages.

Pipeline operators running locally after a full pipeline run can override:
```bash
DATA_DIR=data/processed uv run python scripts/run_public_backtest_batch.py ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)