### PR TITLE
feat(app): UX-08 — outcome logging UI for handoff_completed vessels

### DIFF
--- a/app/src/components/ReviewPanel.tsx
+++ b/app/src/components/ReviewPanel.tsx
@@ -5,6 +5,7 @@ import {
   getReview,
   getEvidence,
   saveReview,
+  saveOutcome,
   tierColor,
   handoffLabel,
   validateTransition,
@@ -12,6 +13,7 @@ import {
   HANDOFF_STATES,
   type DecisionTier,
   type HandoffState,
+  type OutcomeValue,
   type EvidenceRef,
 } from "../lib/reviews";
 
@@ -71,6 +73,14 @@ export default function ReviewPanel({ vessel, conn, onSaved }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
+  // Outcome form state (visible only when handoff_state === 'handoff_completed')
+  const [outcome, setOutcome] = useState<OutcomeValue>("Confirmed");
+  const [outcomeNotes, setOutcomeNotes] = useState("");
+  const [officerId, setOfficerId] = useState(getReviewerId());
+  const [outcomeError, setOutcomeError] = useState<string | null>(null);
+  const [outcomeSuccess, setOutcomeSuccess] = useState(false);
+  const [savingOutcome, setSavingOutcome] = useState(false);
+
   // Form state
   const [tier, setTier] = useState<DecisionTier | "">("");
   const [handoffState, setHandoffState] = useState<HandoffState>("queued_review");
@@ -118,7 +128,35 @@ export default function ReviewPanel({ vessel, conn, onSaved }: Props) {
     load();
     setError(null);
     setSuccess(false);
+    setOutcomeError(null);
+    setOutcomeSuccess(false);
+    setOutcomeNotes("");
   }, [load]);
+
+  const handleLogOutcome = async () => {
+    setOutcomeError(null);
+    if (!outcomeNotes.trim()) {
+      setOutcomeError("Outcome notes are required before logging.");
+      return;
+    }
+    setSavingOutcome(true);
+    try {
+      await saveOutcome(conn, {
+        mmsi: vessel.mmsi,
+        outcome,
+        outcome_notes: outcomeNotes,
+        officer_id: officerId,
+      });
+      setHandoffState("closed");
+      setOutcomeSuccess(true);
+      setTimeout(() => setOutcomeSuccess(false), 2500);
+      onSaved?.();
+    } catch (err) {
+      setOutcomeError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSavingOutcome(false);
+    }
+  };
 
   const addEvidence = () =>
     setEvidence((ev) => [
@@ -425,6 +463,116 @@ export default function ReviewPanel({ vessel, conn, onSaved }: Props) {
       >
         {saving ? "Saving…" : "Save review"}
       </button>
+
+      {/* ── Patrol outcome (handoff_completed only) ─────────────────────── */}
+      {handoffState === "handoff_completed" && (
+        <div style={{ marginTop: "0.85rem", borderTop: "1px solid #2d3748", paddingTop: "0.75rem" }}>
+          <div style={{
+            fontSize: "0.65rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+            color: "#f6ad55",
+            marginBottom: "0.6rem",
+            display: "flex",
+            alignItems: "center",
+            gap: "0.4rem",
+          }}>
+            <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#f6ad55", display: "inline-block" }} />
+            Patrol outcome
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.6rem", marginBottom: "0.6rem" }}>
+            <div>
+              {label("Outcome")}
+              <select
+                value={outcome}
+                onChange={(e) => setOutcome(e.target.value as OutcomeValue)}
+                style={{
+                  ...selectStyle,
+                  color: outcome === "Confirmed" ? "#fc8181" : outcome === "Cleared" ? "#68d391" : "#718096",
+                  borderColor: outcome === "Confirmed" ? "#fc8181" : outcome === "Cleared" ? "#68d391" : "#2d3748",
+                }}
+              >
+                <option value="Confirmed">Confirmed</option>
+                <option value="Cleared">Cleared</option>
+                <option value="Inconclusive">Inconclusive</option>
+              </select>
+            </div>
+            <div>
+              {label("Officer ID")}
+              <input
+                value={officerId}
+                onChange={(e) => setOfficerId(e.target.value)}
+                style={inputStyle}
+                placeholder="officer-id"
+              />
+            </div>
+          </div>
+
+          <div style={{ marginBottom: "0.6rem" }}>
+            {label("Outcome notes (required)")}
+            <textarea
+              value={outcomeNotes}
+              onChange={(e) => setOutcomeNotes(e.target.value)}
+              rows={3}
+              placeholder="Describe the patrol findings and result…"
+              style={{
+                ...inputStyle,
+                resize: "vertical",
+                minHeight: "3.5rem",
+                fontFamily: "inherit",
+                lineHeight: 1.5,
+                borderColor: !outcomeNotes.trim() && outcomeError ? "#fc8181" : "#2d3748",
+              }}
+            />
+          </div>
+
+          {outcomeError && (
+            <div style={{
+              fontSize: "0.72rem",
+              color: "#f6ad55",
+              background: "#1a1209",
+              border: "1px solid #744210",
+              borderRadius: 4,
+              padding: "0.3rem 0.5rem",
+              marginBottom: "0.5rem",
+            }}>
+              {outcomeError}
+            </div>
+          )}
+          {outcomeSuccess && (
+            <div style={{
+              fontSize: "0.72rem",
+              color: "#68d391",
+              background: "#0a1f0f",
+              border: "1px solid #276749",
+              borderRadius: 4,
+              padding: "0.3rem 0.5rem",
+              marginBottom: "0.5rem",
+            }}>
+              Outcome logged — vessel closed.
+            </div>
+          )}
+
+          <button
+            onClick={handleLogOutcome}
+            disabled={savingOutcome}
+            style={{
+              width: "100%",
+              background: savingOutcome ? "#2d3748" : "#1a2a0a",
+              border: "1px solid #4a6a1a",
+              borderRadius: 4,
+              color: savingOutcome ? "#718096" : "#a0d060",
+              cursor: savingOutcome ? "not-allowed" : "pointer",
+              fontSize: "0.75rem",
+              fontWeight: 600,
+              padding: "0.4rem",
+            }}
+          >
+            {savingOutcome ? "Logging…" : "Log outcome → close case"}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/lib/reviews.ts
+++ b/app/src/lib/reviews.ts
@@ -30,6 +30,8 @@ export type HandoffState =
   | "handoff_completed"
   | "closed";
 
+export type OutcomeValue = "Confirmed" | "Cleared" | "Inconclusive";
+
 export interface EvidenceRef {
   id: string;
   mmsi: string;
@@ -46,6 +48,9 @@ export interface VesselReview {
   reviewer_id: string;
   rationale: string;
   identifier_basis: string;
+  outcome: OutcomeValue | null;
+  outcome_notes: string | null;
+  officer_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -79,6 +84,15 @@ export async function initReviewSchema(
       created_at       TIMESTAMP DEFAULT now()
     )
   `);
+
+  // Migrate: add outcome columns to existing tables (no-op if already present)
+  for (const col of [
+    "ALTER TABLE vessel_reviews ADD COLUMN IF NOT EXISTS outcome TEXT",
+    "ALTER TABLE vessel_reviews ADD COLUMN IF NOT EXISTS outcome_notes TEXT",
+    "ALTER TABLE vessel_reviews ADD COLUMN IF NOT EXISTS officer_id TEXT",
+  ]) {
+    try { await conn.query(col); } catch { /* column already exists */ }
+  }
 
   await conn.query(`
     CREATE TABLE IF NOT EXISTS vessel_reviews_audit (
@@ -219,6 +233,53 @@ export async function saveReview(
         '${esc(ev.url)}',
         '${esc(ev.publication_date)}',
         '${esc(ev.credibility)}'
+      )
+    `);
+  }
+}
+
+export interface SaveOutcomeInput {
+  mmsi: string;
+  outcome: OutcomeValue;
+  outcome_notes: string;
+  officer_id: string;
+}
+
+/** Log patrol outcome for a handoff_completed vessel and transition to closed. */
+export async function saveOutcome(
+  conn: AsyncDuckDBConnection,
+  input: SaveOutcomeInput
+): Promise<void> {
+  const existing = await getReview(conn, input.mmsi);
+  const fromState = existing?.handoff_state ?? null;
+
+  await conn.query(`
+    INSERT INTO vessel_reviews_audit (mmsi, reviewer_id, from_state, to_state, rationale)
+    VALUES (
+      '${esc(input.mmsi)}',
+      '${esc(input.officer_id)}',
+      ${fromState ? `'${esc(fromState)}'` : "NULL"},
+      'closed',
+      '${esc(`Outcome: ${input.outcome}. ${input.outcome_notes}`)}'
+    )
+  `);
+
+  if (existing) {
+    await conn.query(`
+      UPDATE vessel_reviews SET
+        outcome        = '${esc(input.outcome)}',
+        outcome_notes  = '${esc(input.outcome_notes)}',
+        officer_id     = '${esc(input.officer_id)}',
+        handoff_state  = 'closed',
+        updated_at     = now()
+      WHERE mmsi = '${esc(input.mmsi)}'
+    `);
+  } else {
+    await conn.query(`
+      INSERT INTO vessel_reviews (mmsi, handoff_state, reviewer_id, rationale, identifier_basis, outcome, outcome_notes, officer_id)
+      VALUES (
+        '${esc(input.mmsi)}', 'closed', '${esc(input.officer_id)}', '', 'MMSI',
+        '${esc(input.outcome)}', '${esc(input.outcome_notes)}', '${esc(input.officer_id)}'
       )
     `);
   }


### PR DESCRIPTION
## Summary

Adds a **Patrol outcome** section to the Review Panel, visible only when `handoff_state === handoff_completed`:

- **Outcome** dropdown: Confirmed (red) / Cleared (green) / Inconclusive (grey)
- **Outcome notes** textarea — required before submission, red border hint if empty
- **Officer ID** field — auto-populated from localStorage session ID, editable
- **"Log outcome → close case"** button — writes outcome + notes + officer, transitions vessel to `closed`, appends audit row

## Schema changes (backward-compatible)

`initReviewSchema` now runs `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for `outcome`, `outcome_notes`, and `officer_id`. Existing review rows are unaffected.

New `saveOutcome()` helper in `reviews.ts` encapsulates the write.

## Test plan

- [ ] `npm run dev` → Sync → select a vessel
- [ ] Open Review panel → set handoff state to `handoff_completed` → Save review
- [ ] **Patrol outcome** section appears below the Save button (amber dot header)
- [ ] Click "Log outcome" without notes → error message shown
- [ ] Fill in notes → click "Log outcome → close case" → success toast, vessel badge flips to `closed`
- [ ] Reopen the vessel → handoff state shows `closed`, outcome section hidden

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)