### PR TITLE
docs: fix stale region names across arktrace/docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,7 +86,7 @@
 ┌─────────────────────────────────────────────────────────────────┐
 │  CI DATA PUBLISHING  (data-publish.yml — weekly + on-merge)     │
 │                                                                 │
-│  Runs full pipeline (all 5 regions, seed mode + custom feeds)   │
+│  Runs backtest on active regions (seed mode + custom feeds)      │
 │  then pushes artifacts to arktrace-public (Cloudflare R2):      │
 │                                                                 │
 │  · <timestamp>.zip  ── generation zip (all region artifacts)    │

--- a/docs/local-e2e-test.md
+++ b/docs/local-e2e-test.md
@@ -110,7 +110,7 @@ Defaults to the **Singapore / Malacca Strait** region with no live AIS streaming
 
 | Env var / flag | Default | Description |
 |---|---|---|
-| `PIPELINE_REGION` | `singapore` | Region preset: `singapore`, `japan`, `middleeast`, `europe`, `gulf` |
+| `PIPELINE_REGION` | `singapore` | Region preset: `singapore`, `japan`, `middleeast`, `europe`, `persiangulf`, `blacksea`, `gulfofaden`, `gulfofguinea`, `gulfofmexico` |
 | `PIPELINE_STREAM_DURATION` | _(unset)_ | Seconds of live AIS to collect |
 | `--gdelt-days N` | `3` | Days of GDELT events to ingest |
 | `--marine-cadastre-year YEAR` | _(unset)_ | Load a historical Marine Cadastre year (repeatable; uses region bbox automatically) |
@@ -125,10 +125,10 @@ PIPELINE_REGION=japan docker compose run --rm pipeline
 # Collect 5 minutes of live AIS
 PIPELINE_REGION=singapore PIPELINE_STREAM_DURATION=300 docker compose run --rm pipeline
 
-# Gulf region with 2023 historical Marine Cadastre backfill
-PIPELINE_REGION=gulf docker compose run --rm pipeline \
+# Gulf of Mexico region with 2023 historical Marine Cadastre backfill
+PIPELINE_REGION=gulfofmexico docker compose run --rm pipeline \
   uv run python scripts/run_pipeline.py \
-  --region gulf --non-interactive --marine-cadastre-year 2023
+  --region gulfofmexico --non-interactive --marine-cadastre-year 2023
 ```
 
 See `docs/regional-playbooks.md` for per-region configuration details.

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -59,7 +59,11 @@ See [Backtracking Runbook](backtracking-runbook.md) for full options, output for
 | Japan Sea / DPRK | `japan` | `japansea.duckdb` | 12 h | 60 d | 0.40 / 0.40 / 0.20 |
 | Middle East | `middleeast` | `middleeast.duckdb` | 12 h | 60 d | 0.40 / 0.40 / 0.20 |
 | Europe / Baltic | `europe` | `europe.duckdb` | 6 h | 45 d | 0.35 / 0.35 / 0.30 |
-| US Gulf | `gulf` | `gulf.duckdb` | 6 h | 14 d | 0.50 / 0.30 / 0.20 |
+| Persian Gulf / Hormuz | `persiangulf` | `persiangulf.duckdb` | 6 h | 14 d | 0.50 / 0.30 / 0.20 |
+| Black Sea / Bosphorus | `blacksea` | `blacksea.duckdb` | 6 h | 30 d | 0.45 / 0.35 / 0.20 |
+| Gulf of Aden | `gulfofaden` | `gulfofaden.duckdb` | 6 h | 14 d | 0.50 / 0.30 / 0.20 |
+| Gulf of Guinea | `gulfofguinea` | `gulfofguinea.duckdb` | 6 h | 14 d | 0.50 / 0.30 / 0.20 |
+| Gulf of Mexico | `gulfofmexico` | `gulfofmexico.duckdb` | 6 h | 14 d | 0.50 / 0.30 / 0.20 |
 
 The preset weights are starting points. The pipeline auto-calibrates `w_graph` on every run via `_calibrate_graph_weight()`. Calling `src.score.composite` standalone still requires `--w-graph` (or the new `--auto-calibrate` flag). The calibrated value is printed at the end of Step 8 for reference.
 
@@ -101,7 +105,7 @@ Without `--stream-duration`, non-interactive mode skips live streaming entirely.
 Only available for US-covered regions (Gulf of Mexico and US coastal waters). Repeat for multiple years.
 
 ```bash
-uv run python scripts/run_pipeline.py --region gulf \
+uv run python scripts/run_pipeline.py --region gulfofmexico \
   --non-interactive \
   --marine-cadastre-year 2022 \
   --marine-cadastre-year 2023
