### PR TITLE
ci(app): fix deploy — use npx wrangler instead of wrangler-action

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -29,15 +29,12 @@ jobs:
 
       - name: Build
         working-directory: app
+        # VITE_MANIFEST_URL left unset so opfs.ts falls back to the R2 URL.
         run: npm run build
-        env:
-          # In production the app fetches from R2, not local fixtures.
-          # Omitting VITE_MANIFEST_URL causes opfs.ts to use the R2 URL.
-          VITE_MANIFEST_URL: ""
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy app/dist --project-name=arktrace --commit-dirty=true
+        working-directory: app
+        run: npx wrangler pages deploy dist --project-name=arktrace --commit-dirty=true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
The `cloudflare/wrangler-action@v3` reference caused a `startup_failure`. Replaced with `npx wrangler pages deploy` run directly — simpler and no action version dependency.