### PR TITLE
ci(app): fix deploy workflow — npx wrangler + pinned action SHAs

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -29,15 +29,12 @@ jobs:
 
       - name: Build
         working-directory: app
+        # VITE_MANIFEST_URL left unset so opfs.ts falls back to the R2 URL.
         run: npm run build
-        env:
-          # In production the app fetches from R2, not local fixtures.
-          # Omitting VITE_MANIFEST_URL causes opfs.ts to use the R2 URL.
-          VITE_MANIFEST_URL: ""
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy app/dist --project-name=arktrace --commit-dirty=true
+        working-directory: app
+        run: npx wrangler pages deploy dist --project-name=arktrace --commit-dirty=true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
Fixes two issues that caused `startup_failure`:
- Replace `cloudflare/wrangler-action@v3` with `npx wrangler pages deploy` (action tag caused startup failure)
- Pin `actions/setup-node` to full SHA (repo policy: all actions must be pinned)