### PR TITLE
feat(#284): replace mlx-lm with llama.cpp for cross-platform LLM

### DIFF
--- a/docs/local-llm-setup.md
+++ b/docs/local-llm-setup.md
@@ -4,7 +4,7 @@ arktrace supports two LLM providers configured via `.env`. Set `LLM_PROVIDER` to
 
 | `LLM_PROVIDER` | Where it runs | Requires |
 |---|---|---|
-| `openai` *(default)* | Local (mlx-lm) or any OpenAI-compatible API | mlx-lm server or remote endpoint |
+| `openai` *(default)* | Local (llama-server) or any OpenAI-compatible API | llama.cpp installed or remote endpoint |
 | `anthropic` | Remote — Anthropic API | `ANTHROPIC_API_KEY` |
 
 ## What the LLM does in arktrace
@@ -19,31 +19,35 @@ Prompts are short (500–1,200 tokens in, 150–300 out). A 4–7B model is suff
 
 ---
 
-## 🍎 Recommended: Native macOS dev mode (mlx-lm)
+## Recommended: llama.cpp (cross-platform)
 
-`mlx-lm` runs natively on Apple Silicon via the MLX framework and exposes an OpenAI-compatible REST endpoint. The dashboard connects to it as a standard `openai` provider.
+arktrace uses **llama.cpp** (`llama-server`) as its local inference backend. It runs on macOS (Metal), Linux (CPU/CUDA), and Windows — the same stack everywhere.
 
-> **Infra (MinIO) still runs in Docker.** Only the FastAPI process and mlx-lm run on the host.
+The default model is `bartowski/Qwen2.5-7B-Instruct-GGUF` (Q4_K_M quantisation), which is commercially licensed under Apache 2.0 and matches what was previously used via mlx-lm.
 
-### One-time setup
+### One-time installation
 
 ```bash
-uv pip install mlx-lm
+# macOS (Homebrew) — recommended
+brew install llama.cpp
+
+# Other platforms — see full install guide:
+# https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md
 ```
 
 ### Start everything
 
 ```bash
-# Recommended — one command starts MinIO, mlx-lm, and the dashboard:
+# One command — starts llama-server and the dashboard:
 bash scripts/run_app.sh
 
+# Different region:
+bash scripts/run_app.sh --region japan
+
 # Override the default model:
-bash scripts/run_app.sh --model mlx-community/Qwen2.5-7B-Instruct-4bit
+bash scripts/run_app.sh --model bartowski/Qwen2.5-14B-Instruct-GGUF --gguf-file Qwen2.5-14B-Instruct-Q4_K_M.gguf
 
-# Skip Docker infra (MinIO already running):
-bash scripts/run_app.sh --no-infra
-
-# Skip mlx-lm (server already running on port 8080):
+# Skip llama-server (already running on port 8080):
 bash scripts/run_app.sh --no-llm
 
 # Use Anthropic instead of local LLM:
@@ -54,41 +58,52 @@ bash scripts/run_app.sh --provider anthropic
 
 | Flag | Default | Description |
 |---|---|---|
-| `--model MODEL` | `mlx-community/Qwen2.5-7B-Instruct-4bit` | mlx-community model ID or local path |
-| `--provider NAME` | `openai` | `openai` (mlx-lm or remote) or `anthropic` |
+| `--model MODEL` | `bartowski/Qwen2.5-7B-Instruct-GGUF` | HuggingFace repo or local `.gguf` path |
+| `--gguf-file FILE` | `Qwen2.5-7B-Instruct-Q4_K_M.gguf` | GGUF filename within the HF repo |
+| `--provider NAME` | `openai` | `openai` (llama-server) or `anthropic` |
 | `--port PORT` | `8000` | uvicorn port |
-| `--llm-port PORT` | `8080` | mlx-lm server port |
-| `--no-infra` | — | Skip starting Docker infra |
-| `--no-llm` | — | Skip starting mlx-lm server |
+| `--llm-port PORT` | `8080` | llama-server port |
+| `--no-llm` | — | Skip starting llama-server |
 
 ### Manual startup (step-by-step)
 
 ```bash
-# 1. Start MinIO
-docker compose -f docker-compose.infra.yml up -d
+# 1. Start llama-server (downloads model from HuggingFace on first run — ~4 GB)
+llama-server \
+  --hf-repo bartowski/Qwen2.5-7B-Instruct-GGUF \
+  --hf-file Qwen2.5-7B-Instruct-Q4_K_M.gguf \
+  --port 8080 \
+  --ctx-size 4096 \
+  --n-gpu-layers 99 &
 
-# 2. Start mlx-lm server (downloads model on first run — ~4 GB)
-uv run mlx_lm.server --model mlx-community/Qwen2.5-7B-Instruct-4bit --port 8080 &
-
-# 3. Start the dashboard
-S3_ENDPOINT=http://localhost:9000 \
+# 2. Start the dashboard
 LLM_PROVIDER=openai \
 LLM_BASE_URL=http://localhost:8080/v1 \
 LLM_API_KEY=local \
-LLM_MODEL=mlx-community/Qwen2.5-7B-Instruct-4bit \
+LLM_MODEL=Qwen2.5-7B-Instruct-Q4_K_M.gguf \
   uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8000 --reload
 ```
 
 ### Model guide
 
-| Model | Size (4-bit) | Min RAM | Licence | Notes |
-|---|---|---|---|---|
-| `mlx-community/Qwen2.5-7B-Instruct-4bit` | ~4.3 GB | 8 GB | Apache 2.0 | Default — good balance of quality and speed |
-| `mlx-community/Qwen2.5-3B-Instruct-4bit` | ~1.9 GB | 6 GB | Apache 2.0 | Faster, lower RAM |
-| `mlx-community/Phi-4-mini-instruct-4bit` | ~2.4 GB | 8 GB | MIT | No restrictions on government or defence use |
-| `mlx-community/Mistral-7B-Instruct-v0.3-4bit` | ~4.1 GB | 10 GB | Apache 2.0 | Highest quality local option |
+All models below are permissively licensed (Apache 2.0 or MIT) — compatible with arktrace's Apache 2.0 / MIT dual licence and safe for government and defence use.
 
-All models above are permissively licensed — no restrictions on government or defence use.
+| HF repo | GGUF file (Q4_K_M) | Size | Min RAM | Licence | Notes |
+|---|---|---|---|---|---|
+| `bartowski/Qwen2.5-7B-Instruct-GGUF` | `Qwen2.5-7B-Instruct-Q4_K_M.gguf` | ~4.4 GB | 8 GB | **Apache 2.0** | **Default** — best balance of quality and speed |
+| `bartowski/Qwen2.5-3B-Instruct-GGUF` | `Qwen2.5-3B-Instruct-Q4_K_M.gguf` | ~2.0 GB | 6 GB | **Apache 2.0** | Faster, lower RAM; good for briefs |
+| `bartowski/Qwen2.5-14B-Instruct-GGUF` | `Qwen2.5-14B-Instruct-Q4_K_M.gguf` | ~8.5 GB | 16 GB | **Apache 2.0** | Higher quality; recommended if RAM allows |
+| `bartowski/Qwen2.5-Coder-7B-Instruct-GGUF` | `Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf` | ~4.4 GB | 8 GB | **Apache 2.0** | Strong structured/JSON output |
+| `Qwen/Qwen3-8B-GGUF` | `Qwen3-8B-Q4_K_M.gguf` | ~4.9 GB | 8 GB | **Apache 2.0** | Newer generation; strong reasoning |
+| `bartowski/Phi-3.5-mini-instruct-GGUF` | `Phi-3.5-mini-instruct-Q4_K_M.gguf` | ~2.2 GB | 6 GB | **MIT** | Very low RAM; suitable for constrained environments |
+
+**Models to avoid** (licence restrictions):
+
+| Model family | Licence issue |
+|---|---|
+| LLaMA 3.x (Meta) | Meta Community Licence — not OSI-approved; usage restrictions above 700M MAU |
+| Gemma (Google) | Google Gemma ToS — restricts certain government/defence applications |
+| Mistral via `mistral.ai` API | Commercial API ToS applies |
 
 ---
 
@@ -104,7 +119,7 @@ LLM_MODEL=claude-haiku-4-5-20251001   # default — fast and cheap for briefs
 
 ## Provider: openai — remote or any OpenAI-compatible API
 
-Works with OpenAI, Ollama, LM Studio, or any other OpenAI-compatible endpoint.
+Works with OpenAI, LM Studio, or any other OpenAI-compatible endpoint.
 
 ```bash
 # OpenAI
@@ -113,15 +128,9 @@ LLM_BASE_URL=https://api.openai.com/v1
 LLM_API_KEY=sk-...
 LLM_MODEL=gpt-4o-mini
 
-# Ollama
-LLM_PROVIDER=openai
-LLM_BASE_URL=http://localhost:11434/v1
-LLM_API_KEY=local
-LLM_MODEL=qwen2.5:7b
-
-# mlx-lm (already running)
+# llama-server (already running)
 LLM_PROVIDER=openai
 LLM_BASE_URL=http://localhost:8080/v1
 LLM_API_KEY=local
-LLM_MODEL=mlx-community/Qwen2.5-7B-Instruct-4bit
+LLM_MODEL=Qwen2.5-7B-Instruct-Q4_K_M.gguf
 ```

--- a/docs/local-llm-setup.md
+++ b/docs/local-llm-setup.md
@@ -23,7 +23,7 @@ Prompts are short (500–1,200 tokens in, 150–300 out). A 4–7B model is suff
 
 arktrace uses **llama.cpp** (`llama-server`) as its local inference backend. It runs on macOS (Metal), Linux (CPU/CUDA), and Windows — the same stack everywhere.
 
-The default model is `bartowski/Qwen2.5-7B-Instruct-GGUF` (Q4_K_M quantisation), which is commercially licensed under Apache 2.0 and matches what was previously used via mlx-lm.
+The default model is `bartowski/Qwen2.5-7B-Instruct-GGUF` (Q4_K_M quantisation), commercially licensed under Apache 2.0.
 
 ### One-time installation
 

--- a/docs/study-guide.md
+++ b/docs/study-guide.md
@@ -208,17 +208,17 @@ For developers, the key is mastering **Prompt Engineering** in `src/api/routes/b
 - **External Docs:** [Prompt Engineering Guide](https://www.promptingguide.ai/).
 - **Internal Source:** `src/api/routes/briefs.py`, `src/api/llm.py`.
 
-### Day 16: Local LLM Inference (mlx-lm)
-To maintain our "Local-First" promise, we run our LLMs natively on Apple Silicon (M-series chips) using the **mlx-lm** framework. This framework is specifically optimized for Apple's unified memory architecture, allowing us to run high-quality models (like Qwen2.5-7B) with very high tokens-per-second.
+### Day 16: Local LLM Inference (llama.cpp)
+To maintain our "Local-First" promise, we run LLMs locally using **llama.cpp** (`llama-server`). Unlike platform-specific solutions, llama.cpp runs on macOS (Metal), Linux (CPU/CUDA), and Windows — the same stack in development, Docker, and air-gapped edge deployments.
 
-Native local inference is a critical capability for air-gapped deployments on ships or in secure facilities. It ensures zero data leakage (the vessel data never leaves the laptop) and zero dependency on expensive or high-latency satellite internet connections.
+Native local inference is a critical capability for air-gapped deployments on ships or in secure facilities. It ensures zero data leakage (vessel data never leaves the device) and zero dependency on expensive or high-latency satellite internet connections.
 
-We expose our local LLM via an **OpenAI-compatible REST endpoint**. This means we can swap between a local model running on `mlx-lm`, an `ollama` instance, or even a remote OpenAI/Anthropic API just by changing an environment variable (`LLM_PROVIDER`), without changing a single line of application code.
+We expose the local LLM via an **OpenAI-compatible REST endpoint** (`llama-server` on port 8080). This means we can swap between a local model, or a remote OpenAI/Anthropic API just by changing an environment variable (`LLM_PROVIDER`), without changing a single line of application code.
 
-For developers, Day 16 is about learning how to manage the `mlx-lm.server` process and how to select the right model quantization (e.g., 4-bit vs 8-bit) to balance performance and memory usage on constrained edge hardware.
+The default model is `bartowski/Qwen2.5-7B-Instruct-GGUF` (Q4_K_M, ~4.4 GB), licensed under Apache 2.0 — commercially safe with no government or defence restrictions. For developers, Day 16 is about learning how to select the right GGUF quantisation (Q4_K_M vs Q8_0) to balance quality and memory on constrained edge hardware.
 
 - **Internal Docs:** [docs/local-llm-setup.md](local-llm-setup.md).
-- **External Docs:** [MLX Framework](https://github.com/ml-explore/mlx), [mlx-lm Examples](https://github.com/ml-explore/mlx-examples/tree/main/llms/mlx_lm).
+- **External Docs:** [llama.cpp install guide](https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md), [GGUF quantisation guide](https://github.com/ggml-org/llama.cpp/blob/master/docs/quantization.md).
 - **Internal Source:** `scripts/run_app.sh`, `src/api/llm.py`.
 
 ### Day 17: The Tactical Interface (FastAPI, HTMX, SSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,6 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
 ]
-llm = [
-    "mlx-lm>=0.19",
-]
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -4,26 +4,28 @@
 # Start arktrace in native macOS dev mode.
 #
 #   • Data is read from local disk (pull from R2 first if not present)
-#   • mlx-lm runs as a local OpenAI-compatible server (Apple Silicon, Metal)
-#   • Dashboard runs natively on the host — connects to the mlx-lm server
+#   • llama-server (llama.cpp) runs as a local OpenAI-compatible server
+#   • Dashboard runs natively on the host — connects to the llama-server
 #
 # Prerequisites (one-time):
-#   uv pip install mlx-lm
+#   Install llama.cpp: https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md
+#   macOS (Homebrew): brew install llama.cpp
 #
 # Usage:
 #   bash scripts/run_app.sh
 #   bash scripts/run_app.sh --region japan
-#   bash scripts/run_app.sh --model mlx-community/Qwen2.5-7B-Instruct-4bit
+#   bash scripts/run_app.sh --model bartowski/Qwen2.5-7B-Instruct-GGUF
 #   bash scripts/run_app.sh --provider anthropic   # skip local LLM entirely
 #
 # Options:
 #   --region REGION   Region to serve: singapore|japan|middleeast|europe|gulf
 #                     (default: singapore)
-#   --model MODEL     mlx-community model ID or local path (overrides LLM_MODEL)
-#   --provider NAME   LLM provider: openai (mlx-lm) | anthropic (overrides LLM_PROVIDER)
+#   --model MODEL     HuggingFace repo (bartowski/...) or local .gguf path (overrides LLM_MODEL)
+#   --gguf-file FILE  GGUF filename within the HF repo (default: Qwen2.5-7B-Instruct-Q4_K_M.gguf)
+#   --provider NAME   LLM provider: openai (llama-server) | anthropic (overrides LLM_PROVIDER)
 #   --port PORT       Port for uvicorn (default: 8000)
-#   --llm-port PORT   Port for mlx-lm server (default: 8080)
-#   --no-llm          Skip starting mlx-lm server (assumes it is already running)
+#   --llm-port PORT   Port for llama-server (default: 8080)
+#   --no-llm          Skip starting llama-server (assumes it is already running)
 #   --help            Show this message
 
 set -euo pipefail
@@ -36,16 +38,19 @@ PORT="${PORT:-8000}"
 LLM_PORT="${LLM_PORT:-8080}"
 REGION="singapore"
 START_LLM=true
+HF_MODEL="bartowski/Qwen2.5-7B-Instruct-GGUF"
+GGUF_FILE="Qwen2.5-7B-Instruct-Q4_K_M.gguf"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --region)   REGION="$2";             shift 2 ;;
-    --model)    export LLM_MODEL="$2";   shift 2 ;;
-    --provider) export LLM_PROVIDER="$2"; shift 2 ;;
-    --port)     PORT="$2";               shift 2 ;;
-    --llm-port) LLM_PORT="$2";           shift 2 ;;
-    --no-llm)   START_LLM=false;         shift   ;;
+    --region)    REGION="$2";              shift 2 ;;
+    --model)     HF_MODEL="$2";            shift 2 ;;
+    --gguf-file) GGUF_FILE="$2";           shift 2 ;;
+    --provider)  export LLM_PROVIDER="$2"; shift 2 ;;
+    --port)      PORT="$2";                shift 2 ;;
+    --llm-port)  LLM_PORT="$2";            shift 2 ;;
+    --no-llm)    START_LLM=false;          shift   ;;
     --help|-h)
       sed -n '/^# Usage/,/^[^#]/{ /^[^#]/d; s/^# \{0,2\}//; p }' "$0"
       exit 0
