### PR TITLE
fix: seed candidate_watchlist.parquet to demo_dir before push-demo

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -103,12 +103,17 @@ jobs:
           demo_dir.mkdir(parents=True, exist_ok=True)
           processed = Path("data/processed")
 
-          # composite_scores.parquet — use candidate_watchlist if available.
-          # "Pull watchlists from R2" downloads to demo_dir, not data/processed,
-          # so check demo_dir first as a fallback source.
+          # candidate_watchlist.parquet — primary demo file; must exist in demo_dir.
+          # The backtest writes it to data/processed/; copy it across.
           src = processed / "candidate_watchlist.parquet"
           if not src.exists():
               src = demo_dir / "candidate_watchlist.parquet"
+          dst_w = demo_dir / "candidate_watchlist.parquet"
+          if src.exists() and src != dst_w and not dst_w.exists():
+              shutil.copy2(src, dst_w)
+              print(f"  candidate_watchlist.parquet ← {src}")
+
+          # composite_scores.parquet — use candidate_watchlist as source.
           dst = demo_dir / "composite_scores.parquet"
           if src.exists() and not dst.exists():
               shutil.copy2(src, dst)


### PR DESCRIPTION
## Problem

`data-publish` failed at the **Push demo bundle to R2** step:

```
Error: the following demo files are missing from /home/runner/.arktrace/data:
  candidate_watchlist.parquet
```

The **Seed demo files** step copied `candidate_watchlist.parquet` from `data/processed/` as the *source* for `composite_scores.parquet`, but never wrote it to `~/.arktrace/data/candidate_watchlist.parquet` itself. `push-demo` then checked for all four `_DEMO_FILES` and failed because `candidate_watchlist.parquet` was absent.

## Fix

Add an explicit `shutil.copy2` for `candidate_watchlist.parquet → demo_dir/candidate_watchlist.parquet` before the existing copy that produces `composite_scores.parquet`.

Fixes: https://github.com/edgesentry/arktrace/actions/runs/24450854154

🤖 Generated with [Claude Code](https://claude.com/claude-code)