### PR TITLE
fix(ci): resolve watchlist dir from ~/.arktrace/data/ in run_public_backtest_batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,10 @@ jobs:
             --seed-dummy
 
       - name: Run public backtest
+        env:
+          # Pipeline wrote watchlists to data/processed/ (not ~/.arktrace/data/).
+          # DATA_DIR tells run_public_backtest_batch where to find them.
+          DATA_DIR: data/processed
         run: |
           uv run python scripts/run_public_backtest_batch.py \
             --regions singapore \

--- a/scripts/run_public_backtest_batch.py
+++ b/scripts/run_public_backtest_batch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from datetime import UTC, datetime
@@ -34,12 +35,18 @@ _DUMMY_MMSIS: frozenset[str] = frozenset(
     }
 )
 
-WATCHLIST_BY_REGION = {
-    "singapore": "data/processed/singapore_watchlist.parquet",
-    "japan": "data/processed/japansea_watchlist.parquet",
-    "middleeast": "data/processed/middleeast_watchlist.parquet",
-    "europe": "data/processed/europe_watchlist.parquet",
-    "gulf": "data/processed/gulf_watchlist.parquet",
+# Watchlists are pulled from R2 to the canonical user data directory.
+# Pipeline operators can override with ARKTRACE_DATA_DIR or DATA_DIR.
+_watchlist_dir = Path(
+    os.getenv("ARKTRACE_DATA_DIR") or os.getenv("DATA_DIR") or (Path.home() / ".arktrace" / "data")
+)
+
+WATCHLIST_BY_REGION: dict[str, Path] = {
+    "singapore": _watchlist_dir / "singapore_watchlist.parquet",
+    "japan": _watchlist_dir / "japansea_watchlist.parquet",
+    "middleeast": _watchlist_dir / "middleeast_watchlist.parquet",
+    "europe": _watchlist_dir / "europe_watchlist.parquet",
+    "gulf": _watchlist_dir / "gulf_watchlist.parquet",
 }
 
 
@@ -325,7 +332,7 @@ def main() -> None:
     windows: list[dict[str, Any]] = []
     label_counts: dict[str, int] = {}
     for region in regions:
-        watchlist_path = (project_root / WATCHLIST_BY_REGION[region]).resolve()
+        watchlist_path = WATCHLIST_BY_REGION[region].resolve()
         if not watchlist_path.exists():
             print(f"[skip] {region}: watchlist not found at {watchlist_path}", flush=True)
             skipped_regions.append(region)
@@ -368,9 +375,9 @@ def main() -> None:
     # a vessel scored in multiple regions is represented once at its best score.
     evaluated_regions = [r for r in regions if r not in skipped_regions]
     watchlist_parts = [
-        pl.read_parquet((project_root / WATCHLIST_BY_REGION[r]).resolve())
+        pl.read_parquet(WATCHLIST_BY_REGION[r].resolve())
         for r in evaluated_regions
-        if (project_root / WATCHLIST_BY_REGION[r]).exists()
+        if WATCHLIST_BY_REGION[r].exists()
     ]
     if watchlist_parts:
         combined_raw = pl.concat(watchlist_parts, how="vertical_relaxed")

--- a/scripts/validate_lead_time_ofac.py
+++ b/scripts/validate_lead_time_ofac.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -55,14 +56,19 @@ import polars as pl
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 JSONL_PATH = REPO_ROOT / "data" / "raw" / "sanctions" / "opensanctions_entities.jsonl"
-PROCESSED = REPO_ROOT / "data" / "processed"
+
+# Watchlists are pulled from R2 to the canonical user data directory.
+# Pipeline operators can override with ARKTRACE_DATA_DIR or DATA_DIR.
+_watchlist_dir = Path(
+    os.getenv("ARKTRACE_DATA_DIR") or os.getenv("DATA_DIR") or (Path.home() / ".arktrace" / "data")
+)
 
 WATCHLIST_BY_REGION = {
-    "singapore": PROCESSED / "singapore_watchlist.parquet",
-    "japan": PROCESSED / "japansea_watchlist.parquet",
-    "europe": PROCESSED / "europe_watchlist.parquet",
-    "gulf": PROCESSED / "gulf_watchlist.parquet",
-    "middleeast": PROCESSED / "middleeast_watchlist.parquet",
+    "singapore": _watchlist_dir / "singapore_watchlist.parquet",
+    "japan": _watchlist_dir / "japansea_watchlist.parquet",
+    "europe": _watchlist_dir / "europe_watchlist.parquet",
+    "gulf": _watchlist_dir / "gulf_watchlist.parquet",
+    "middleeast": _watchlist_dir / "middleeast_watchlist.parquet",
 }
 
 # Score threshold above which a vessel is considered "flagged" by the model


### PR DESCRIPTION
## Root cause

`pull-watchlists` extracts `*_watchlist.parquet` to `~/.arktrace/data/` but `run_public_backtest_batch.py` hardcoded `data/processed/` in `WATCHLIST_BY_REGION`. In `data-publish.yml` CI, all 5 regions were silently skipped and the backtest produced empty results.

Found by log inspection of https://github.com/edgesentry/arktrace/actions/runs/24409239837.

## Fix

**`run_public_backtest_batch.py`** — `WATCHLIST_BY_REGION` now resolves via `ARKTRACE_DATA_DIR` → `DATA_DIR` → `~/.arktrace/data/` (absolute `Path` objects; `project_root /` prefix dropped).

**`ci.yml` regression gate** — `run_pipeline.py` writes watchlists to `data/processed/`, not `~/.arktrace/data/`. Added `DATA_DIR: data/processed` env var to the backtest step so it finds the locally-produced watchlists.

Fixes: https://github.com/edgesentry/arktrace/actions/runs/24410336083

## Test plan

- [ ] `data-publish.yml`: backtest finds watchlists in `~/.arktrace/data/` after `pull-watchlists`
- [ ] `ci.yml` regression gate: backtest finds watchlists in `data/processed/` after `run_pipeline.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)