@@ -92,45 +97,53 @@ if [[ ! -f "${WATCHLIST}" ]]; then
   echo ""
 fi
 
-# ── Start mlx-lm server ───────────────────────────────────────────────────────
+# ── Start llama-server ────────────────────────────────────────────────────────
 PROVIDER="${LLM_PROVIDER:-openai}"
-MODEL="${LLM_MODEL:-mlx-community/Qwen2.5-7B-Instruct-4bit}"
 
 if [[ "${START_LLM}" == true && "${PROVIDER}" != "anthropic" ]]; then
-  if ! uv run python -c "import mlx_lm" 2>/dev/null; then
-    echo "⬇️  mlx-lm not found. Installing…"
-    uv pip install mlx-lm
+  if ! command -v llama-server &>/dev/null; then
+    echo "❌ llama-server not found."
+    echo ""
+    echo "   Please install llama.cpp first:"
+    echo "     macOS (Homebrew): brew install llama.cpp"
+    echo "     Other platforms:  https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md"
+    echo ""
+    echo "   Then re-run: bash scripts/run_app.sh"
+    exit 1
   fi
 
-  echo "🤖 Starting mlx-lm server on port ${LLM_PORT}…"
-  echo "   Model: ${MODEL}"
-  uv run mlx_lm.server \
-    --model "${MODEL}" \
+  echo "🤖 Starting llama-server on port ${LLM_PORT}…"
+  echo "   Model: ${HF_MODEL} (${GGUF_FILE})"
+  llama-server \
+    --hf-repo "${HF_MODEL}" \
+    --hf-file "${GGUF_FILE}" \
     --port "${LLM_PORT}" \
