### PR TITLE
docs: label flag_changes_2y as Phase C deferred feature (#296)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,7 +37,8 @@
 **Goal:** Full feature matrix computed for all vessels in the area of interest.
 
 - AIS behavioral features (Polars): `ais_gap_count_30d` (with configurable `--gap-threshold-hours`), `position_jump_count`, `sts_candidate_count`, `loitering_hours_30d` (`src/features/ais_behavior.py`)
-- Identity volatility features: `flag_changes_2y`, `name_changes_2y`, `owner_changes_2y` (`src/features/identity.py`)
+- Identity volatility features: `name_changes_2y`, `owner_changes_2y` (`src/features/identity.py`)
+- **[TODO — Phase C]** `flag_changes_2y` — count of flag-state changes over 24 months. Currently hardcoded to 0 (see `src/features/identity.py`). **Pre-requisite:** ingest historical flag-state records from an external source (e.g., VesselFinder/MarineTraffic historical flag API, or manual EQUASIS export). Once available, remove the `pl.lit(0)` hardcode. See #296.
 - Ownership graph features (Lance Graph + Polars joins): `sanctions_distance`, `cluster_sanctions_ratio` (`src/features/ownership_graph.py`)
 - Trade flow mismatch: `route_cargo_mismatch` (`src/features/trade_mismatch.py`)
 - **[TODO]** GEBCO bathymetric mask (`src/features/bathymetric_mask.py`) — provides higher-precision STS candidate filtering than the current 5nm-from-port heuristic.

--- a/src/features/identity.py
+++ b/src/features/identity.py
@@ -190,7 +190,11 @@ def compute_identity_features(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
     depth_df = _compute_ownership_depth(tables)
     hrisk_df = _compute_high_risk_flag_ratio(tables)
 
-    # flag_changes_2y: from DuckDB vessel_meta (0 where full history unavailable)
+    # flag_changes_2y: hardcoded to 0 — historical flag-state records are not yet
+    # ingested. This is an intentional deferral, not a broken feature.
+    # TODO (Phase C): ingest flag-state history from VesselFinder / MarineTraffic
+    # historical API or manual EQUASIS export, then remove this pl.lit(0) hardcode.
+    # See docs/roadmap.md § A3 and arktrace#296.
     con = duckdb.connect(db_path, read_only=True)
     try:
         meta = con.execute(


### PR DESCRIPTION
Closes #296

## Changes
- **`src/features/identity.py`**: Replaces the single-line comment with a 4-line explanation: intentional deferral, prerequisite (flag-state history ingest), and reference to this issue and roadmap
- **`docs/roadmap.md` § A3**: Adds explicit `[TODO — Phase C]` entry for `flag_changes_2y` with prerequisite sources (VesselFinder/MarineTraffic/EQUASIS) and link to #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)