### PR TITLE
docs(380): sync documentation with code — 8 mismatches fixed

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,7 +248,7 @@ Computed with Polars over a rolling 30-day window per MMSI.
 
 | Feature | Definition | Shadow fleet signal |
 |---|---|---|
-| `ais_gap_count_30d` | Gaps > 6h in AIS signal while in open sea | STS transfer or deliberate dark period |
+| `ais_gap_count_30d` | Gaps > 10h in AIS signal while in open sea | STS transfer or deliberate dark period (10h threshold avoids normal 8–12h anchorage waits) |
 | `ais_gap_max_hours` | Longest single gap | Severity indicator |
 | `position_jump_count` | Consecutive positions implying > 50 knots | GPS spoofing |
 | `sts_candidate_count` | Co-located drift events (2 vessels within 0.5nm, both drifting, at sea) | Illicit STS transfer |

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,26 +51,26 @@ uv run python scripts/run_pipeline.py --region singapore --non-interactive
 uv run python scripts/run_pipeline.py --region japan --non-interactive
 ```
 
-Available regions: `singapore`, `japan`, `middleeast`, `europe`, `gulf`. See [`regional-playbooks.md`](regional-playbooks.md) for per-region parameter details.
+Available regions: `singapore`, `japan`, `middleeast`, `europe`, `persiangulf`, `gulfofguinea`, `gulfofaden`, `gulfofmexico`, `blacksea`. See [`regional-playbooks.md`](regional-playbooks.md) for per-region parameter details.
 
 Alternatively, run each step manually:
 
 ```bash
-uv run python src/ingest/schema.py             # initialise DuckDB schema
-uv run python src/ingest/marine_cadastre.py    # load historical AIS
-uv run python src/ingest/sanctions.py          # load sanctions entities
-uv run python src/ingest/vessel_registry.py    # load Equasis + ITU MMSI → Lance Graph
-uv run python src/ingest/eo_gfw.py --bbox 95,1,110,6 --days 30  # EO detections (requires GFW_API_TOKEN in .env)
-uv run python src/ingest/eo_gfw.py --csv data/raw/eo_detections_sample.csv  # EO detections via local CSV (no token needed)
-uv run python src/features/ais_behavior.py     # compute AIS behavioral features
-uv run python src/features/identity.py         # identity volatility features (Lance Graph)
-uv run python src/features/ownership_graph.py  # Lance Graph ownership features
-uv run python src/features/trade_mismatch.py   # trade flow mismatch features
-uv run python src/score/mpol_baseline.py       # HDBSCAN baseline
-uv run python src/score/anomaly.py             # Isolation Forest scoring
-uv run python src/score/causal_sanction.py     # C3: DiD causal model → calibrated w_graph
-uv run python src/score/composite.py           # composite score + SHAP (pass --w-graph from above)
-uv run python src/score/watchlist.py           # output candidate_watchlist.parquet
+uv run python -m pipeline.src.ingest.schema             # initialise DuckDB schema
+uv run python -m pipeline.src.ingest.marine_cadastre    # load historical AIS
+uv run python -m pipeline.src.ingest.sanctions          # load sanctions entities
+uv run python -m pipeline.src.ingest.vessel_registry    # load Equasis + ITU MMSI → Lance Graph
+uv run python -m pipeline.src.ingest.eo_gfw --bbox 95,1,110,6 --days 30  # EO detections (requires GFW_API_TOKEN in .env)
+uv run python -m pipeline.src.ingest.eo_gfw --csv data/raw/eo_detections_sample.csv  # EO detections via local CSV (no token needed)
+uv run python -m pipeline.src.features.ais_behavior     # compute AIS behavioral features
+uv run python -m pipeline.src.features.identity         # identity volatility features (Lance Graph)
+uv run python -m pipeline.src.features.ownership_graph  # Lance Graph ownership features
+uv run python -m pipeline.src.features.trade_mismatch   # trade flow mismatch features
+uv run python -m pipeline.src.score.mpol_baseline       # HDBSCAN baseline
+uv run python -m pipeline.src.score.anomaly             # Isolation Forest scoring
+uv run python -m pipeline.src.score.causal_sanction     # C3: DiD causal model → calibrated w_graph
+uv run python -m pipeline.src.score.composite           # composite score + SHAP (pass --w-graph from above)
+uv run python -m pipeline.src.score.watchlist           # output candidate_watchlist.parquet
 ```
 
 ### Run the dashboard
@@ -103,7 +103,14 @@ See [`backtracking-runbook.md`](backtracking-runbook.md) for full options and ou
 ### Run tests
 
 ```bash
+# Python — pipeline unit and integration tests
 uv run pytest tests/
