### PR TITLE
feat(app): one-click Claim button on watchlist rows (#328)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -12,7 +12,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { initDuckDB, queryWatchlist, queryMetrics, queryRegions } from "./lib/duckdb";
-import { initReviewSchema, getBulkReviewStates } from "./lib/reviews";
+import { initReviewSchema, getBulkReviewStates, saveReview } from "./lib/reviews";
 import type { DecisionTier, HandoffState } from "./lib/reviews";
 import type { VesselRow, MetricsRow } from "./lib/duckdb";
 import type { AsyncDuckDB, AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
@@ -84,6 +84,35 @@ export default function App() {
     const states = await getBulkReviewStates(conn, vs.map((v) => v.mmsi));
     setReviewStates(states);
   }, [minConfidence, selectedRegion]);
+
+  const handleClaim = useCallback(async (mmsi: string) => {
+    const conn = connRef.current;
+    if (!conn) return;
+    // Optimistic update
+    setReviewStates((prev) => {
+      const next = new Map(prev);
+      const existing = next.get(mmsi);
+      next.set(mmsi, {
+        decision_tier: existing?.decision_tier ?? null,
+        handoff_state: "in_review",
+      });
+      return next;
+    });
+    try {
+      await saveReview(conn, {
+        mmsi,
+        decision_tier: reviewStates.get(mmsi)?.decision_tier ?? null,
+        handoff_state: "in_review",
+        reviewer_id: "analyst",
+        rationale: "",
+        identifier_basis: "mmsi",
+        evidence: [],
+      });
+    } catch {
+      // Roll back on failure
+      await refreshQuery();
+    }
+  }, [reviewStates, refreshQuery]);
 
   // Re-query when filter changes (if data is already loaded)
   useEffect(() => {
@@ -186,6 +215,7 @@ export default function App() {
             reviewStates={reviewStates}
             handoffFilter={handoffFilter}
             onHandoffFilterChange={setHandoffFilter}
+            onClaim={handleClaim}
           />
           {selectedMmsi && (() => {
             const v = vessels.find((v) => v.mmsi === selectedMmsi);

--- a/app/src/components/WatchlistTable.tsx
+++ b/app/src/components/WatchlistTable.tsx
@@ -10,6 +10,7 @@ interface Props {
   reviewStates?: Map<string, { decision_tier: DecisionTier | null; handoff_state: HandoffState }>;
   handoffFilter?: HandoffState | "all";
   onHandoffFilterChange?: (v: HandoffState | "all") => void;
+  onClaim?: (mmsi: string) => void;
 }
 
 function confidenceColor(c: number): string {
@@ -72,8 +73,10 @@ export default function WatchlistTable({
   reviewStates,
   handoffFilter = "all",
   onHandoffFilterChange,
+  onClaim,
 }: Props) {
   const [search, setSearch] = useState("");
+  const [hovered, setHovered] = useState<string | null>(null);
   const selectedRowRef = useRef<HTMLTableRowElement | null>(null);
 
   const filtered = vessels.filter((v) => {
@@ -218,10 +221,12 @@ export default function WatchlistTable({
                   onMouseEnter={(e) => {
                     if (!isSelected)
                       (e.currentTarget as HTMLElement).style.background = "#1e2a3a";
+                    setHovered(v.mmsi);
                   }}
                   onMouseLeave={(e) => {
                     if (!isSelected)
                       (e.currentTarget as HTMLElement).style.background = "transparent";
+                    setHovered(null);
                   }}
                 >
                   <td
@@ -271,8 +276,36 @@ export default function WatchlistTable({
                   >
                     {v.confidence.toFixed(3)}
                   </td>
-                  <td style={{ padding: "0.35rem 0.5rem", color: "#718096" }}>
-                    {v.region || "—"}
+                  <td style={{ padding: "0.35rem 0.5rem", color: "#718096", whiteSpace: "nowrap" }}>
+                    {onClaim && hovered === v.mmsi ? (
+                      (() => {
+                        const isClaimed = rs?.handoff_state === "in_review";
+                        return (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (!isClaimed) onClaim(v.mmsi);
+                            }}
+                            disabled={isClaimed}
+                            style={{
+                              background: isClaimed ? "none" : "#1a3a5c",
+                              border: `1px solid ${isClaimed ? "#2d3748" : "#2b5a8a"}`,
+                              borderRadius: 3,
+                              color: isClaimed ? "#4a5568" : "#93c5fd",
+                              cursor: isClaimed ? "default" : "pointer",
+                              fontSize: "0.6rem",
+                              fontWeight: 600,
+                              padding: "0.1rem 0.4rem",
+                              fontFamily: "ui-monospace,monospace",
+                            }}
+                          >
+                            {isClaimed ? "claimed" : "claim"}
+                          </button>
+                        );
+                      })()
+                    ) : (
+                      v.region || "—"
+                    )}
                   </td>
                 </tr>
               );


### PR DESCRIPTION
## Summary
- Hover over any watchlist row → **"claim"** button appears in the Region cell
- Single click sets `handoff_state = in_review` via a direct DuckDB write (no form needed)
- Optimistic UI update: badge flips immediately; rolls back if the write fails
- Already-claimed rows show a disabled **"claimed"** label on hover

## Test plan
- [ ] Hover over a vessel row → "claim" button appears (region text hides)
- [ ] Click claim → row badge updates to `in_review` immediately (no panel needed)
- [ ] Mouse off then back on → button shows "claimed" (disabled)
- [ ] Open Review panel on that vessel → state shows `in_review`
- [ ] Handoff filter → filter by `in_review` shows the claimed vessel

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)