### PR TITLE
chore: multi-region AIS stream launchd configs and management script

### DIFF
--- a/config/launchagents/io.arktrace.aisstream.blacksea.plist
+++ b/config/launchagents/io.arktrace.aisstream.blacksea.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.arktrace.aisstream.blacksea</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/uv</string>
+    <string>run</string>
+    <string>--project</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>src.ingest.ais_stream</string>
+    <string>--db</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/blacksea.duckdb</string>
+    <string>--bbox</string>
+    <string>40</string>
+    <string>27</string>
+    <string>48</string>
+    <string>42</string>
+    <string>--duration</string>
+    <string>0</string>
+    <string>--flush-interval</string>
+    <string>60</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AISSTREAM_API_KEY</key>
+    <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
+    <key>DB_PATH</key>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/blacksea.duckdb</string>
+    <key>HOME</key>
+    <string>/Users/yoheionishi</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/yoheionishi/.arktrace/blacksea.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/yoheionishi/.arktrace/blacksea.err</string>
+</dict>
+</plist>

--- a/config/launchagents/io.arktrace.aisstream.europe.plist
+++ b/config/launchagents/io.arktrace.aisstream.europe.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.arktrace.aisstream.europe</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/uv</string>
+    <string>run</string>
+    <string>--project</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>src.ingest.ais_stream</string>
+    <string>--db</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/europe.duckdb</string>
+    <string>--bbox</string>
+    <string>30</string>
+    <string>-22</string>
+    <string>72</string>
+    <string>42</string>
+    <string>--duration</string>
+    <string>0</string>
+    <string>--flush-interval</string>
+    <string>60</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AISSTREAM_API_KEY</key>
+    <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
+    <key>DB_PATH</key>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/europe.duckdb</string>
+    <key>HOME</key>
+    <string>/Users/yoheionishi</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/yoheionishi/.arktrace/europe.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/yoheionishi/.arktrace/europe.err</string>
+</dict>
+</plist>

--- a/config/launchagents/io.arktrace.aisstream.gulf.plist
+++ b/config/launchagents/io.arktrace.aisstream.gulf.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.arktrace.aisstream.gulf</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/uv</string>
+    <string>run</string>
+    <string>--project</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>src.ingest.ais_stream</string>
+    <string>--db</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/gulf.duckdb</string>
+    <string>--bbox</string>
+    <string>8</string>
+    <string>-98</string>
+    <string>32</string>
+    <string>-60</string>
+    <string>--duration</string>
+    <string>0</string>
+    <string>--flush-interval</string>
+    <string>60</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AISSTREAM_API_KEY</key>
+    <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
+    <key>DB_PATH</key>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/gulf.duckdb</string>
+    <key>HOME</key>
+    <string>/Users/yoheionishi</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/yoheionishi/.arktrace/gulf.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/yoheionishi/.arktrace/gulf.err</string>
+</dict>
+</plist>

--- a/config/launchagents/io.arktrace.aisstream.hornofafrica.plist
+++ b/config/launchagents/io.arktrace.aisstream.hornofafrica.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.arktrace.aisstream.hornofafrica</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/uv</string>
+    <string>run</string>
+    <string>--project</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>src.ingest.ais_stream</string>
+    <string>--db</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/hornofafrica.duckdb</string>
+    <string>--bbox</string>
+    <string>0</string>
+    <string>42</string>
+    <string>20</string>
+    <string>68</string>
+    <string>--duration</string>
+    <string>0</string>
+    <string>--flush-interval</string>
+    <string>60</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AISSTREAM_API_KEY</key>
+    <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
+    <key>DB_PATH</key>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/hornofafrica.duckdb</string>
+    <key>HOME</key>
+    <string>/Users/yoheionishi</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/yoheionishi/.arktrace/hornofafrica.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/yoheionishi/.arktrace/hornofafrica.err</string>
+</dict>
+</plist>

--- a/config/launchagents/io.arktrace.aisstream.japansea.plist
+++ b/config/launchagents/io.arktrace.aisstream.japansea.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.arktrace.aisstream.japansea</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/uv</string>
+    <string>run</string>
+    <string>--project</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>src.ingest.ais_stream</string>
+    <string>--db</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/japansea.duckdb</string>
+    <string>--bbox</string>
+    <string>25</string>
+    <string>115</string>
+    <string>48</string>
+    <string>145</string>
+    <string>--duration</string>
+    <string>0</string>
+    <string>--flush-interval</string>
+    <string>60</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AISSTREAM_API_KEY</key>
+    <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
+    <key>DB_PATH</key>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/japansea.duckdb</string>
+    <key>HOME</key>
+    <string>/Users/yoheionishi</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/yoheionishi/.arktrace/japansea.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/yoheionishi/.arktrace/japansea.err</string>
+</dict>
+</plist>

