### PR TITLE
fix(#49): repair capture_screenshots.py and seed_demo_sar for screenshots 03/04/05

### DIFF
--- a/scripts/capture_screenshots.py
+++ b/scripts/capture_screenshots.py
@@ -127,8 +127,12 @@ def capture_dispatch_brief(page, out: Path) -> None:
     page.locator("#dispatch-brief-btn").click()
     # Wait for the modal and brief body to load
     page.wait_for_selector("#dispatch-modal", state="visible", timeout=10_000)
+    # Wait until the body has real content: > 5 chars AND no longer in "Loading…" state.
+    # Original threshold (> 50) missed the 30-char error string; > 5 alone catches
+    # "Loading…" (10 chars) too early — combining both guards handles all states.
     page.wait_for_function(
-        "document.getElementById('dispatch-brief-body').innerText.length > 5",
+        "document.getElementById('dispatch-brief-body').innerText.length > 5 "
+        "&& !document.getElementById('dispatch-brief-body').innerText.includes('Loading')",
         timeout=20_000,
     )
     time.sleep(0.5)

--- a/scripts/seed_demo_sar.py
+++ b/scripts/seed_demo_sar.py
@@ -43,24 +43,27 @@ def main() -> None:
     if SAR_MMSI not in df["mmsi"].to_list():
         raise SystemExit(f"MMSI {SAR_MMSI} not found in watchlist.")
 
-    # Also raise confidence so the vessel clears the dashboard min_confidence=0.4 filter
-    # (without a high score the row never renders in /api/watchlist/top and the
-    # capture_sar_shap Playwright selector finds no matching tr.watchlist-row).
-    updated = df.with_columns(
-        pl.when(pl.col("mmsi") == SAR_MMSI)
-        .then(pl.lit(json.dumps(SAR_SIGNALS)))
-        .otherwise(pl.col("top_signals"))
-        .alias("top_signals"),
-        pl.when(pl.col("mmsi") == SAR_MMSI)
-        .then(pl.lit(0.85).cast(pl.Float64))
-        .otherwise(pl.col("confidence"))
-        .alias("confidence"),
+    # Also raise confidence so the vessel clears the dashboard min_confidence=0.4 filter.
+    # Then sort by confidence descending so the vessel appears in head(top_n) — the
+    # watchlist/top endpoint uses head() without a sort, so file order is the rank order.
+    updated = (
+        df.with_columns(
+            pl.when(pl.col("mmsi") == SAR_MMSI)
+            .then(pl.lit(json.dumps(SAR_SIGNALS)))
+            .otherwise(pl.col("top_signals"))
+            .alias("top_signals"),
+            pl.when(pl.col("mmsi") == SAR_MMSI)
+            .then(pl.lit(0.85).cast(pl.Float64))
+            .otherwise(pl.col("confidence"))
+            .alias("confidence"),
+        )
+        .sort("confidence", descending=True)
     )
 
     write_parquet(updated, WATCHLIST_URI)
     print(f"Injected SAR signals for MMSI {SAR_MMSI} into {WATCHLIST_URI}")
     print("  Top signal: unmatched_sar_detections_30d = 3 (contribution 0.24)")
-    print("  confidence boosted to 0.85 (required for dashboard min_confidence=0.4 filter)")
+    print("  confidence boosted to 0.85 (sorted to rank 1 so it appears in watchlist/top)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three screenshots (03/04/05) were blank or stale due to two code bugs and one seed-script data-path mismatch.

**`capture_screenshots.py`**
- `capture_causal_badge`: added `.shap-table` wait before attempting `.att-badge`, replacing the 0.5s blind sleep that produced a blank panel when `causal_effects.parquet` was absent
- `capture_dispatch_brief`: changed guard from `innerText.length > 50` → `> 5 && !includes('Loading')`. The 30-char error string ("Failed to load dispatch brief.") never reached 50; the new guard fires once the modal shows any non-loading content

**`seed_demo_sar.py`**
- Switched from `output_uri("candidate_watchlist.parquet")` to `watchlist_uri()` so the correct regional file (`singapore_watchlist.parquet`) is seeded
- Boosts SARI NOUR confidence to 0.85 (was 0.015) to clear the `min_confidence=0.4` dashboard filter
- Sorts parquet by confidence descending before writing so `head(top_n)` in the `watchlist/top` route returns SARI NOUR first (the API has no ORDER BY)

## Test plan

- [ ] Run `ARKTRACE_DATA_DIR=./data/processed uv run python scripts/seed_demo_causal_effects.py`
- [ ] Run `ARKTRACE_DATA_DIR=./data/processed uv run python scripts/seed_demo_sar.py`
- [ ] Start dashboard: `AUTO_PULL=0 uv run uvicorn src.api.main:app`
- [ ] Run `uv run python scripts/capture_screenshots.py` — all 5 screenshots saved with no warnings
- [ ] 03_causal_badge.png: review panel with SHAP table visible (not blank)
- [ ] 04_dispatch_brief.png: modal with vessel details (not map view / not "Loading...")
- [ ] 05_sar_shap.png: SARI NOUR with unmatched_sar_detections_30d as top signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)