### PR TITLE
feat(app): humanise vessel detail and dispatch brief (#355)

### DIFF
--- a/app/src/components/DispatchModal.tsx
+++ b/app/src/components/DispatchModal.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import type { VesselRow } from "../lib/duckdb";
+import {
+  formatLastSeen,
+  confidenceTier,
+  confidenceTierColor,
+  signalLabel,
+  signalSeverity,
+  severityColor,
+} from "../lib/humanise";
 
 interface ShapSignal {
   feature: string;
@@ -16,12 +24,6 @@ function parseSignals(raw: string | null | undefined): ShapSignal[] {
   } catch {
     return [];
   }
-}
-
-function confidenceColor(c: number): string {
-  if (c >= 0.75) return "#fc8181";
-  if (c >= 0.5) return "#f6ad55";
-  return "#68d391";
 }
 
 interface Props {
@@ -83,11 +85,18 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
       flag: vessel.flag || null,
       vessel_type: vessel.vessel_type || null,
       confidence: vessel.confidence,
+      confidence_tier: confidenceTier(vessel.confidence),
       region: vessel.region || null,
       last_lat: vessel.last_lat ?? null,
       last_lon: vessel.last_lon ?? null,
       last_seen: vessel.last_seen ?? null,
-      top_signals: signals,
+      top_signals: signals.map((s) => ({
+        feature: s.feature,
+        label: signalLabel(s.feature),
+        value: s.value,
+        severity: signalSeverity(s.feature, s.value),
+        contribution: s.contribution,
+      })),
       analyst_brief: brief || null,
     };
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
@@ -102,7 +111,10 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
   // ── Copy to clipboard ─────────────────────────────────────────────────────
   function handleCopy() {
     const signalLines = signals
-      .map((s) => `- **${s.feature.replace(/_/g, " ")}**: ${s.value ?? "—"} (${(s.contribution * 100).toFixed(0)}%)`)
+      .map((s) => {
+        const sev = signalSeverity(s.feature, s.value);
+        return `- **${signalLabel(s.feature)}**: ${s.value ?? "—"}${sev ? ` [${sev}]` : ""} (${(s.contribution * 100).toFixed(0)}%)`;
+      })
       .join("\n");
 
     const md = [
@@ -113,11 +125,11 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
       `**Flag:** ${vessel.flag || "—"}`,
       `**Type:** ${vessel.vessel_type || "—"}`,
       `**Region:** ${vessel.region || "—"}`,
-      `**Last seen:** ${vessel.last_seen || "—"}`,
+      `**Last seen:** ${formatLastSeen(vessel.last_seen)}`,
       vessel.last_lat != null && vessel.last_lon != null
         ? `**Position:** ${vessel.last_lat.toFixed(4)}°, ${vessel.last_lon.toFixed(4)}°`
         : null,
-      `**Anomaly confidence:** ${vessel.confidence.toFixed(3)}`,
+      `**Anomaly confidence:** ${vessel.confidence.toFixed(3)} — ${confidenceTier(vessel.confidence)}`,
       "",
       signals.length ? `## Top signals\n${signalLines}` : null,
       "",
@@ -132,17 +144,15 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
     navigator.clipboard.writeText(md).catch(() => {/* ignore */});
   }
 
+  const color = confidenceTierColor(vessel.confidence);
+  const tier = confidenceTier(vessel.confidence);
+
   return createPortal(
     <>
       {/* Backdrop */}
       <div
         onClick={onClose}
-        style={{
-          position: "fixed",
-          inset: 0,
-          background: "rgba(0,0,0,0.6)",
-          zIndex: 100,
-        }}
+        style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)", zIndex: 100 }}
       />
 
       {/* Modal */}
@@ -168,38 +178,18 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
         }}
       >
         {/* Header */}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            padding: "0.75rem 1rem",
-            borderBottom: "1px solid #2d3748",
-            flexShrink: 0,
-          }}
-        >
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0.75rem 1rem", borderBottom: "1px solid #2d3748", flexShrink: 0 }}>
           <div>
             <div style={{ fontWeight: 700, fontSize: "0.9rem", color: "#93c5fd" }}>
               Dispatch Brief
             </div>
             <div style={{ fontSize: "0.68rem", color: "#4a5568", marginTop: 2 }}>
               {vessel.vessel_name || vessel.mmsi} · MMSI {vessel.mmsi}