--- a/config/launchagents/io.arktrace.aisstream.middleeast.plist
+++ b/config/launchagents/io.arktrace.aisstream.middleeast.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.arktrace.aisstream.middleeast</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/uv</string>
+    <string>run</string>
+    <string>--project</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>src.ingest.ais_stream</string>
+    <string>--db</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/middleeast.duckdb</string>
+    <string>--bbox</string>
+    <string>-10</string>
+    <string>32</string>
+    <string>30</string>
+    <string>80</string>
+    <string>--duration</string>
+    <string>0</string>
+    <string>--flush-interval</string>
+    <string>60</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AISSTREAM_API_KEY</key>
+    <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
+    <key>DB_PATH</key>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/middleeast.duckdb</string>
+    <key>HOME</key>
+    <string>/Users/yoheionishi</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/yoheionishi/.arktrace/middleeast.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/yoheionishi/.arktrace/middleeast.err</string>
+</dict>
+</plist>

--- a/config/launchagents/io.arktrace.aisstream.singapore.plist
+++ b/config/launchagents/io.arktrace.aisstream.singapore.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.arktrace.aisstream.singapore</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/uv</string>
+    <string>run</string>
+    <string>--project</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>src.ingest.ais_stream</string>
+    <string>--db</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/singapore.duckdb</string>
+    <string>--bbox</string>
+    <string>-5</string>
+    <string>92</string>
+    <string>22</string>
+    <string>122</string>
+    <string>--duration</string>
+    <string>0</string>
+    <string>--flush-interval</string>
+    <string>60</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AISSTREAM_API_KEY</key>
+    <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
+    <key>DB_PATH</key>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/singapore.duckdb</string>
+    <key>HOME</key>
+    <string>/Users/yoheionishi</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/yoheionishi/.arktrace/singapore.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/yoheionishi/.arktrace/singapore.err</string>
+</dict>
+</plist>

