### PR TITLE
fix(app): show 'LLM offline' on Safari instead of 'Brief unavailable'

### DIFF
--- a/app/src/components/VesselDetail.tsx
+++ b/app/src/components/VesselDetail.tsx
@@ -221,16 +221,14 @@ export default function VesselDetail({ vessel, conn, onClose, onReviewSaved }: P
         setBrief(text);
         setBriefStatus("ready");
         if (conn && text) await saveCachedBrief(conn, vessel.mmsi, text);
-      } catch (err: unknown) {
+      } catch {
         clearTimeout(timeout);
         if (ac.signal.aborted) return;
-        const msg = err instanceof Error ? err.message : String(err);
-        const isOffline =
-          msg.includes("Failed to fetch") ||
-          msg.includes("fetch") ||
-          msg.includes("ECONNREFUSED") ||
-          msg.includes("NetworkError");
-        setBriefStatus(isOffline ? "offline" : "error");
+        // Any error here is a connection failure (HTTP errors are thrown
+        // explicitly by fetchBrief before this catch). Show offline for all
+        // browsers — Safari throws "Load failed", Chrome "Failed to fetch",
+        // Firefox "NetworkError"; string-matching is fragile and unnecessary.
+        setBriefStatus("offline");
       }
     }
 
@@ -253,16 +251,10 @@ export default function VesselDetail({ vessel, conn, onClose, onReviewSaved }: P
       setBrief(text);
       setBriefStatus("ready");
       await saveCachedBrief(conn, vessel.mmsi, text);
-    } catch (err: unknown) {
+    } catch {
       clearTimeout(timeout);
       if (ac.signal.aborted) return;
-      const msg = err instanceof Error ? err.message : String(err);
-      const isOffline =
-        msg.includes("Failed to fetch") ||
-        msg.includes("fetch") ||
-        msg.includes("ECONNREFUSED") ||
-        msg.includes("NetworkError");
-      setBriefStatus(isOffline ? "offline" : "error");
+      setBriefStatus("offline");
     }
   }
 


### PR DESCRIPTION
## Bug

On Safari, the Analyst Brief showed **"Brief unavailable"** instead of **"Local LLM offline"** when `localhost:8080` is unreachable.

## Root cause

The error classifier matched known message strings:
- Chrome: `"Failed to fetch"`
- Firefox: `"NetworkError"`
- **Safari: `"Load failed"` ← not matched → fell through to `"error"` state**

## Fix

`fetchBrief()` already throws an explicit `Error("HTTP N")` for non-2xx responses before the catch. Any error that reaches the catch block is therefore a **connection failure**, not an HTTP error. Remove the string-matching entirely and always set `briefStatus("offline")`.

Same fix applied to both `loadBrief` (initial load) and `handleRegenerate`.

## Browsers tested by design

| Browser | Old error | Shows offline? |
|---|---|---|
| Chrome | `Failed to fetch` | ✓ (was already matched) |
| Firefox | `NetworkError when…` | ✓ (was already matched) |
| **Safari** | **`Load failed`** | ✓ **now fixed** |
| Any future browser | any | ✓ (no string matching) |

Fixes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)