+
+# Frontend — Vitest unit tests (jsdom environment)
+cd app && npm test
+
+# Frontend — ESLint static analysis
+cd app && npx eslint src/
 ```
 
 ## Coding Conventions

--- a/docs/feature-engineering.md
+++ b/docs/feature-engineering.md
@@ -1,6 +1,6 @@
 # Feature Engineering
 
-The arktrace pipeline computes 21 features across five families for every vessel MMSI. All features are written to the `vessel_features` DuckDB table by `src/features/build_matrix.py`.
+The arktrace pipeline computes 22 features across five families for every vessel MMSI. All features are written to the `vessel_features` DuckDB table by `src/features/build_matrix.py`.
 
 ## Feature families
 
@@ -10,8 +10,8 @@ The arktrace pipeline computes 21 features across five families for every vessel
 | Identity Volatility | `identity.py` | 5 | Lance Graph + DuckDB |
 | Ownership Graph | `ownership_graph.py` | 5 | Lance Graph (Polars joins) |
 | Trade Flow Mismatch | `trade_mismatch.py` | 2 | DuckDB + Comtrade API |
-| EO Fusion | `eo_fusion.py` | 2 | DuckDB (GFW API / CSV) |
-| **Total** | | **21** | |
+| EO Fusion | `eo_fusion.py` | 4 | DuckDB (GFW API via `eo_gfw.py` / CSV) |
+| **Total** | | **22** | |
 
 ---
 
@@ -21,9 +21,9 @@ Source: `ais_positions` table, computed over a rolling window (default 30 days, 
 
 ### `ais_gap_count_30d`
 
-Count of AIS transmission gaps longer than the configured threshold (default 6 hours) in the last 30 days.
+Count of AIS transmission gaps longer than the configured threshold (default 10 hours) in the last 30 days.
 
-**Shadow fleet signal:** Deliberate AIS switch-off is the primary evasion technique for sanctioned tankers. A gap of 6+ hours during transit is operationally unusual for a compliant vessel and strongly correlated with dark-transfer events.
+**Shadow fleet signal:** Deliberate AIS switch-off is the primary evasion technique for sanctioned tankers. The threshold is set to 10h because Singapore/Malacca anchorage wait times of 8–12h are normal commercial behaviour; genuine shadow-fleet dark periods for STS transfers are 12–48h and are still captured reliably.
 
 **Implementation:** The Polars lazy pipeline computes the time delta between consecutive position rows for each MMSI. Gaps are counted and summed per vessel over the rolling window.
 

--- a/docs/pipeline-catalog.md
+++ b/docs/pipeline-catalog.md
@@ -25,7 +25,7 @@ For implementation-level commands and flags, see [Pipeline Operations](pipeline-
 
 | Pipeline Type | Primary Purpose | Typical Run Timing | Expected Result |
 |---|---|---|---|
-| Full Screening (9-step) | Generate ranked shadow-fleet candidates from raw/public data | Initial setup, regional refresh, periodic baseline run | Updated watchlist and supporting artifacts for analyst triage |
+| Full Screening (11-step) | Generate ranked shadow-fleet candidates from raw/public data | Initial setup, regional refresh, periodic baseline run | Updated watchlist and supporting artifacts for analyst triage |
 | Continuous Monitoring (Streaming) | Keep vessel risk ranking fresh with live AIS and alerting | Persistent operations mode (minutes-level cadence) | Near-real-time watchlist updates and threshold-based alerts |
 | Historical Backtesting Validation | Validate ranking quality on historical evidence-backed windows | Before model/weight changes, pre-release, governance reviews | Reproducible metrics + threshold recommendations |
 | Review-Feedback Evaluation | Learn from human review outcomes and detect quality drift | Weekly/monthly quality cycle, after enough reviews accumulate | Tier-aware and ops-aware quality report with regression checks |
@@ -274,7 +274,7 @@ pipeline locally.
 ### Pipeline Steps
 
 1. Pull custom feeds from `arktrace-private-capvista` → `_inputs/custom_feeds/` (`continue-on-error`).
-2. Run `run_public_backtest_batch.py` for all 5 regions in seed mode — custom feeds are ingested at step 5 of the 9-step pipeline.
+2. Run `run_public_backtest_batch.py` for all 5 regions in seed mode — custom feeds are ingested at step 5 of the 11-step pipeline.
 3. `sync_r2.py push --keep 1` — zip all region artifacts, upload to `arktrace-public`, delete previous generation.
 4. `sync_r2.py push-demo` — overwrite `demo.zip` (lightweight bundle for quick developer setup).
 5. `sync_r2.py push-sanctions-db --force` — upload `public_eval.duckdb`.

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -71,7 +71,7 @@ The preset weights are starting points. The pipeline auto-calibrates `w_graph` o
 
 ## Pipeline steps
 
-The pipeline runs 10 steps in sequence. Each step prints a status line; in interactive mode, failed steps prompt retry or skip.
+The pipeline runs 11 steps in sequence. Each step prints a status line; in interactive mode, failed steps prompt retry or skip.
 
 | # | Step | Key modules |
 |---|---|---|
@@ -80,11 +80,12 @@ The pipeline runs 10 steps in sequence. Each step prints a status line; in inter
 | 3 | Live AIS streaming | `src/ingest/ais_stream.py` |
 | 4 | Sanctions loading | `src/ingest/sanctions.py` |
 | 5 | Custom feed drop-ins | `src/ingest/custom_feeds.py` |
-| 6 | Ownership graph | `src/ingest/vessel_registry.py` (→ Lance Graph) + `src/features/ownership_graph.py` |
-| 7 | Feature engineering | `src/features/ais_behavior.py` + `identity.py` + `trade_mismatch.py` + `build_matrix.py` |
-| 8 | Scoring | `src/score/causal_sanction.py` + `mpol_baseline.py` + `anomaly.py` + `composite.py` + `watchlist.py` |
-| 9 | GDELT ingestion | `src/ingest/gdelt.py` |
-| 10 | Dashboard | `src/api/main.py` (uvicorn) |
+| 6 | GFW EO dark-vessel ingest | `src/ingest/eo_gfw.py` (requires `GFW_API_TOKEN`; skipped gracefully if unset or quota exceeded) |
+| 7 | Ownership graph | `src/ingest/vessel_registry.py` (→ Lance Graph) + `src/features/ownership_graph.py` |
+| 8 | Feature engineering | `src/features/ais_behavior.py` + `identity.py` + `trade_mismatch.py` + `build_matrix.py` |
+| 9 | Scoring | `src/score/causal_sanction.py` + `mpol_baseline.py` + `anomaly.py` + `composite.py` + `watchlist.py` |
+| 10 | GDELT ingestion | `src/ingest/gdelt.py` |
+| 11 | DuckLake catalog checkpoint | `scripts/checkpoint_ducklake.py` |
 
 ---
 
@@ -339,11 +340,11 @@ SQL
 **Step 3 (AIS stream) — 0 rows inserted**
 Check `AISSTREAM_API_KEY` in `.env` and verify the bounding box covers an area with vessel traffic.
 
-**Step 5 (Ownership graph) — vessel_registry fails**
+**Step 7 (Ownership graph) — vessel_registry fails**
 Run `uv run python src/ingest/vessel_registry.py --db <db_path>` to rebuild the Lance Graph datasets manually. Alternatively, pass `--skip-graph` to `build_matrix.py` to run without graph features (graph features default to safe values).
 
-**Step 7 (Scoring) — composite returns empty DataFrame**
-`vessel_features` is empty. Re-run step 6 (feature engineering) and confirm `build_matrix.py` completed without errors.
+**Step 9 (Scoring) — composite returns empty DataFrame**
+`vessel_features` is empty. Re-run step 8 (feature engineering) and confirm `build_matrix.py` completed without errors.
 
 **Dashboard shows no vessels**
 Confirm `WATCHLIST_OUTPUT_PATH` points to the correct parquet file and that it contains rows (`polars.read_parquet(path).height > 0`).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
   - Operations:
     - Pipeline Catalog (Operations View): pipeline-catalog.md
     - Pipeline Operations: pipeline-operations.md
+    - Custom Feed Integration: custom-feeds.md
     - Regional Playbooks: regional-playbooks.md
     - Backtesting Validation: backtesting-validation.md
     - Pre-Label Governance: prelabel-governance.md


### PR DESCRIPTION
Closes #380

## Changes

| File | Fix |
|------|-----|
| `pipeline-catalog.md` | 9-step → 11-step throughout |
| `pipeline-operations.md` | 10 steps → 11; add missing step 6 (GFW EO ingest); renumber steps 7–11; fix troubleshooting references |
| `feature-engineering.md` | 21 features → 22; gap threshold 6h → 10h with rationale; `eo_fusion.py` source note updated |
| `architecture.md` | `ais_gap_count_30d` threshold 6h → 10h |
| `development.md` | Regions list expanded to all 9; module paths corrected to `python -m pipeline.src.*`; frontend test commands added (vitest, eslint) |
| `mkdocs.yml` | `custom-feeds.md` added to Operations nav |

## Test plan
- [ ] `mkdocs build` passes (no broken nav refs)
- [ ] All 8 acceptance criteria in #380 checked off

🤖 Generated with [Claude Code](https://claude.com/claude-code)