+    --ctx-size 4096 \
+    --n-gpu-layers 99 \
     &
-  MLX_PID=$!
-  echo "   mlx-lm PID: ${MLX_PID}"
+  LLM_PID=$!
+  echo "   llama-server PID: ${LLM_PID}"
   echo "   Waiting for server to be ready…"
   for i in $(seq 1 30); do
     if curl -sf "http://localhost:${LLM_PORT}/v1/models" > /dev/null 2>&1; then
-      echo "   ✅ mlx-lm ready → http://localhost:${LLM_PORT}/v1"
+      echo "   ✅ llama-server ready → http://localhost:${LLM_PORT}/v1"
       break
     fi
     sleep 2
     if [[ $i -eq 30 ]]; then
-      echo "   ⚠️  mlx-lm did not respond in 60s — dashboard will start anyway"
+      echo "   ⚠️  llama-server did not respond in 60s — dashboard will start anyway"
     fi
   done
   echo ""
 
-  # Point the dashboard at the local mlx-lm server
+  # Point the dashboard at the local llama-server
   export LLM_PROVIDER="openai"
   export LLM_BASE_URL="http://localhost:${LLM_PORT}/v1"
   export LLM_API_KEY="${LLM_API_KEY:-local}"
-  export LLM_MODEL="${MODEL}"
+  export LLM_MODEL="${GGUF_FILE}"
 
