### PR TITLE
fix: aggregate per-window AUROC into backtest summary

### DIFF
--- a/src/score/backtest.py
+++ b/src/score/backtest.py
@@ -519,6 +519,11 @@ def run_backtest(manifest_path: str, output_path: str, capacities: list[int]) ->
     p50 = [float(w["metrics"]["precision_at_50"]) for w in window_reports]  # type: ignore[index]
     p100 = [float(w["metrics"]["precision_at_100"]) for w in window_reports]  # type: ignore[index]
     r200 = [float(w["metrics"]["recall_at_200"]) for w in window_reports]  # type: ignore[index]
+    auroc_vals = [
+        float(w["metrics"]["auroc"])  # type: ignore[index]
+        for w in window_reports
+        if w["metrics"].get("auroc") is not None  # type: ignore[index]
+    ]
 
     report: dict[str, object] = {
         "schema_version": schema_version,
@@ -530,6 +535,7 @@ def run_backtest(manifest_path: str, output_path: str, capacities: list[int]) ->
             "precision_at_50": _metric_ci(p50),
             "precision_at_100": _metric_ci(p100),
             "recall_at_200": _metric_ci(r200),
+            "auroc": _metric_ci(auroc_vals) if auroc_vals else None,
         },
     }
 

--- a/src/score/backtest.py
+++ b/src/score/backtest.py
@@ -522,7 +522,7 @@ def run_backtest(manifest_path: str, output_path: str, capacities: list[int]) ->
     auroc_vals = [
         float(w["metrics"]["auroc"])  # type: ignore[index]
         for w in window_reports
-        if w["metrics"].get("auroc") is not None  # type: ignore[index]
+        if w["metrics"]["auroc"] is not None  # type: ignore[index]
     ]
 
     report: dict[str, object] = {


### PR DESCRIPTION
## Problem
`run_backtest()` computed AUROC per evaluation window but never aggregated it into the `summary` dict. As a result, `s.get("auroc")` in `notify_metrics.py` and `data-publish` always returned `None` — AUROC never appeared in the metrics email or `validation_metrics.json`.

## Fix
Collect non-`None` per-window AUROC values and roll them up via `_metric_ci` (mean + 95% CI), consistent with how `precision_at_50` and `recall_at_200` are already handled.

## After this fix
AUROC will be computed and surfaced in the summary whenever at least one evaluation window has enough positives **and** negatives in its labeled set (the existing per-window guard at `backtest.py:453`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)