+              {vessel.imo && <span style={{ marginLeft: "0.5rem" }}>· IMO {vessel.imo}</span>}
             </div>
           </div>
-          <button
-            ref={closeRef}
-            onClick={onClose}
-            aria-label="Close dispatch modal"
-            style={{
-              background: "none",
-              border: "none",
-              color: "#4a5568",
-              cursor: "pointer",
-              fontSize: "1.1rem",
-              lineHeight: 1,
-              padding: "0.2rem 0.3rem",
-            }}
-          >
+          <button ref={closeRef} onClick={onClose} aria-label="Close dispatch modal"
+            style={{ background: "none", border: "none", color: "#4a5568", cursor: "pointer", fontSize: "1.1rem", lineHeight: 1, padding: "0.2rem 0.3rem" }}>
             ✕
           </button>
         </div>
@@ -209,19 +199,17 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
 
           {/* Confidence */}
           <div style={{ marginBottom: "0.75rem" }}>
-            <span
-              style={{
-                display: "inline-block",
-                padding: "0.2rem 0.6rem",
-                borderRadius: 4,
-                background: "#1a1f2e",
-                border: `1px solid ${confidenceColor(vessel.confidence)}`,
-                color: confidenceColor(vessel.confidence),
-                fontSize: "0.78rem",
-                fontWeight: 700,
-              }}
-            >
-              confidence {vessel.confidence.toFixed(3)}
+            <span style={{
+              display: "inline-block",
+              padding: "0.2rem 0.6rem",
+              borderRadius: 4,
+              background: "#1a1f2e",
+              border: `1px solid ${color}`,
+              color,
+              fontSize: "0.78rem",
+              fontWeight: 700,
+            }}>
+              {vessel.confidence.toFixed(3)} — {tier}
             </span>
           </div>
 