--- a/scripts/aisstream_agents.sh
+++ b/scripts/aisstream_agents.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# aisstream_agents.sh — manage launchd agents for all AIS stream regions.
+#
+# Usage:
+#   scripts/aisstream_agents.sh init                   # install all plists from config/launchagents/
+#   scripts/aisstream_agents.sh start [region ...]     # load agent(s); omit region to start all
+#   scripts/aisstream_agents.sh stop  [region ...]     # unload agent(s); omit region to stop all
+#   scripts/aisstream_agents.sh status                 # show running agents + record counts
+#   scripts/aisstream_agents.sh logs  <region>         # tail logs for one region
+#
+# Regions: singapore  japansea  gulf  europe  middleeast  hornofafrica
+#
+# NOTE: max 3 concurrent streams on the aisstream.io free tier — 429s will occur above that.
+#
+# Requirements:
+#   - macOS (launchd)
+#   - AISSTREAM_API_KEY in .env or exported
+#   - uv installed
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_DIR="$PROJECT_ROOT/config/launchagents"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$HOME/.arktrace"
+DOT_ENV="$PROJECT_ROOT/.env"
+
+LABEL_PREFIX="io.arktrace.aisstream"
+ALL_REGIONS=(singapore japansea gulf europe middleeast hornofafrica)
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+_load_dotenv() {
+  if [[ -f "$DOT_ENV" ]]; then
+    while IFS='=' read -r key rest; do
+      [[ -z "$key" || "$key" == \#* ]] && continue
+      export "$key"="${rest}"
+    done < "$DOT_ENV"
+  fi
+}
+
+_check_api_key() {
+  _load_dotenv
+  if [[ -z "${AISSTREAM_API_KEY:-}" ]]; then
+    echo "Error: AISSTREAM_API_KEY is not set." >&2
+    echo "  Add it to $DOT_ENV or export it before running this script." >&2
+    exit 1
+  fi
+}
+
+_plist_src() { echo "$CONFIG_DIR/${LABEL_PREFIX}.${1}.plist"; }
+_plist_dst() { echo "$LAUNCH_AGENTS_DIR/${LABEL_PREFIX}.${1}.plist"; }
+_label()     { echo "${LABEL_PREFIX}.${1}"; }
+_db_path()   { echo "$PROJECT_ROOT/data/processed/${1}.duckdb"; }
+_log_file()  { echo "$LOG_DIR/${1}.log"; }
+_err_file()  { echo "$LOG_DIR/${1}.err"; }
+
+_resolve_regions() {
+  # If args given, use them; otherwise use ALL_REGIONS
+  if [[ $# -gt 0 ]]; then
+    echo "$@"
+  else
+    echo "${ALL_REGIONS[@]}"
+  fi
+}
+
+# --------------------------------------------------------------------------- #
+# init — copy plists to ~/Library/LaunchAgents, injecting real API key
+# --------------------------------------------------------------------------- #
+
+cmd_init() {
+  _check_api_key
+  local api_key="$AISSTREAM_API_KEY"
+
+  mkdir -p "$LOG_DIR"
+
+  local installed=0
+  for region in "${ALL_REGIONS[@]}"; do
+    local src; src="$(_plist_src "$region")"
+    local dst; dst="$(_plist_dst "$region")"
+
+    if [[ ! -f "$src" ]]; then
+      echo "  [skip] $region — no config found at $src"
+      continue
+    fi
+
+    sed "s|REPLACE_WITH_AISSTREAM_API_KEY|${api_key}|g" "$src" > "$dst"
+    echo "  [ok]   $region → $dst"
+    (( installed++ )) || true
+  done
+
+  echo
+  echo "$installed plist(s) installed to $LAUNCH_AGENTS_DIR"
+  echo "Run 'scripts/aisstream_agents.sh start <region>' to activate."
+}
+
+# --------------------------------------------------------------------------- #
+# start — load agent(s)
+# --------------------------------------------------------------------------- #
+
+cmd_start() {
+  local regions
+  read -ra regions <<< "$(_resolve_regions "$@")"
+
+  for region in "${regions[@]}"; do
+    local dst; dst="$(_plist_dst "$region")"
+    if [[ ! -f "$dst" ]]; then
+      echo "  [skip] $region — plist not found (run 'init' first)"
+      continue
+    fi
+    # Unload first to avoid "already loaded" errors
+    launchctl unload "$dst" 2>/dev/null || true
+    launchctl load "$dst"
+    echo "  [started] $region"
+  done
+}
+
+# --------------------------------------------------------------------------- #
+# stop — unload agent(s)
+# --------------------------------------------------------------------------- #
+
+cmd_stop() {
+  local regions
+  read -ra regions <<< "$(_resolve_regions "$@")"
+
+  for region in "${regions[@]}"; do
+    local dst; dst="$(_plist_dst "$region")"
+    if [[ ! -f "$dst" ]]; then
+      echo "  [skip] $region — plist not installed"
+      continue
+    fi
+    launchctl unload "$dst" 2>/dev/null || true
+    echo "  [stopped] $region"
+  done
+}
+
+# --------------------------------------------------------------------------- #
+# status — running agents + record counts
+# --------------------------------------------------------------------------- #
+
+cmd_status() {
+  printf "%-16s  %-10s  %-8s  %s\n" "REGION" "STATUS" "RECORDS" "LAST LOG LINE"
+  printf "%-16s  %-10s  %-8s  %s\n" "------" "------" "-------" "-------------"
+
+  for region in "${ALL_REGIONS[@]}"; do
+    local label; label="$(_label "$region")"
+    local db;    db="$(_db_path "$region")"
+    local log;   log="$(_log_file "$region")"
+
+    # launchd status
+    local pid exit_code status
+    pid=$(launchctl list 2>/dev/null | awk -v lbl="$label" '$3==lbl{print $1}') || true
+    exit_code=$(launchctl list 2>/dev/null | awk -v lbl="$label" '$3==lbl{print $2}') || true
+
+    if [[ -z "$pid" ]]; then
+      status="not loaded"
+    elif [[ "$pid" == "-" ]]; then
+      status="stopped(${exit_code})"
+    else
+      status="running(${pid})"
+    fi
+
+    # record count
+    local count="-"
+    if [[ -f "$db" ]]; then
+      count=$(uv run --project "$PROJECT_ROOT" python -c "
+import duckdb
+try:
+    con = duckdb.connect('$db', read_only=True)
+    print(con.execute('SELECT COUNT(*) FROM ais_positions').fetchone()[0])
+    con.close()
+except:
+    print('-')
+" 2>/dev/null) || count="-"
+    fi
+
+    # last log line
+    local last_log="-"
+    if [[ -f "$log" ]]; then
+      last_log=$(tail -1 "$log" 2>/dev/null || echo "-")
+    fi
+
+    printf "%-16s  %-10s  %-8s  %s\n" "$region" "$status" "$count" "${last_log:0:60}"
+  done
+}
+
+# --------------------------------------------------------------------------- #
+# logs — tail logs for one region
+# --------------------------------------------------------------------------- #
+
+cmd_logs() {
+  local region="${1:-}"
+  local lines="${2:-50}"
+
+  if [[ -z "$region" ]]; then
+    echo "Usage: $(basename "$0") logs <region> [lines]" >&2
+    exit 1
+  fi
+
+  local log; log="$(_log_file "$region")"
+  local err; err="$(_err_file "$region")"
+
+  if [[ -f "$log" ]]; then
+    echo "=== stdout ($log) — last $lines lines ==="
+    tail -"$lines" "$log"
+  else
+    echo "(no stdout log: $log)"
+  fi
+
+  echo
+  if [[ -f "$err" ]] && [[ -s "$err" ]]; then
+    echo "=== stderr ($err) — last $lines lines ==="
+    tail -"$lines" "$err"
+  else
+    echo "(stderr empty)"
+  fi
+}
+
+# --------------------------------------------------------------------------- #
+# Dispatch
+# --------------------------------------------------------------------------- #
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command> [region ...] [options]
+
+Commands:
+  init              Install all region plists to ~/Library/LaunchAgents/
+                    (reads AISSTREAM_API_KEY from .env or environment)
+  start [region …]  Load and start agent(s). Omit region to start all.
+  stop  [region …]  Unload and stop agent(s). Omit region to stop all.
+  status            Show status and record counts for all regions.
+  logs  <region>    Tail stdout/stderr logs for one region.
+
+Regions: ${ALL_REGIONS[*]}
+
+NOTE: aisstream.io free tier supports max ~3 concurrent streams.
+      Starting more will trigger HTTP 429 rate limiting.
+
+Examples:
+  scripts/aisstream_agents.sh init
+  scripts/aisstream_agents.sh start singapore japansea gulf
+  scripts/aisstream_agents.sh stop gulf
+  scripts/aisstream_agents.sh status
+  scripts/aisstream_agents.sh logs singapore
+EOF
+}
+
+case "${1:-}" in
+  init)   shift; cmd_init   "$@" ;;
+  start)  shift; cmd_start  "$@" ;;
+  stop)   shift; cmd_stop   "$@" ;;
+  status) shift; cmd_status "$@" ;;
+  logs)   shift; cmd_logs   "$@" ;;
+  *)      usage; exit 1 ;;
+esac

