### PR TITLE
feat(app): region picker — choose download region, default Singapore (#378)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,6 +27,7 @@ import VesselDetail from "./components/VesselDetail";
 import VesselMap from "./components/VesselMap";
 import SyncStatusBar from "./components/SyncStatus";
 import AlertDrawer from "./components/AlertDrawer";
+import RegionPicker, { getStoredRegion, setStoredRegion, KNOWN_REGIONS, DEFAULT_REGION } from "./components/RegionPicker";
 
 export default function App() {
   const dbRef = useRef<AsyncDuckDB | null>(null);
@@ -37,7 +38,14 @@ export default function App() {
   const [vessels, setVessels] = useState<VesselRow[]>([]);
   const [metrics, setMetrics] = useState<MetricsRow | null>(null);
   const [regions, setRegions] = useState<string[]>([]);
-  const [selectedRegion, setSelectedRegion] = useState<string>("all");
+  // Persist region choice in localStorage; default to Singapore on first visit.
+  const [selectedRegion, setSelectedRegion] = useState<string>(
+    () => getStoredRegion() ?? DEFAULT_REGION
+  );
+  // Show region picker overlay on first visit (no stored preference yet).
+  const [showRegionPicker, setShowRegionPicker] = useState<boolean>(
+    () => getStoredRegion() === null
+  );
   const [selectedMmsi, setSelectedMmsi] = useState<string | null>(null);
   const [minConfidence, setMinConfidence] = useState(0.4);
   const [reviewStates, setReviewStates] = useState<Map<string, { decision_tier: DecisionTier | null; handoff_state: HandoffState }>>(new Map());
@@ -58,7 +66,10 @@ export default function App() {
         connRef.current = conn;
         await initReviewSchema(conn);
         await initBriefCache(conn);
-        await doSync(db);
+        // Skip auto-sync if the region picker is waiting for user input.
+        if (!showRegionPicker) {
+          await doSync(db);
+        }
       } catch (err) {
         if (!cancelled) setInitError(String(err));
       }
@@ -67,16 +78,21 @@ export default function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const doSync = useCallback(async (db?: AsyncDuckDB) => {
+  const doSync = useCallback(async (db?: AsyncDuckDB, region?: string) => {
     const target = db ?? dbRef.current;
     if (!target) return;
+    const activeRegion = region ?? selectedRegion;
+    // Pass region as a single-element list so syncAndLoad can filter
+    // region-tagged manifest files.  Currently manifest files have no region
+    // tags (combined dataset), so this is a no-op until the pipeline adds them.
+    const regionFilter = activeRegion !== "all" ? [activeRegion] : undefined;
     setSyncStatus({ phase: "fetching_manifest" });
-    const loaded = await syncAndLoad(target, setSyncStatus);
+    const loaded = await syncAndLoad(target, setSyncStatus, regionFilter);
     if (loaded > 0 && connRef.current) {
       await refreshQuery();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [selectedRegion]);
 
   const refreshQuery = useCallback(async () => {
     const conn = connRef.current;
@@ -166,7 +182,11 @@ export default function App() {
         {/* Region selector */}
         <select
           value={selectedRegion}
-          onChange={(e) => setSelectedRegion(e.target.value)}
+          onChange={(e) => {
+            const r = e.target.value;
+            setStoredRegion(r === "all" ? "all" : r);
+            setSelectedRegion(r);
+          }}
           style={{
             background: "#0f1117",
             border: "1px solid #2d3748",
@@ -177,9 +197,16 @@ export default function App() {
           }}
         >
           <option value="all">All regions</option>
-          {regions.map((r) => (
-            <option key={r} value={r}>{r}</option>
+          {/* Show known regions even before data loads so users can switch */}
+          {KNOWN_REGIONS.map((r) => (
+            <option key={r.id} value={r.id}>{r.label}</option>
           ))}
+          {/* Also include any regions from live data not in the known list */}
+          {regions
+            .filter((r) => !KNOWN_REGIONS.some((k) => k.id === r))
+            .map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
         </select>
 
         {/* Confidence filter */}
@@ -273,6 +300,17 @@ export default function App() {
           onClose={() => setAlertDrawerOpen(false)}
           onSelectVessel={(mmsi) => setSelectedMmsi(mmsi)}
           onAlertsChange={setAlerts}
+        />
+      )}
+
+      {/* Region picker — shown on first visit before any data is downloaded */}
+      {showRegionPicker && (
+        <RegionPicker
+          onConfirm={(region) => {
+            setSelectedRegion(region);
+            setShowRegionPicker(false);
+            doSync(undefined, region);
+          }}
         />
       )}
     </div>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,7 +27,7 @@ import VesselDetail from "./components/VesselDetail";
 import VesselMap from "./components/VesselMap";
 import SyncStatusBar from "./components/SyncStatus";
 import AlertDrawer from "./components/AlertDrawer";
-import RegionPicker, { getStoredRegion, setStoredRegion, KNOWN_REGIONS, DEFAULT_REGION } from "./components/RegionPicker";
+import RegionPicker, { getStoredRegions, formatRegionLabel, DEFAULT_REGIONS } from "./components/RegionPicker";
 
 export default function App() {
   const dbRef = useRef<AsyncDuckDB | null>(null);
@@ -37,14 +37,14 @@ export default function App() {
   const [syncStatus, setSyncStatus] = useState<SyncStatus>({ phase: "idle" });
   const [vessels, setVessels] = useState<VesselRow[]>([]);
   const [metrics, setMetrics] = useState<MetricsRow | null>(null);
-  const [regions, setRegions] = useState<string[]>([]);
-  // Persist region choice in localStorage; default to Singapore on first visit.
-  const [selectedRegion, setSelectedRegion] = useState<string>(
-    () => getStoredRegion() ?? DEFAULT_REGION
+  const [, setRegions] = useState<string[]>([]);
+  // Persist region list in localStorage; default to Singapore on first visit.
+  const [selectedRegions, setSelectedRegions] = useState<string[]>(
+    () => getStoredRegions() ?? DEFAULT_REGIONS
   );
   // Show region picker overlay on first visit (no stored preference yet).
   const [showRegionPicker, setShowRegionPicker] = useState<boolean>(
-    () => getStoredRegion() === null
+    () => getStoredRegions() === null
   );
   const [selectedMmsi, setSelectedMmsi] = useState<string | null>(null);
   const [minConfidence, setMinConfidence] = useState(0.4);
@@ -78,28 +78,27 @@ export default function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const doSync = useCallback(async (db?: AsyncDuckDB, region?: string) => {
+  const doSync = useCallback(async (db?: AsyncDuckDB, regions?: string[]) => {
     const target = db ?? dbRef.current;
     if (!target) return;
-    const activeRegion = region ?? selectedRegion;
-    // Pass region as a single-element list so syncAndLoad can filter
-    // region-tagged manifest files.  Currently manifest files have no region
-    // tags (combined dataset), so this is a no-op until the pipeline adds them.
-    const regionFilter = activeRegion !== "all" ? [activeRegion] : undefined;
+    const activeRegions = regions ?? selectedRegions;
+    // Pass region list so syncAndLoad can filter region-tagged manifest files.
+    // Currently manifest files have no region tags (combined dataset), so this
+    // is a no-op until the pipeline adds them.
+    const regionFilter = activeRegions.length > 0 ? activeRegions : undefined;
     setSyncStatus({ phase: "fetching_manifest" });
     const loaded = await syncAndLoad(target, setSyncStatus, regionFilter);
     if (loaded > 0 && connRef.current) {
       await refreshQuery();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedRegion]);
+  }, [selectedRegions]);
 
   const refreshQuery = useCallback(async () => {
     const conn = connRef.current;
     if (!conn) return;
-    const region = selectedRegion === "all" ? undefined : selectedRegion;
     const [vs, m, rs, sh] = await Promise.all([
-      queryWatchlist(conn, { minConfidence, region }),
+      queryWatchlist(conn, { minConfidence, regions: selectedRegions.length > 0 ? selectedRegions : undefined }),
       queryMetrics(conn),
       queryRegions(conn),
       queryScoreHistoryBulk(conn),
@@ -113,7 +112,7 @@ export default function App() {
     setRegions(rs);
     const states = await getBulkReviewStates(conn, vs.map((v) => v.mmsi));
     setReviewStates(states);
-  }, [minConfidence, selectedRegion]);
+  }, [minConfidence, selectedRegions]);
 
   const handleClaim = useCallback(async (mmsi: string) => {
     const conn = connRef.current;
@@ -150,7 +149,7 @@ export default function App() {
       refreshQuery();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [minConfidence, selectedRegion]);
+  }, [minConfidence, selectedRegions]);
 
   if (initError) {
     return (
@@ -179,35 +178,26 @@ export default function App() {
           MPOL Watchlist
         </h1>
 
-        {/* Region selector */}
-        <select
-          value={selectedRegion}
-          onChange={(e) => {
-            const r = e.target.value;
-            setStoredRegion(r === "all" ? "all" : r);
-            setSelectedRegion(r);
-          }}
+        {/* Region selector — shows active regions; click to edit */}
+        <button
+          onClick={() => setShowRegionPicker(true)}
+          title="Change regions"
           style={{
             background: "#0f1117",
             border: "1px solid #2d3748",
             color: "#e2e8f0",
-            padding: "0.25rem 0.5rem",
+            padding: "0.25rem 0.6rem",
             borderRadius: 4,
             fontSize: "0.78rem",
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            gap: "0.35rem",
           }}
         >
-          <option value="all">All regions</option>
-          {/* Show known regions even before data loads so users can switch */}
-          {KNOWN_REGIONS.map((r) => (
-            <option key={r.id} value={r.id}>{r.label}</option>
-          ))}
-          {/* Also include any regions from live data not in the known list */}
-          {regions
-            .filter((r) => !KNOWN_REGIONS.some((k) => k.id === r))
-            .map((r) => (
-              <option key={r} value={r}>{r}</option>
-            ))}
-        </select>
+          {formatRegionLabel(selectedRegions)}
+          <span style={{ color: "#4a5568", fontSize: "0.65rem" }}>▾</span>
+        </button>
 
         {/* Confidence filter */}
         <label style={{ display: "flex", alignItems: "center", gap: "0.4rem", fontSize: "0.75rem", color: "#a0aec0" }}>
@@ -262,7 +252,7 @@ export default function App() {
             handoffFilter={handoffFilter}
             onHandoffFilterChange={setHandoffFilter}
             onClaim={handleClaim}
-            exportRegion={selectedRegion}
+            exportRegion={selectedRegions.join("_") || "all"}
             scoreHistory={scoreHistory}
           />
           {selectedMmsi && (() => {
@@ -303,14 +293,21 @@ export default function App() {
         />
       )}
 
-      {/* Region picker — shown on first visit before any data is downloaded */}
+      {/* Region picker — shown on first visit or when user clicks the header button */}
       {showRegionPicker && (
         <RegionPicker
-          onConfirm={(region) => {
-            setSelectedRegion(region);
+          initial={selectedRegions}
+          onConfirm={(regions) => {
+            setSelectedRegions(regions);
             setShowRegionPicker(false);
-            doSync(undefined, region);
+            // Re-sync only if this is the first load (no data yet)
+            if (syncStatus.phase === "idle") {
+              doSync(undefined, regions);
+            } else {
+              refreshQuery();
+            }
           }}
+          onCancel={syncStatus.phase !== "idle" ? () => setShowRegionPicker(false) : undefined}
         />
       )}
     </div>

--- a/app/src/components/RegionPicker.tsx
+++ b/app/src/components/RegionPicker.tsx
@@ -1,6 +1,6 @@
 /**
  * RegionPicker — full-screen overlay shown on first install (empty OPFS).
- * User picks which region to download; defaults to Singapore.
+ * User picks one or more regions to download; defaults to Singapore.
  * Choice is persisted to localStorage and not shown again unless reset.
  */
 
@@ -21,40 +21,72 @@ export const KNOWN_REGIONS = [
 
 export type RegionId = (typeof KNOWN_REGIONS)[number]["id"];
 
-export const STORAGE_KEY = "arktrace.region";
-export const DEFAULT_REGION: RegionId = "singapore";
+export const STORAGE_KEY = "arktrace.regions";
+export const DEFAULT_REGIONS: RegionId[] = ["singapore"];
 
-/** Read persisted region preference, or null if not yet chosen. */
-export function getStoredRegion(): string | null {
+/** Read persisted region list, or null if not yet chosen. */
+export function getStoredRegions(): string[] | null {
   try {
-    return localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) && parsed.length > 0 ? parsed : null;
   } catch {
     return null;
   }
 }
 
-/** Persist region preference. */
-export function setStoredRegion(region: string): void {
+/** Persist region list. */
+export function setStoredRegions(regions: string[]): void {
   try {
-    localStorage.setItem(STORAGE_KEY, region);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(regions));
   } catch {
     // localStorage unavailable — ignore
   }
 }
 
-interface Props {
-  onConfirm: (region: string) => void;
+/** Format a region list for display in the header (max 2 names then "+N"). */
+export function formatRegionLabel(regions: string[]): string {
+  if (regions.length === 0) return "No region";
+  const names = regions.map(
+    (id) => KNOWN_REGIONS.find((r) => r.id === id)?.label ?? id
+  );
+  if (names.length <= 2) return names.join(", ");
+  return `${names.slice(0, 2).join(", ")} +${names.length - 2}`;
 }
 
-export default function RegionPicker({ onConfirm }: Props) {
-  const [selected, setSelected] = useState<string>(DEFAULT_REGION);
+interface Props {
+  initial?: string[];
+  onConfirm: (regions: string[]) => void;
+  onCancel?: () => void;
+}
+
+export default function RegionPicker({ initial, onConfirm, onCancel }: Props) {
+  const [selected, setSelected] = useState<Set<string>>(
+    new Set(initial ?? DEFAULT_REGIONS)
+  );
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        // Keep at least one region selected
+        if (next.size > 1) next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  const selectedList = Array.from(selected);
 
   return (
     <div
       style={{
         position: "fixed",
         inset: 0,
-        background: "#0f1117",
+        background: "rgba(15,17,23,0.92)",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
@@ -67,7 +99,7 @@ export default function RegionPicker({ onConfirm }: Props) {
           border: "1px solid #2d3748",
           borderRadius: 8,
           padding: "2rem",
-          width: 400,
+          width: 420,
           maxWidth: "90vw",
         }}
       >
@@ -79,7 +111,7 @@ export default function RegionPicker({ onConfirm }: Props) {
             marginBottom: "0.25rem",
           }}
         >
-          Select region
+          Select regions
         </h2>
         <p
           style={{
@@ -88,7 +120,7 @@ export default function RegionPicker({ onConfirm }: Props) {
             marginBottom: "1.25rem",
           }}
         >
-          Choose which region to download. You can change this later.
+          Choose one or more regions to download. You can change this later.
         </p>
 
         <div
@@ -99,45 +131,82 @@ export default function RegionPicker({ onConfirm }: Props) {
             marginBottom: "1.5rem",
           }}
         >
-          {KNOWN_REGIONS.map((r) => (
-            <button
-              key={r.id}
-              onClick={() => setSelected(r.id)}
-              style={{
-                padding: "0.5rem 0.75rem",
-                borderRadius: 4,
-                border: `1px solid ${selected === r.id ? "#3b82f6" : "#2d3748"}`,
-                background: selected === r.id ? "#1e3a5f" : "#0f1117",
-                color: selected === r.id ? "#93c5fd" : "#a0aec0",
-                fontSize: "0.75rem",
-                cursor: "pointer",
-                textAlign: "left",
-              }}
-            >
-              {r.label}
-            </button>
-          ))}
+          {KNOWN_REGIONS.map((r) => {
+            const active = selected.has(r.id);
+            return (
+              <button
+                key={r.id}
+                onClick={() => toggle(r.id)}
+                style={{
+                  padding: "0.5rem 0.75rem",
+                  borderRadius: 4,
+                  border: `1px solid ${active ? "#3b82f6" : "#2d3748"}`,
+                  background: active ? "#1e3a5f" : "#0f1117",
+                  color: active ? "#93c5fd" : "#a0aec0",
+                  fontSize: "0.75rem",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "0.4rem",
+                }}
+              >
+                <span
+                  style={{
+                    width: 10,
+                    height: 10,
+                    borderRadius: 2,
+                    border: `1px solid ${active ? "#3b82f6" : "#4a5568"}`,
+                    background: active ? "#3b82f6" : "transparent",
+                    flexShrink: 0,
+                  }}
+                />
+                {r.label}
+              </button>
+            );
+          })}
         </div>
 
-        <button
-          onClick={() => {
-            setStoredRegion(selected);
-            onConfirm(selected);
-          }}
-          style={{
-            width: "100%",
-            padding: "0.6rem",
-            borderRadius: 4,
-            border: "none",
-            background: "#3b82f6",
-            color: "#fff",
-            fontSize: "0.85rem",
-            fontWeight: 600,
-            cursor: "pointer",
-          }}
-        >
-          Download {KNOWN_REGIONS.find((r) => r.id === selected)?.label ?? selected}
-        </button>
+        <div style={{ display: "flex", gap: "0.5rem" }}>
+          {onCancel && (
+            <button
+              onClick={onCancel}
+              style={{
+                flex: 1,
+                padding: "0.6rem",
+                borderRadius: 4,
+                border: "1px solid #2d3748",
+                background: "transparent",
+                color: "#a0aec0",
+                fontSize: "0.85rem",
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+          )}
+          <button
+            onClick={() => {
+              setStoredRegions(selectedList);
+              onConfirm(selectedList);
+            }}
+            style={{
+              flex: 2,
+              padding: "0.6rem",
+              borderRadius: 4,
+              border: "none",
+              background: "#3b82f6",
+              color: "#fff",
+              fontSize: "0.85rem",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Download {selectedList.length === 1
+              ? (KNOWN_REGIONS.find((r) => r.id === selectedList[0])?.label ?? selectedList[0])
+              : `${selectedList.length} regions`}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/app/src/components/RegionPicker.tsx
+++ b/app/src/components/RegionPicker.tsx
@@ -1,0 +1,144 @@
+/**
+ * RegionPicker — full-screen overlay shown on first install (empty OPFS).
+ * User picks which region to download; defaults to Singapore.
+ * Choice is persisted to localStorage and not shown again unless reset.
+ */
+
+import { useState } from "react";
+
+export const KNOWN_REGIONS = [
+  { id: "singapore",    label: "Singapore Strait" },
+  { id: "japansea",     label: "Japan Sea" },
+  { id: "persiangulf",  label: "Persian Gulf" },
+  { id: "europe",       label: "Europe" },
+  { id: "middleeast",   label: "Middle East" },
+  { id: "blacksea",     label: "Black Sea" },
+  { id: "hornofafrica", label: "Horn of Africa" },
+  { id: "gulfofguinea", label: "Gulf of Guinea" },
+  { id: "gulfofaden",   label: "Gulf of Aden" },
+  { id: "gulfofmexico", label: "Gulf of Mexico" },
+] as const;
+
+export type RegionId = (typeof KNOWN_REGIONS)[number]["id"];
+
+export const STORAGE_KEY = "arktrace.region";
+export const DEFAULT_REGION: RegionId = "singapore";
+
+/** Read persisted region preference, or null if not yet chosen. */
+export function getStoredRegion(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist region preference. */
+export function setStoredRegion(region: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, region);
+  } catch {
+    // localStorage unavailable — ignore
+  }
+}
+
+interface Props {
+  onConfirm: (region: string) => void;
+}
+
+export default function RegionPicker({ onConfirm }: Props) {
+  const [selected, setSelected] = useState<string>(DEFAULT_REGION);
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "#0f1117",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+      }}
+    >
+      <div
+        style={{
+          background: "#1a1f2e",
+          border: "1px solid #2d3748",
+          borderRadius: 8,
+          padding: "2rem",
+          width: 400,
+          maxWidth: "90vw",
+        }}
+      >
+        <h2
+          style={{
+            fontSize: "1rem",
+            fontWeight: 600,
+            color: "#93c5fd",
+            marginBottom: "0.25rem",
+          }}
+        >
+          Select region
+        </h2>
+        <p
+          style={{
+            fontSize: "0.75rem",
+            color: "#718096",
+            marginBottom: "1.25rem",
+          }}
+        >
+          Choose which region to download. You can change this later.
+        </p>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: "0.5rem",
+            marginBottom: "1.5rem",
+          }}
+        >
+          {KNOWN_REGIONS.map((r) => (
+            <button
+              key={r.id}
+              onClick={() => setSelected(r.id)}
+              style={{
+                padding: "0.5rem 0.75rem",
+                borderRadius: 4,
+                border: `1px solid ${selected === r.id ? "#3b82f6" : "#2d3748"}`,
+                background: selected === r.id ? "#1e3a5f" : "#0f1117",
+                color: selected === r.id ? "#93c5fd" : "#a0aec0",
+                fontSize: "0.75rem",
+                cursor: "pointer",
+                textAlign: "left",
+              }}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+
+        <button
+          onClick={() => {
+            setStoredRegion(selected);
+            onConfirm(selected);
+          }}
+          style={{
+            width: "100%",
+            padding: "0.6rem",
+            borderRadius: 4,
+            border: "none",
+            background: "#3b82f6",
+            color: "#fff",
+            fontSize: "0.85rem",
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          Download {KNOWN_REGIONS.find((r) => r.id === selected)?.label ?? selected}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/lib/duckdb.ts
+++ b/app/src/lib/duckdb.ts
@@ -117,9 +117,9 @@ async function watchlistHasTopSignals(conn: duckdb.AsyncDuckDBConnection): Promi
 
 export async function queryWatchlist(
   conn: duckdb.AsyncDuckDBConnection,
-  opts: { minConfidence?: number; region?: string } = {}
+  opts: { minConfidence?: number; regions?: string[] } = {}
 ): Promise<VesselRow[]> {
-  const { minConfidence = 0, region } = opts;
+  const { minConfidence = 0, regions } = opts;
   const [hasImo, hasTopSignals] = await Promise.all([
     watchlistHasImo(conn),
     watchlistHasTopSignals(conn),
@@ -141,8 +141,9 @@ export async function queryWatchlist(
     FROM read_parquet('watchlist.parquet')
     WHERE confidence >= ${minConfidence}
   `;
-  if (region) {
-    sql += ` AND region = '${region.replace(/'/g, "''")}'`;
+  if (regions && regions.length > 0) {
+    const list = regions.map((r) => `'${r.replace(/'/g, "''")}'`).join(", ");
+    sql += ` AND region IN (${list})`;
   }
   sql += " ORDER BY confidence DESC LIMIT 500";
 

--- a/app/src/lib/opfs.ts
+++ b/app/src/lib/opfs.ts
@@ -31,6 +31,12 @@ export interface ManifestFile {
   size_bytes: number;
   /** DuckDB-WASM registration name, e.g. "watchlist.parquet" */
   register_as: string;
+  /**
+   * Optional region tag, e.g. "singapore".  When present, `syncAndLoad` can
+   * filter downloads to only the requested regions.  Absent on combined files
+   * that contain all regions — those are always downloaded.
+   */
+  region?: string;
 }
 
 export interface Manifest {
@@ -106,13 +112,19 @@ export async function fetchManifest(): Promise<Manifest> {
 /**
  * Sync R2 Parquet files into OPFS, then register them with DuckDB-WASM.
  *
- * @param db      Initialised DuckDB-WASM instance.
- * @param onStatus Called on every status change so the UI can show progress.
+ * @param db        Initialised DuckDB-WASM instance.
+ * @param onStatus  Called on every status change so the UI can show progress.
+ * @param regions   Optional list of regions to download.  Files tagged with a
+ *                  `region` field in the manifest are skipped unless their
+ *                  region appears in this list.  Files with no region tag
+ *                  (combined multi-region files) are always downloaded.
+ *                  Pass `undefined` (default) to download everything.
  * @returns Number of files loaded into DuckDB.
  */
 export async function syncAndLoad(
   db: AsyncDuckDB,
-  onStatus: (s: SyncStatus) => void
+  onStatus: (s: SyncStatus) => void,
+  regions?: string[]
 ): Promise<number> {
   // ── 1. Fetch manifest ───────────────────────────────────────────────────
   onStatus({ phase: "fetching_manifest" });
@@ -140,8 +152,14 @@ export async function syncAndLoad(
   }
 
   // ── 2. Download missing / stale files ───────────────────────────────────
+  // Filter by region: skip files tagged for a different region than requested.
+  // Files with no region tag are always included (they contain all regions).
+  const wantedFiles = regions
+    ? manifest.files.filter((f) => !f.region || regions.includes(f.region))
+    : manifest.files;
+
   const toDownload: ManifestFile[] = [];
-  for (const f of manifest.files) {
+  for (const f of wantedFiles) {
     const cached = await opfsFileSize(f.register_as);
     if (cached === f.size_bytes) continue; // already fresh
     toDownload.push(f);
@@ -166,10 +184,10 @@ export async function syncAndLoad(
     done++;
   }
 
-  // ── 3. Load all manifest files into DuckDB-WASM from OPFS ───────────────
+  // ── 3. Load all wanted files into DuckDB-WASM from OPFS ────────────────
   onStatus({ phase: "loading" });
   let loaded = 0;
-  for (const f of manifest.files) {
+  for (const f of wantedFiles) {
     const buf = await opfsReadBuffer(f.register_as);
     if (!buf) continue;
     await registerParquet(db, f.register_as, buf);


### PR DESCRIPTION
## Summary

Closes #378

- **First-visit overlay**: on fresh install (no `localStorage` preference), a full-screen `RegionPicker` shows before any download starts. User picks from all 10 known regions; Singapore is pre-selected.
- **Persisted choice**: selection is saved to `localStorage` (`arktrace.region`). Returning users skip the picker and go straight to sync with their last region.
- **Header selector updated**: now lists all 10 known regions even before data loads (previously only populated from loaded parquet data). Changing region in the header persists immediately.
- **Forward-compatible download filtering**: `syncAndLoad()` gains an optional `regions` param. Manifest files with a `region` field are filtered; files without (current combined dataset) are always downloaded. Per-region filtering activates automatically once the pipeline generates region-tagged manifest entries.

## What the picker looks like

```
┌─────────────────────────────────────┐
│  Select region                       │
│  Choose which region to download...  │
│                                      │
│  [Singapore ✓]  [Japan Sea]          │
│  [Persian Gulf] [Europe]             │
│  [Middle East]  [Black Sea]          │
│  [Horn of Africa][Gulf of Guinea]    │
│  [Gulf of Aden] [Gulf of Mexico]     │
│                                      │
│  [  Download Singapore Strait  ]     │
└─────────────────────────────────────┘
```

## Test plan
- [ ] Clear `localStorage` (`localStorage.removeItem('arktrace.region')`) → picker appears on reload, Singapore pre-selected
- [ ] Pick a different region → picker dismisses, header shows that region, sync starts
- [ ] Reload → picker does NOT appear, header shows the previously chosen region
- [ ] Change region in header → persists across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)