### PR TITLE
fix: tighten middleeast/hornofafrica AIS bboxes and fix gulf region name in CI

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run backtest (skip pipeline, use pulled watchlists)
         run: |
           uv run python scripts/run_public_backtest_batch.py \
-            --regions singapore,japan,middleeast,europe,gulf \
+            --regions singapore,japan,middleeast,europe,persiangulf \
             --gdelt-days 14 \
             --seed-dummy \
             --skip-pipeline \

--- a/.github/workflows/public-backtest-integration.yml
+++ b/.github/workflows/public-backtest-integration.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run public-data backtest integration batch
         run: |
           uv run python scripts/run_public_backtest_batch.py \
-            --regions singapore,japan,middleeast,europe,gulf \
+            --regions singapore,japan,middleeast,europe,persiangulf \
             --gdelt-days 14 \
             --stream-duration 0 \
             --seed-dummy \

--- a/config/launchagents/io.arktrace.aisstream.hornofafrica.plist
+++ b/config/launchagents/io.arktrace.aisstream.hornofafrica.plist
@@ -19,7 +19,7 @@
     <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/hornofafrica.duckdb</string>
     <string>--bbox</string>
     <string>0</string>
-    <string>42</string>
+    <string>38</string>
     <string>20</string>
     <string>68</string>
     <string>--duration</string>

--- a/config/launchagents/io.arktrace.aisstream.middleeast.plist
+++ b/config/launchagents/io.arktrace.aisstream.middleeast.plist
@@ -18,10 +18,10 @@
     <string>--db</string>
     <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed/middleeast.duckdb</string>
     <string>--bbox</string>
-    <string>-10</string>
+    <string>12</string>
     <string>32</string>
-    <string>30</string>
-    <string>80</string>
+    <string>32</string>
+    <string>60</string>
     <string>--duration</string>
     <string>0</string>
     <string>--flush-interval</string>

--- a/scripts/seed_demo_sar.py
+++ b/scripts/seed_demo_sar.py
@@ -46,19 +46,16 @@ def main() -> None:
     # Also raise confidence so the vessel clears the dashboard min_confidence=0.4 filter.
     # Then sort by confidence descending so the vessel appears in head(top_n) — the
     # watchlist/top endpoint uses head() without a sort, so file order is the rank order.
-    updated = (
-        df.with_columns(
-            pl.when(pl.col("mmsi") == SAR_MMSI)
-            .then(pl.lit(json.dumps(SAR_SIGNALS)))
-            .otherwise(pl.col("top_signals"))
-            .alias("top_signals"),
-            pl.when(pl.col("mmsi") == SAR_MMSI)
-            .then(pl.lit(0.85).cast(pl.Float64))
-            .otherwise(pl.col("confidence"))
-            .alias("confidence"),
-        )
-        .sort("confidence", descending=True)
-    )
+    updated = df.with_columns(
+        pl.when(pl.col("mmsi") == SAR_MMSI)
+        .then(pl.lit(json.dumps(SAR_SIGNALS)))
+        .otherwise(pl.col("top_signals"))
+        .alias("top_signals"),
+        pl.when(pl.col("mmsi") == SAR_MMSI)
+        .then(pl.lit(0.85).cast(pl.Float64))
+        .otherwise(pl.col("confidence"))
+        .alias("confidence"),
+    ).sort("confidence", descending=True)
 
     write_parquet(updated, WATCHLIST_URI)
     print(f"Injected SAR signals for MMSI {SAR_MMSI} into {WATCHLIST_URI}")


### PR DESCRIPTION
Fixes #299

## Summary
- **middleeast plist**: bbox `-10,32→30,80` (1,920 sq°) → `12,32→32,60` (400 sq°) — tightened to Persian Gulf + Red Sea core, within free-tier limits
- **hornofafrica plist**: `lon_min` 42 → 38 to fully capture Bab-el-Mandeb and the southern Red Sea shipping lane
- **CI workflows**: rename `gulf` → `persiangulf` in `public-backtest-integration.yml` and `data-publish.yml` — `WATCHLIST_BY_REGION` key is `persiangulf`, `gulf` caused immediate `SystemExit`

## Test plan
- [ ] Reload agents: `scripts/aisstream_agents.sh init && scripts/aisstream_agents.sh start middleeast hornofafrica`
- [ ] Confirm `middleeast` flushes at least one batch within 5 minutes
- [ ] Confirm `hornofafrica` flushes at least one batch within 5 minutes
- [ ] If still zero after 5 min, document as free-tier satellite coverage gap and open separate issue for paid AIS (Spire/exactEarth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)