-  # Shut down mlx-lm when the script exits
-  trap 'echo ""; echo "Stopping mlx-lm (PID ${MLX_PID})…"; kill "${MLX_PID}" 2>/dev/null || true' EXIT
+  # Shut down llama-server when the script exits
+  trap 'echo ""; echo "Stopping llama-server (PID ${LLM_PID})…"; kill "${LLM_PID}" 2>/dev/null || true' EXIT
 fi
 
 # ── Print config summary ───────────────────────────────────────────────────────
@@ -140,7 +153,7 @@ echo "   Data dir      = ${DATA_DIR}"
 echo "   DB_PATH       = ${DB_PATH}"
 echo "   LLM_PROVIDER  = ${LLM_PROVIDER:-openai}"
 echo "   LLM_BASE_URL  = ${LLM_BASE_URL:-http://localhost:${LLM_PORT}/v1}"
-echo "   LLM_MODEL     = ${LLM_MODEL:-${MODEL}}"
+echo "   LLM_MODEL     = ${LLM_MODEL:-${GGUF_FILE}}"
 echo "   Dashboard     → http://localhost:${PORT}"
 echo ""
 

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -124,9 +124,10 @@ if [[ "${START_LLM}" == true && "${PROVIDER}" != "anthropic" ]]; then
   LLM_PID=$!
   echo "   llama-server PID: ${LLM_PID}"
   echo "   Waiting for server to be ready…"