@@ -289,9 +293,9 @@ All configurable paths are also settable via environment variables (useful in Do
 PIPELINE_REGION=singapore docker compose run --rm pipeline
 
 # With historical backfill
-PIPELINE_REGION=gulf docker compose run --rm pipeline \
+PIPELINE_REGION=gulfofmexico docker compose run --rm pipeline \
   uv run python scripts/run_pipeline.py \
-  --region gulf --non-interactive \
+  --region gulfofmexico --non-interactive \
   --marine-cadastre-year 2023
 
 # Dashboard only (after pipeline has run)

--- a/docs/prelabel-governance.md
+++ b/docs/prelabel-governance.md
@@ -46,7 +46,7 @@ Every pre-label entry must include:
 | `imo` | IMO number where known |
 | `pre_label` | One of `suspected-positive`, `uncertain`, `analyst-negative` |
 | `confidence_tier` | One of `high`, `medium`, `weak` |
-| `region` | One of `singapore`, `middleeast`, `europe`, `japan`, `gulf` |
+| `region` | One of `singapore`, `middleeast`, `europe`, `japan`, `persiangulf`, `blacksea`, `gulfofaden`, `gulfofguinea`, `gulfofmexico` |
 | `evidence_notes` | Human-readable summary of the evidence basis (mandatory) |
 | `source_urls` | At least one URL or internal report reference for `high`/`medium` labels |
 | `analyst_id` | Analyst identifier (e.g. `analyst-a`) |

--- a/docs/regional-playbooks.md
+++ b/docs/regional-playbooks.md
@@ -203,7 +203,7 @@ Override the bbox to the Gulf of Mexico and Caribbean:
 
 ```bash
 uv run python src/ingest/ais_stream.py \
-  --bbox 8 -98 32 -60 --db data/processed/gulf.duckdb
+  --bbox 8 -98 32 -60 --db data/processed/gulfofmexico.duckdb
 # Gulf of Mexico + Caribbean + Venezuelan approaches
 ```
 
@@ -219,15 +219,15 @@ uv run python src/ingest/ais_stream.py \
 This is the one region where Marine Cadastre is directly useful. Pass `--marine-cadastre-year` to the pipeline, and it runs automatically using the Gulf bounding box:
 
 ```bash
-PIPELINE_REGION=gulf docker compose run --rm pipeline \
+PIPELINE_REGION=gulfofmexico docker compose run --rm pipeline \
   uv run python scripts/run_pipeline.py \
-  --region gulf --non-interactive \
+  --region gulfofmexico --non-interactive \
   --marine-cadastre-year 2023
 
 # Multiple years
-PIPELINE_REGION=gulf docker compose run --rm pipeline \
+PIPELINE_REGION=gulfofmexico docker compose run --rm pipeline \
   uv run python scripts/run_pipeline.py \
-  --region gulf --non-interactive \
+  --region gulfofmexico --non-interactive \
   --marine-cadastre-year 2022 --marine-cadastre-year 2023
 ```
 
@@ -236,9 +236,9 @@ PIPELINE_REGION=gulf docker compose run --rm pipeline \
 Use a shorter window for US coastal traffic — vessels transit faster and more frequently:
 
 ```bash
-DB_PATH=data/processed/gulf.duckdb \
+DB_PATH=data/processed/gulfofmexico.duckdb \
   uv run python src/features/ais_behavior.py \
-  --db data/processed/gulf.duckdb \
+  --db data/processed/gulfofmexico.duckdb \
   --window 14
 ```
 
@@ -248,7 +248,7 @@ For US/OFAC analysis, ownership graph proximity is less discriminating (more ves
 
 ```bash
 uv run python src/score/composite.py \
-  --db data/processed/gulf.duckdb \
+  --db data/processed/gulfofmexico.duckdb \
   --w-anomaly 0.50 --w-graph 0.30 --w-identity 0.20
 ```
 
@@ -278,7 +278,7 @@ WATCHLIST_OUTPUT_PATH=data/processed/gulf_watchlist.parquet \
 
 ```bash
 uv run python src/score/composite.py \
-  --db data/processed/gulf.duckdb \
+  --db data/processed/gulfofmexico.duckdb \
   --w-anomaly 0.50 --w-graph 0.30 --w-identity 0.20
 ```
 
@@ -293,8 +293,8 @@ DB_PATH=data/processed/japansea.duckdb uv run python src/ingest/ais_stream.py \
   --bbox 25 115 48 145 --db data/processed/japansea.duckdb
 
 # Terminal 3 — Gulf
-DB_PATH=data/processed/gulf.duckdb uv run python src/ingest/ais_stream.py \
-  --bbox 8 -98 32 -60 --db data/processed/gulf.duckdb
+DB_PATH=data/processed/gulfofmexico.duckdb uv run python src/ingest/ais_stream.py \
+  --bbox 8 -98 32 -60 --db data/processed/gulfofmexico.duckdb
 ```
 
 Each region gets its own DuckDB file. Run the full feature + scoring pipeline separately for each by passing `--db` to every script.


### PR DESCRIPTION
## Summary
`gulf` was never a valid `run_pipeline.py` preset key — the actual keys are `gulfofmexico`, `persiangulf`, `gulfofaden`, `gulfofguinea`. This fixes all docs that referenced the invalid name and adds missing regions.

## Changes
| File | Fix |
|---|---|
| `pipeline-operations.md` | Replace `gulf` row with all 9 current presets (persiangulf, blacksea, gulfofaden, gulfofguinea, gulfofmexico); fix Marine Cadastre example |
| `local-e2e-test.md` | Expand region list to all valid presets; fix example command |
| `prelabel-governance.md` | Update region enum to match current `PRESETS` |
| `architecture.md` | Remove hardcoded "5 regions" (active CI set changes over time) |
| `regional-playbooks.md` | Replace all `--region gulf` / `gulf.duckdb` with `gulfofmexico` (Gulf of Mexico context throughout) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)