@@ -229,14 +217,14 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
           <table style={{ borderCollapse: "collapse", width: "100%", marginBottom: "0.75rem" }}>
             <tbody>
               {[
+                vessel.imo ? ["IMO", vessel.imo] : null,
                 ["Flag", vessel.flag],
                 ["Type", vessel.vessel_type],
                 ["Region", vessel.region],
-                ["Last seen", vessel.last_seen],
+                ["Last seen", formatLastSeen(vessel.last_seen)],
                 vessel.last_lat != null && vessel.last_lon != null
                   ? ["Position", `${vessel.last_lat.toFixed(4)}°, ${vessel.last_lon.toFixed(4)}°`]
                   : null,
-                vessel.imo ? ["IMO", vessel.imo] : null,
               ]
                 .filter((r): r is [string, string] => r !== null)
                 .map(([label, val]) => (
@@ -255,26 +243,36 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
           {/* Top signals */}
           {signals.length > 0 && (
             <div style={{ marginBottom: "0.75rem" }}>
-              <div style={{ fontSize: "0.65rem", textTransform: "uppercase", letterSpacing: "0.08em", color: "#4a5568", marginBottom: "0.4rem" }}>
+              <div style={{ fontSize: "0.65rem", textTransform: "uppercase", letterSpacing: "0.08em", color: "#4a5568", marginBottom: "0.5rem" }}>
                 Top signals
               </div>
               {signals.map((s) => {
                 const pct = (s.contribution / maxContrib) * 100;
-                const label = s.feature.replace(/_/g, " ");
+                const label = signalLabel(s.feature);
+                const sev = signalSeverity(s.feature, s.value);
+                const barColor = sev ? severityColor(sev) : "#fc8181";
+                const rawVal = s.value != null ? String(s.value) : "—";
                 return (
-                  <div key={s.feature} title={`${s.feature}: ${s.value ?? "—"}`} style={{ marginBottom: "0.3rem" }}>
-                    <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
-                      <span style={{ fontSize: "0.65rem", color: "#a0aec0", width: 160, flexShrink: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  <div key={s.feature} title={`${s.feature}: ${rawVal}`} style={{ marginBottom: "0.4rem" }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: "0.3rem", marginBottom: "0.15rem" }}>
+                      <span style={{ fontSize: "0.68rem", color: "#a0aec0", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                         {label}
                       </span>
-                      <div style={{ flex: 1, background: "#1a1f2e", borderRadius: 2, height: 6, minWidth: 0 }}>
-                        <div style={{ width: `${pct}%`, background: "#fc8181", height: "100%", borderRadius: 2 }} />
-                      </div>
-                      <span style={{ fontSize: "0.65rem", color: "#718096", minWidth: 28, textAlign: "right" }}>
-                        {(s.contribution * 100).toFixed(0)}%
+                      {sev && (
+                        <span style={{ fontSize: "0.55rem", fontWeight: 700, color: severityColor(sev), border: `1px solid ${severityColor(sev)}`, borderRadius: 2, padding: "0 0.25rem", flexShrink: 0 }}>
+                          {sev}
+                        </span>
+                      )}
+                      <span style={{ fontSize: "0.65rem", color: "#718096", flexShrink: 0 }}>
+                        {rawVal}
                       </span>
-                      <span style={{ fontSize: "0.65rem", color: "#4a5568", minWidth: 32, textAlign: "right" }}>
-                        {s.value ?? "—"}
+                    </div>
+                    <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                      <div style={{ flex: 1, background: "#1a1f2e", borderRadius: 2, height: 5, minWidth: 0 }}>
+                        <div style={{ width: `${pct}%`, background: barColor, height: "100%", borderRadius: 2 }} />
+                      </div>
+                      <span style={{ fontSize: "0.6rem", color: "#4a5568", minWidth: 24, textAlign: "right" }}>
+                        {(s.contribution * 100).toFixed(0)}%
                       </span>
                     </div>
                   </div>
@@ -289,18 +287,7 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
               <div style={{ fontSize: "0.65rem", textTransform: "uppercase", letterSpacing: "0.08em", color: "#4a5568", marginBottom: "0.35rem" }}>
                 Analyst brief
               </div>
-              <div
-                style={{
-                  fontSize: "0.75rem",
-                  color: "#cbd5e0",
-                  lineHeight: 1.6,
-                  padding: "0.5rem 0.7rem",
-                  background: "#1a1f2e",
-                  borderRadius: 4,
-                  border: "1px solid #2d3748",
-                  borderLeft: "3px solid #93c5fd",
-                }}
-              >
+              <div style={{ fontSize: "0.75rem", color: "#cbd5e0", lineHeight: 1.6, padding: "0.5rem 0.7rem", background: "#1a1f2e", borderRadius: 4, border: "1px solid #2d3748", borderLeft: "3px solid #93c5fd" }}>
                 {brief}
               </div>
             </div>
@@ -308,44 +295,11 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
         </div>
 
         {/* Footer actions — hidden in print */}
-        <div
-          id="dispatch-print-footer"
-          style={{
-            display: "flex",
-            gap: "0.5rem",
-            padding: "0.65rem 1rem",
-            borderTop: "1px solid #2d3748",
-            flexShrink: 0,
-          }}
-        >
-          <button
-            onClick={handleExport}
-            style={{
-              background: "#1a3a5c",
-              border: "1px solid #2b5a8a",
-              borderRadius: 4,
-              color: "#93c5fd",
-              cursor: "pointer",
-              fontSize: "0.72rem",
-              fontWeight: 600,
-              padding: "0.3rem 0.75rem",
-            }}
-          >
+        <div id="dispatch-print-footer" style={{ display: "flex", gap: "0.5rem", padding: "0.65rem 1rem", borderTop: "1px solid #2d3748", flexShrink: 0 }}>
+          <button onClick={handleExport} style={{ background: "#1a3a5c", border: "1px solid #2b5a8a", borderRadius: 4, color: "#93c5fd", cursor: "pointer", fontSize: "0.72rem", fontWeight: 600, padding: "0.3rem 0.75rem" }}>
             Export JSON
           </button>
-          <button
-            onClick={handleCopy}
-            style={{
-              background: "none",
-              border: "1px solid #2d3748",
-              borderRadius: 4,
-              color: "#718096",
-              cursor: "pointer",
-              fontSize: "0.72rem",
-              fontWeight: 600,
-              padding: "0.3rem 0.75rem",
-            }}
-          >
+          <button onClick={handleCopy} style={{ background: "none", border: "1px solid #2d3748", borderRadius: 4, color: "#718096", cursor: "pointer", fontSize: "0.72rem", fontWeight: 600, padding: "0.3rem 0.75rem" }}>
             Copy brief
           </button>
           <button
@@ -355,32 +309,11 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
               window.print();
               document.title = prev;
             }}
-            style={{
-              background: "none",
-              border: "1px solid #2d3748",
-              borderRadius: 4,
-              color: "#718096",
-              cursor: "pointer",
-              fontSize: "0.72rem",
-              fontWeight: 600,
-              padding: "0.3rem 0.75rem",
-            }}
+            style={{ background: "none", border: "1px solid #2d3748", borderRadius: 4, color: "#718096", cursor: "pointer", fontSize: "0.72rem", fontWeight: 600, padding: "0.3rem 0.75rem" }}
           >
             Print
           </button>
-          <button
-            onClick={onClose}
-            style={{
-              marginLeft: "auto",
-              background: "none",
-              border: "1px solid #2d3748",
-              borderRadius: 4,
-              color: "#4a5568",
-              cursor: "pointer",
-              fontSize: "0.72rem",
-              padding: "0.3rem 0.75rem",
-            }}
-          >
+          <button onClick={onClose} style={{ marginLeft: "auto", background: "none", border: "1px solid #2d3748", borderRadius: 4, color: "#4a5568", cursor: "pointer", fontSize: "0.72rem", padding: "0.3rem 0.75rem" }}>
             Close
           </button>
         </div>

--- a/app/src/components/DispatchModal.tsx
+++ b/app/src/components/DispatchModal.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import type { VesselRow } from "../lib/duckdb";
+import { getReview, tierColor, handoffLabel } from "../lib/reviews";
+import type { VesselReview } from "../lib/reviews";
 import {
   formatLastSeen,
   confidenceTier,
@@ -29,13 +32,21 @@ function parseSignals(raw: string | null | undefined): ShapSignal[] {
 interface Props {
   vessel: VesselRow;
   brief: string;
+  conn: AsyncDuckDBConnection | null;
   onClose: () => void;
 }
 
-export default function DispatchModal({ vessel, brief, onClose }: Props) {
+export default function DispatchModal({ vessel, brief, conn, onClose }: Props) {
   const signals = parseSignals(vessel.top_signals);
   const maxContrib = signals.length ? Math.max(...signals.map((s) => s.contribution)) : 1;
   const closeRef = useRef<HTMLButtonElement | null>(null);
+  const [review, setReview] = useState<VesselReview | null>(null);
+
+  // Fetch review record on open
+  useEffect(() => {
+    if (!conn) return;
+    getReview(conn, vessel.mmsi).then(setReview).catch(() => {});
+  }, [conn, vessel.mmsi]);
 
   // Focus close button on open; close on Escape; inject print stylesheet
   useEffect(() => {
@@ -98,6 +109,13 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
         contribution: s.contribution,
       })),
       analyst_brief: brief || null,
+      review: review ? {
+        decision_tier: review.decision_tier,
+        handoff_state: review.handoff_state,
+        reviewer_id: review.reviewer_id || null,
+        rationale: review.rationale || null,
+        updated_at: review.updated_at,
+      } : null,
     };
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
@@ -134,6 +152,14 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
       signals.length ? `## Top signals\n${signalLines}` : null,
       "",
       brief ? `## Analyst brief\n${brief}` : null,
+      "",
+      review ? [
+        `## Review decision`,
+        review.decision_tier ? `**Tier:** ${review.decision_tier}` : null,
+        `**Status:** ${handoffLabel(review.handoff_state)}`,
+        review.reviewer_id ? `**Reviewer:** ${review.reviewer_id}` : null,
+        review.rationale ? `**Rationale:** ${review.rationale}` : null,
+      ].filter(Boolean).join("\n") : null,
       "",
       `---`,
       `*Generated ${new Date().toISOString()}*`,
@@ -283,12 +309,53 @@ export default function DispatchModal({ vessel, brief, onClose }: Props) {
 
           {/* Analyst brief */}
           {brief && (
-            <div>
+            <div style={{ marginBottom: "0.75rem" }}>
               <div style={{ fontSize: "0.65rem", textTransform: "uppercase", letterSpacing: "0.08em", color: "#4a5568", marginBottom: "0.35rem" }}>
                 Analyst brief
               </div>
               <div style={{ fontSize: "0.75rem", color: "#cbd5e0", lineHeight: 1.6, padding: "0.5rem 0.7rem", background: "#1a1f2e", borderRadius: 4, border: "1px solid #2d3748", borderLeft: "3px solid #93c5fd" }}>
                 {brief}
+              </div>
+            </div>
+          )}
+
+          {/* Review decision */}
+          {review && (
+            <div>
+              <div style={{ fontSize: "0.65rem", textTransform: "uppercase", letterSpacing: "0.08em", color: "#4a5568", marginBottom: "0.4rem" }}>
+                Review decision
+              </div>
+              <div style={{ background: "#1a1f2e", border: "1px solid #2d3748", borderRadius: 4, padding: "0.5rem 0.7rem" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: review.rationale ? "0.4rem" : 0 }}>
+                  {review.decision_tier && (
+                    <span style={{
+                      display: "inline-block",
+                      padding: "0.1rem 0.4rem",
+                      borderRadius: 3,
+                      fontSize: "0.62rem",
+                      fontWeight: 700,
+                      fontFamily: "ui-monospace,monospace",
+                      background: tierColor(review.decision_tier) + "22",
+                      border: `1px solid ${tierColor(review.decision_tier)}`,
+                      color: tierColor(review.decision_tier),
+                    }}>
+                      {review.decision_tier.toUpperCase()}
+                    </span>
+                  )}
+                  <span style={{ fontSize: "0.72rem", color: "#a0aec0" }}>
+                    {handoffLabel(review.handoff_state)}
+                  </span>
+                  {review.reviewer_id && (
+                    <span style={{ fontSize: "0.65rem", color: "#4a5568", marginLeft: "auto" }}>
+                      {review.reviewer_id}
+                    </span>
+                  )}
+                </div>
+                {review.rationale && (
+                  <div style={{ fontSize: "0.72rem", color: "#cbd5e0", lineHeight: 1.5, borderTop: "1px solid #2d3748", paddingTop: "0.35rem", marginTop: "0.1rem" }}>
+                    {review.rationale}
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/app/src/components/VesselDetail.tsx
+++ b/app/src/components/VesselDetail.tsx
@@ -1,6 +1,14 @@
 import { useState, useEffect, useRef } from "react";
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import type { VesselRow } from "../lib/duckdb";
+import {
+  formatLastSeen,
+  confidenceTier,
+  confidenceTierColor,
+  signalLabel,
+  signalSeverity,
+  severityColor,
+} from "../lib/humanise";
 import ReviewPanel from "./ReviewPanel";
 import DispatchModal from "./DispatchModal";
 
@@ -98,55 +106,33 @@ function ShapBarChart({ raw }: { raw: string | null | undefined }) {
       </div>
       {signals.map((s) => {
         const pct = maxContrib > 0 ? (s.contribution / maxContrib) * 100 : 0;
-        const label = s.feature.replace(/_/g, " ");
+        const label = signalLabel(s.feature);
         const rawVal = s.value != null ? String(s.value) : "—";
+        const sev = signalSeverity(s.feature, s.value);
         return (
           <div
             key={s.feature}
             title={`${s.feature}: ${rawVal}`}
-            style={{ marginBottom: "0.3rem" }}
+            style={{ marginBottom: "0.35rem" }}
           >
-            <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
-              <span
-                style={{
-                  fontSize: "0.65rem",
-                  color: "#a0aec0",
-                  width: 130,
-                  flexShrink: 0,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-              >
+            <div style={{ display: "flex", alignItems: "center", gap: "0.3rem", marginBottom: "0.15rem" }}>
+              <span style={{ fontSize: "0.65rem", color: "#a0aec0", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                 {label}
               </span>
-              <div
-                style={{
-                  flex: 1,
-                  background: "#1a1f2e",
-                  borderRadius: 2,
-                  height: 6,
-                  minWidth: 0,
-                }}
-              >
-                <div
-                  style={{
-                    width: `${pct}%`,
-                    background: "#fc8181",
-                    height: "100%",
-                    borderRadius: 2,
-                  }}
-                />
+              {sev && (
+                <span style={{ fontSize: "0.55rem", fontWeight: 700, color: severityColor(sev), border: `1px solid ${severityColor(sev)}`, borderRadius: 2, padding: "0 0.25rem", flexShrink: 0, fontFamily: "ui-monospace,monospace" }}>
+                  {sev}
+                </span>
+              )}
+              <span style={{ fontSize: "0.65rem", color: "#718096", flexShrink: 0, fontFamily: "ui-monospace,monospace" }}>
+                {rawVal}
+              </span>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+              <div style={{ flex: 1, background: "#1a1f2e", borderRadius: 2, height: 5, minWidth: 0 }}>
+                <div style={{ width: `${pct}%`, background: sev ? severityColor(sev) : "#fc8181", height: "100%", borderRadius: 2 }} />
               </div>
-              <span
-                style={{
-                  fontSize: "0.65rem",
-                  color: "#718096",
-                  minWidth: 28,
-                  textAlign: "right",
-                  fontFamily: "ui-monospace,monospace",
-                }}
-              >
+              <span style={{ fontSize: "0.6rem", color: "#4a5568", minWidth: 24, textAlign: "right", fontFamily: "ui-monospace,monospace" }}>
                 {(s.contribution * 100).toFixed(0)}%
               </span>
             </div>
@@ -183,12 +169,6 @@ const row = (label: string, value: string | number | null | undefined) => (
     </td>
   </tr>
 );
-
-function confidenceColor(c: number): string {
-  if (c >= 0.75) return "#fc8181";
-  if (c >= 0.5) return "#f6ad55";
-  return "#68d391";
-}
 
 export default function VesselDetail({ vessel, conn, onClose, onReviewSaved }: Props) {
   const [reviewOpen, setReviewOpen] = useState(false);
@@ -328,24 +308,25 @@ export default function VesselDetail({ vessel, conn, onClose, onReviewSaved }: P
             padding: "0.2rem 0.6rem",
             borderRadius: 4,
             background: "#1a1f2e",
-            border: `1px solid ${confidenceColor(vessel.confidence)}`,
-            color: confidenceColor(vessel.confidence),
+            border: `1px solid ${confidenceTierColor(vessel.confidence)}`,
+            color: confidenceTierColor(vessel.confidence),
             fontSize: "0.78rem",
-            fontWeight: 600,
+            fontWeight: 700,
             fontFamily: "ui-monospace, monospace",
           }}
         >
-          confidence {vessel.confidence.toFixed(3)}
+          {vessel.confidence.toFixed(3)} — {confidenceTier(vessel.confidence)}
         </span>
       </div>
 
       {/* Details table */}
       <table style={{ borderCollapse: "collapse", width: "100%" }}>
         <tbody>
+          {vessel.imo && row("IMO", vessel.imo)}
           {row("Flag", vessel.flag)}
           {row("Type", vessel.vessel_type)}
           {row("Region", vessel.region)}
-          {row("Last seen", vessel.last_seen)}
+          {row("Last seen", formatLastSeen(vessel.last_seen))}
           {vessel.last_lat != null &&
             vessel.last_lon != null &&
             row(

--- a/app/src/lib/humanise.ts
+++ b/app/src/lib/humanise.ts
@@ -1,0 +1,103 @@
+/**
+ * Human-readable formatting helpers for maritime operational display.
+ * Used in VesselDetail, DispatchModal, and export output.
+ */
+
+// ── Timestamp ────────────────────────────────────────────────────────────────
+
+/** "2026-04-17T12:00:00Z" → "17 Apr 2026 12:00 UTC" */
+export function formatLastSeen(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return iso;
+    return d.toUTCString().replace(/:\d\d GMT$/, " UTC").replace(/^.*, /, "");
+  } catch {
+    return iso;
+  }
+}
+
+// ── Confidence label ─────────────────────────────────────────────────────────
+
+export type ConfidenceTier = "CRITICAL" | "ELEVATED" | "WATCH";
+
+export function confidenceTier(c: number): ConfidenceTier {
+  if (c >= 0.75) return "CRITICAL";
+  if (c >= 0.5) return "ELEVATED";
+  return "WATCH";
+}
+
+export function confidenceTierColor(c: number): string {
+  if (c >= 0.75) return "#fc8181";
+  if (c >= 0.5) return "#f6ad55";
+  return "#68d391";
+}
+
+// ── Signal display names ─────────────────────────────────────────────────────
+
+const SIGNAL_LABELS: Record<string, string> = {
+  high_risk_flag_ratio:            "High-risk flag state",
+  ais_gap_count_30d:               "AIS dark periods (30d)",
+  sanctions_distance:              "Proximity to sanctioned vessel",
+  route_cargo_mismatch:            "Route / cargo mismatch",
+  position_jump_count:             "GPS position jumps",
+  flag_changes_2y:                 "Flag changes (2 years)",
+  sts_hub_degree:                  "Ship-to-ship transfer hub",
+  shared_address_centrality:       "Shared registration address",
+  dark_activity_days:              "AIS dark days",
+  port_state_control_deficiencies: "Port state control deficiencies",
+  behavioral_deviation_score:      "Behavioural deviation",
+  graph_risk_score:                "Network risk score",
+  identity_score:                  "Identity risk score",
+};
+
+export function signalLabel(feature: string): string {
+  return (
+    SIGNAL_LABELS[feature] ??
+    feature
+      .replace(/_/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase())
+  );
+}
+
+// ── Signal severity bands ────────────────────────────────────────────────────
+
+export type Severity = "HIGH" | "ELEVATED" | "LOW";
+
+type SeverityThreshold = { high: number; elevated: number; invert?: boolean };
+
+/** invert=true means lower value = higher risk (e.g. sanctions_distance) */
+const SEVERITY_THRESHOLDS: Record<string, SeverityThreshold> = {
+  high_risk_flag_ratio:            { high: 0.6,  elevated: 0.3 },
+  ais_gap_count_30d:               { high: 8,    elevated: 3 },
+  sanctions_distance:              { high: 1,    elevated: 3,  invert: true },
+  route_cargo_mismatch:            { high: 0.7,  elevated: 0.4 },
+  position_jump_count:             { high: 5,    elevated: 2 },
+  flag_changes_2y:                 { high: 3,    elevated: 1 },
+  sts_hub_degree:                  { high: 5,    elevated: 2 },
+  shared_address_centrality:       { high: 4,    elevated: 2 },
+  dark_activity_days:              { high: 10,   elevated: 4 },
+  port_state_control_deficiencies: { high: 3,    elevated: 1 },
+};
+
+export function signalSeverity(feature: string, value: number | string | null): Severity | null {
+  const thresh = SEVERITY_THRESHOLDS[feature];
+  if (!thresh || value == null) return null;
+  const n = typeof value === "number" ? value : parseFloat(String(value));
+  if (isNaN(n)) return null;
+
+  if (thresh.invert) {
+    if (n <= thresh.high) return "HIGH";
+    if (n <= thresh.elevated) return "ELEVATED";
+    return "LOW";
+  }
+  if (n >= thresh.high) return "HIGH";
+  if (n >= thresh.elevated) return "ELEVATED";
+  return "LOW";
+}
+
+export function severityColor(s: Severity): string {
+  if (s === "HIGH") return "#fc8181";
+  if (s === "ELEVATED") return "#f6ad55";
+  return "#68d391";
+}


### PR DESCRIPTION
## Summary

Addresses the "so what" usability problem in the vessel detail panel and dispatch brief.

### Before → After

| Before | After |
|---|---|
| `2026-04-17T12:00:00Z` | `17 Apr 2026 12:00 UTC` |
| `confidence 0.958` | `0.958 — CRITICAL` |
| `high risk flag ratio` | `High-risk flag state` |
| `0.8` (no context) | `0.8  [HIGH]` with coloured badge |
| IMO buried at bottom | IMO first in details table |
| Red bar for all signals | Bar colour follows severity |

### Changes
- New `humanise.ts`: `formatLastSeen`, `confidenceTier`, `signalLabel`, `signalSeverity`, `severityColor`
- Signal severity bands per feature (e.g. `high_risk_flag_ratio ≥ 0.6 → HIGH`)
- Export JSON now includes `label` and `severity` per signal
- Copy brief markdown uses human labels and `[HIGH]` severity tags
- Applied to VesselDetail, DispatchModal, and exported JSON

## Test plan
- [ ] Select a high-confidence vessel — timestamp shows "17 Apr 2026 12:00 UTC", confidence shows "0.958 — CRITICAL"
- [ ] Top signals: human labels, HIGH/ELEVATED/LOW badge, bar colour matches severity
- [ ] Open Dispatch Brief → same display, IMO at top of details
- [ ] Export JSON → signals include `label` and `severity` fields
- [ ] Copy brief → markdown uses human labels and `[HIGH]` tags

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)