+  LLAMA_READY=false
   for i in $(seq 1 30); do
     if curl -sf "http://localhost:${LLM_PORT}/v1/models" > /dev/null 2>&1; then
-      echo "   ✅ llama-server ready → http://localhost:${LLM_PORT}/v1"
+      LLAMA_READY=true
       break
     fi
     sleep 2
@@ -134,6 +135,26 @@ if [[ "${START_LLM}" == true && "${PROVIDER}" != "anthropic" ]]; then
       echo "   ⚠️  llama-server did not respond in 60s — dashboard will start anyway"
     fi
   done
+
+  if [[ "${LLAMA_READY}" == true ]]; then
+    # Verify /v1/chat/completions is available — older llama.cpp returns 404 here.
+    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+      -X POST "http://localhost:${LLM_PORT}/v1/chat/completions" \
+      -H "Content-Type: application/json" \
+      -d '{"model":"test","messages":[{"role":"user","content":"ping"}],"max_tokens":1}' \
+      2>/dev/null || echo "000")
+    if [[ "${HTTP_STATUS}" == "404" ]]; then
+      echo ""
+      echo "   ❌ llama-server is running but /v1/chat/completions returned 404."
+      echo "      Your llama.cpp is outdated. Upgrade it and retry:"
+      echo "        brew upgrade llama.cpp"
+      echo "      Then re-run: bash scripts/run_app.sh"
+      echo ""
+      kill "${LLM_PID}" 2>/dev/null || true
+      exit 1
+    fi
+    echo "   ✅ llama-server ready → http://localhost:${LLM_PORT}/v1"
+  fi
   echo ""
 
   # Point the dashboard at the local llama-server

