### PR TITLE
fix: restrict CI regions to those with sufficient AIS data

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run backtest (skip pipeline, use pulled watchlists)
         run: |
           uv run python scripts/run_public_backtest_batch.py \
-            --regions singapore,japan,middleeast,europe,persiangulf \
+            --regions singapore,japan,europe,blacksea \
             --gdelt-days 14 \
             --seed-dummy \
             --skip-pipeline \

--- a/.github/workflows/public-backtest-integration.yml
+++ b/.github/workflows/public-backtest-integration.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run public-data backtest integration batch
         run: |
           uv run python scripts/run_public_backtest_batch.py \
-            --regions singapore,japan,middleeast,europe,persiangulf \
+            --regions singapore,japan,europe,blacksea \
             --gdelt-days 14 \
             --stream-duration 0 \
             --seed-dummy \


### PR DESCRIPTION
## Summary
- Drop `middleeast` (24 vessels — below `--min-known-cases 30`) and `persiangulf` (0 vessels) from CI region list
- Add `blacksea` (432 vessels) as a replacement
- Final set: `singapore, japan, europe, blacksea`

## Why
Current AIS vessel counts show only four regions have enough data for meaningful score regression:

| Region | Vessels |
|---|---|
| europe | 22,655 |
| singapore | 1,993 |
| japansea | 1,872 |
| blacksea | 432 |
| middleeast | 24 ❌ |
| persiangulf | 0 ❌ |

## Test plan
- [ ] CI backtest passes without region-skip warnings
- [ ] Score regression gate produces results for all four regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)