### PR TITLE
fix(pipeline): raise AIS gap threshold 6h → 10h (#199)

### DIFF
--- a/pipeline/src/features/ais_behavior.py
+++ b/pipeline/src/features/ais_behavior.py
@@ -24,7 +24,10 @@ load_dotenv()
 
 DEFAULT_DB_PATH = os.getenv("DB_PATH", "data/processed/mpol.duckdb")
 
-GAP_THRESHOLD_H = 6  # gaps longer than this (hours) are anomalous
+GAP_THRESHOLD_H = 10  # gaps longer than this (hours) are anomalous
+# Raised from 6h → 10h: Singapore/Malacca anchorage wait times are 8-12h
+# (normal commercial behaviour).  Genuine shadow-fleet dark periods are
+# 12-48h (STS transfer duration) so real evasion is still captured.
 JUMP_SPEED_KNOTS = 50.0  # implied speed above this = GPS spoofing
 LOITER_SPEED_KNOTS = 2.0  # SOG below this (outside port) = loitering
 H3_RESOLUTION = 8  # ~0.7 km cell edge ≈ 0.5 nm for STS detection

--- a/pipeline/src/features/sar_detections.py
+++ b/pipeline/src/features/sar_detections.py
@@ -48,7 +48,8 @@ MATCH_RADIUS_KM: float = 5.0  # AIS broadcast within this radius = matched
 MATCH_WINDOW_MINUTES: int = 60  # and within this time window
 
 # Gap & attribution parameters
-GAP_THRESHOLD_H: float = 6.0  # gaps longer than this (hours) are considered dark periods
+GAP_THRESHOLD_H: float = 10.0  # gaps longer than this (hours) are considered dark periods
+# Raised from 6h → 10h: matches ais_behavior.py; Singapore anchorage waits are 8-12h normal.
 ATTRIBUTION_RADIUS_KM: float = 50.0  # last known position must be within this of detection
 
 


### PR DESCRIPTION
## Summary
- Raises `GAP_THRESHOLD_H` from `6.0` → `10.0` in both `ais_behavior.py` and `sar_detections.py`
- Singapore/Malacca anchorage wait times are 8-12h normal commercial behaviour — 6h threshold was generating false positives for legitimate vessels
- Genuine shadow-fleet dark periods are 12-48h (STS transfer duration), so real evasion is still captured at the new threshold

## Test plan
- [ ] Run `uv run python src/features/ais_behavior.py --db data/processed/mpol.duckdb` — `ais_gap_count_30d` counts should drop for Singapore-area vessels
- [ ] Run `uv run python src/features/sar_detections.py` — dark period counts should be lower for legitimate tankers in Strait of Malacca
- [ ] Verify that known DPRK/Iran shadow-fleet vessels (12-48h gaps) still appear in gap feature output

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)