--- a/src/api/llm.py
+++ b/src/api/llm.py
@@ -73,6 +73,12 @@ class OpenAICompatClient:
                 json=payload,
                 headers={"Authorization": f"Bearer {self._api_key}"},
             ) as resp:
+                if resp.status_code == 404:
+                    raise RuntimeError(
+                        f"/v1/chat/completions not found at {self._base_url}. "
+                        "Your llama.cpp is likely outdated — upgrade it: "
+                        "brew upgrade llama.cpp  (or see docs/local-llm-setup.md)"
+                    )
                 resp.raise_for_status()
                 async for line in resp.aiter_lines():
                     if not line.startswith("data: "):


### PR DESCRIPTION
Closes #284

## Summary

- **`pyproject.toml`** — remove `mlx-lm` optional dependency (`[llm]` extra dropped entirely)
- **`scripts/run_app.sh`** — replace mlx-lm startup with `llama-server`; checks if `llama-server` is on PATH and exits with clear install instructions if not; default model is `bartowski/Qwen2.5-7B-Instruct-GGUF` Q4_K_M (same quality as previous default, Apache 2.0)
- **`docs/local-llm-setup.md`** — full rewrite for llama.cpp; model guide with licence notes; models-to-avoid table (LLaMA 3, Gemma)

## Why llama.cpp

| | mlx-lm | llama.cpp |
|---|---|---|
| macOS Apple Silicon | ✅ | ✅ (Metal) |
| macOS Intel | ❌ | ✅ |
| Linux (CPU/CUDA) | ❌ | ✅ |
| Windows | ❌ | ✅ |
| Docker | ❌ | ✅ |

## Default model

`bartowski/Qwen2.5-7B-Instruct-GGUF` — Apache 2.0, commercially friendly, no government/defence restrictions. Same model family as the previous mlx-lm default.

## Install (one-time)

```bash
brew install llama.cpp   # macOS
# other: https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md
```

## Test plan
- [ ] `bash scripts/run_app.sh` starts llama-server and downloads model on first run
- [ ] Without llama-server installed: clear error message with install link
- [ ] `--no-llm` skips llama-server startup
- [ ] `--provider anthropic` bypasses llama-server entirely
- [ ] `uv sync` completes without mlx-lm (macOS Intel / Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)