### PR TITLE
fix: pull watchlists from R2 before backtest in data-publish workflow

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -62,17 +62,35 @@ jobs:
           AWS_REGION: auto
         run: uv run python scripts/sync_r2.py pull-custom-feeds
 
-      # Run the full pipeline for all regions in seed mode (no live AIS key needed)
-      # then evaluate the freshly generated watchlists with the backtest.
-      # --seed-dummy injects 10 known OFAC vessels so backtest metrics are
-      # meaningful; custom feeds from _inputs/custom_feeds/ are ingested during
-      # pipeline step 5 and their signals appear in the published watchlists.
-      - name: Run pipeline + backtest (seed mode, custom feeds included)
+      # Download real watchlists produced by a previous local pipeline run.
+      # Without this step, the backtest has no watchlists to evaluate:
+      #   - run_pipeline.py writes to data/processed/{region}_watchlist.parquet
+      #   - run_public_backtest_batch.py reads from ~/.arktrace/data/ (path mismatch)
+      #   - even if paths matched, --seed-dummy only injects ~10 vessels, failing
+      #     the --min-watchlist-size=100 guard
+      # Skips gracefully (continue-on-error) if no watchlists have been pushed yet.
+      # To populate R2: run the pipeline locally then push with:
+      #   uv run python scripts/sync_r2.py push-watchlists
+      - name: Pull watchlists from R2
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+        run: uv run python scripts/sync_r2.py pull-watchlists
+
+      # Run backtest against the pulled watchlists.
+      # --skip-pipeline: watchlists are pre-pulled from R2 above; CI has no live
+      #   AIS data so running the pipeline here would produce only ~10 seeded
+      #   dummy vessels — below --min-watchlist-size=100 — and all regions skip.
+      # --seed-dummy: still passed so the dummy MMSI filter logic is consistent.
+      - name: Run backtest (skip pipeline, use pulled watchlists)
         run: |
           uv run python scripts/run_public_backtest_batch.py \
             --regions singapore,japan,middleeast,europe,gulf \
             --gdelt-days 14 \
             --seed-dummy \
+            --skip-pipeline \
             --max-known-cases 200 \
             --min-known-cases 5
 


### PR DESCRIPTION
## Root cause

Two compounding bugs caused all regions to be skipped and the metrics email to be suppressed on every `data-publish` run:

**Bug 1 — Path mismatch**
`run_pipeline.py` writes watchlists to `data/processed/{region}_watchlist.parquet` (repo-relative), but `run_public_backtest_batch.py` reads from `~/.arktrace/data/{region}_watchlist.parquet` (home directory). The pipeline output was never visible to the backtest.

**Bug 2 — Size gate**
`--seed-dummy` only injects ~10 known OFAC vessels. Even if paths matched, every region would fail the `--min-watchlist-size=100` guard, producing `total_known_cases=0` → email suppressed.

Log evidence from run [24461022766](https://github.com/edgesentry/arktrace/actions/runs/24461022766):
```
[skip] singapore: watchlist not found at /home/runner/.arktrace/data/singapore_watchlist.parquet
[skip] japan:     watchlist not found at /home/runner/.arktrace/data/japansea_watchlist.parquet
… (all 5 regions)
skipped_reason: "watchlist below --min-watchlist-size=100 (likely seeded dummy data)"
total_known_cases: 0
Email suppressed — push real watchlists first
```

## Fix

1. **Add `pull-watchlists` step** before the backtest — downloads `watchlists.zip` from R2 (built by a local pipeline run and pushed with `sync_r2.py push-watchlists`) into `~/.arktrace/data/`, where the backtest expects them. `continue-on-error: true` so the workflow doesn't hard-fail when no watchlists have been pushed yet.

2. **Add `--skip-pipeline`** to the backtest command — CI has no live AIS data, so running the pipeline would only produce ~10 seeded vessels regardless. The pulled R2 watchlists are the real data source.

## Pre-requisite for email to fire

After a local pipeline run, push the watchlists to R2 once:
```bash
uv run python scripts/sync_r2.py push-watchlists
```
Subsequent `data-publish` runs will pull them automatically.

## Test plan
- [ ] Trigger `data-publish` manually after `push-watchlists` — confirm email fires with real metrics
- [ ] Trigger `data-publish` when no watchlists in R2 — confirm `pull-watchlists` skips gracefully (`continue-on-error`) and backtest reports all-skipped without hard failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)