--- a/scripts/aisstream_agents.sh
+++ b/scripts/aisstream_agents.sh
@@ -26,7 +26,7 @@ LOG_DIR="$HOME/.arktrace"
 DOT_ENV="$PROJECT_ROOT/.env"
 
 LABEL_PREFIX="io.arktrace.aisstream"
-ALL_REGIONS=(singapore japansea gulf europe middleeast hornofafrica)
+ALL_REGIONS=(singapore japansea gulf europe middleeast hornofafrica blacksea)
 
 # --------------------------------------------------------------------------- #
 # Helpers
@@ -237,6 +237,7 @@ Commands:
 Regions: ${ALL_REGIONS[*]}
 
 NOTE: aisstream.io free tier supports max ~3 concurrent streams.
+      hornofafrica and middleeast show poor coverage on the free tier.
       Starting more will trigger HTTP 429 rate limiting.
 
 Examples:


### PR DESCRIPTION
## Summary

- **`config/launchagents/`** — plist templates for all 6 AIS stream regions (singapore, japansea, gulf, europe, middleeast, hornofafrica). API key is redacted as `REPLACE_WITH_AISSTREAM_API_KEY` so configs are safe to version-control.
- **`scripts/aisstream_agents.sh`** — unified management script replacing manual `launchctl` commands.

## Usage

```bash
# First-time setup — injects AISSTREAM_API_KEY from .env into plists
scripts/aisstream_agents.sh init

# Start specific regions (free tier: max ~3 concurrent)
scripts/aisstream_agents.sh start singapore japansea gulf

# Stop a region
scripts/aisstream_agents.sh stop gulf

# Check all regions with status + record counts
scripts/aisstream_agents.sh status

# Tail logs for one region
scripts/aisstream_agents.sh logs singapore
```

## Regions

| Region | Bbox (lat_min lon_min lat_max lon_max) | Key waterways |
|--------|----------------------------------------|---------------|
| singapore | -5 92 22 122 | Malacca Strait, South China Sea |
| japansea | 25 115 48 145 | Japan Sea, East China Sea |
| gulf | 8 -98 32 -60 | Gulf of Mexico, Caribbean |
| europe | 30 -22 72 42 | Mediterranean, North Sea, Baltic |
| middleeast | -10 32 30 80 | Persian Gulf, Red Sea, Arabian Sea |
| hornofafrica | 0 42 20 68 | Gulf of Aden, Bab-el-Mandeb, Somali coast |

> **Note:** aisstream.io free tier supports max ~3 concurrent streams. Starting more will trigger HTTP 429 rate limiting.

## Test plan
- [ ] `scripts/aisstream_agents.sh init` installs plists with real API key substituted
- [ ] `start`/`stop` correctly load/unload launchd agents
- [ ] `status` shows running agents and record counts
- [ ] `logs` tails the correct region log file

🤖 Generated with [Claude Code](https://claude.com/claude-code)