### PR TITLE
fix(app): fix local LLM offline on Safari and Chrome at demo URL

### DIFF
--- a/app/src/components/VesselDetail.tsx
+++ b/app/src/components/VesselDetail.tsx
@@ -26,12 +26,12 @@ interface Props {
 // ── LLM brief fetcher ────────────────────────────────────────────────────────
 
 // VITE_LLM_ENDPOINT can be set in Cloudflare Pages environment variables to
-// point at a remote HTTPS inference endpoint.  Falls back to local llama-server
-// for development.  Chrome allows http://localhost from HTTPS pages; Safari and
-// Firefox do not — on those browsers the fetch throws and "offline" is shown.
+// point at a remote HTTPS inference endpoint.  Falls back to the Caddy HTTPS
+// proxy started by run_llama.sh (:8443 → :8080).  Using HTTPS for both Chrome
+// and Safari avoids mixed-content issues entirely.
 const LLM_ENDPOINT =
-  import.meta.env.VITE_LLM_ENDPOINT ?? "http://localhost:8080/v1/chat/completions";
-const LLM_TIMEOUT_MS = 10_000;
+  import.meta.env.VITE_LLM_ENDPOINT ?? "https://localhost:8443/v1/chat/completions";
+const LLM_TIMEOUT_MS = 45_000;
 
 type BriefStatus = "idle" | "loading" | "cached" | "ready" | "offline" | "error";
 
@@ -60,10 +60,9 @@ function buildPrompt(v: VesselRow): string {
 }
 
 async function fetchBrief(v: VesselRow, signal: AbortSignal): Promise<string> {
-  // Note: Chrome exempts http://localhost from mixed-content blocking (HTTPS
-  // page → HTTP localhost is allowed).  Safari and Firefox do not.  We let the
-  // fetch run unconditionally; browsers that block it will throw a network
-  // error which the caller's catch block handles uniformly as "offline".
+  // Default endpoint is https://localhost:8443 (Caddy proxy) so both Chrome
+  // and Safari avoid mixed-content issues.  Network errors fall through to
+  // the caller's "offline" handler.
   const res = await fetch(LLM_ENDPOINT, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/docs/local-llm-setup.md
+++ b/docs/local-llm-setup.md
@@ -27,13 +27,49 @@ The default model is `bartowski/Qwen2.5-7B-Instruct-GGUF` (Q4_K_M quantisation),
 
 ### One-time installation
 
-```bash
-# macOS (Homebrew) — recommended
-brew install llama.cpp
+**macOS**
 
-# Other platforms — see full install guide:
-# https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md
+```bash
+brew install llama.cpp caddy
 ```
+
+**Linux (Debian / Ubuntu)**
+
+```bash
+# llama.cpp — download the pre-built binary for your arch
+# https://github.com/ggml-org/llama.cpp/releases/latest
+# e.g. llama-<tag>-bin-ubuntu-x64.zip → unzip, add to PATH
+
+# Caddy
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+  | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+  | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update && sudo apt install caddy
+```
+
+**Linux (Fedora / RHEL)**
+
+```bash
+sudo dnf install caddy
+```
+
+**Windows**
+
+```powershell
+# llama.cpp — download the pre-built binary:
+# https://github.com/ggml-org/llama.cpp/releases/latest
+# e.g. llama-<tag>-bin-win-avx2-x64.zip → unzip, add folder to PATH
+
+# Caddy (winget)
+winget install Caddy.Caddy
+
+# or Chocolatey
+choco install caddy
+```
+
+Caddy is required for Safari support — `run_llama.sh` starts it automatically as an HTTPS proxy on `:8443`. On first run it adds its local CA to the system trust store (macOS Keychain / Windows Certificate Store); Linux users may need to accept the cert manually in the browser on first visit.
 
 ### Start everything
 

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -7,10 +7,14 @@
 # The SPA calls: http://localhost:8080/v1/chat/completions
 #
 # Prerequisites (one-time):
-#   macOS:          brew install llama.cpp
-#   Linux / WSL2:   Download pre-built binary from:
+#   macOS:          brew install llama.cpp caddy
+#   Linux / WSL2:   llama.cpp — download pre-built binary from:
 #                   https://github.com/ggml-org/llama.cpp/releases/latest
-#                   e.g. llama-<tag>-bin-ubuntu-x64.zip  →  unzip, add to PATH
+#                   caddy — see docs/local-llm-setup.md (apt/dnf packages)
+#   Windows:        llama.cpp — download pre-built binary from:
+#                   https://github.com/ggml-org/llama.cpp/releases/latest
+#                   e.g. llama-<tag>-bin-win-avx2-x64.zip  →  unzip, add to PATH
+#                   caddy — winget install Caddy.Caddy
 #
 # Usage:
 #   bash scripts/run_llama.sh
@@ -120,6 +124,35 @@ for i in $(seq 1 30); do
       exit 1
     fi
     echo "   ✅ llama-server ready → http://localhost:${PORT}/v1"
+
+    # ── Caddy HTTPS proxy ─────────────────────────────────────────────────────
+    # The SPA defaults to https://localhost:8443 so Safari (which blocks
+    # HTTPS→HTTP) and Chrome both work without any VITE_LLM_ENDPOINT override.
+    # Caddy adds its local CA to the macOS keychain on first run; Safari will
+    # prompt once to accept the cert — after that it's seamless.
+    HTTPS_PORT=$((PORT + 363))   # 8080 → 8443
+    CADDY_PID=""
+    if command -v caddy &>/dev/null; then
+      caddy reverse-proxy \
+        --from "localhost:${HTTPS_PORT}" \
+        --to   "localhost:${PORT}" \
+        > /tmp/caddy-llama.log 2>&1 &
+      CADDY_PID=$!
+      sleep 1
+      if kill -0 "${CADDY_PID}" 2>/dev/null; then
+        echo "   ✅ Caddy HTTPS proxy   → https://localhost:${HTTPS_PORT}/v1"
+        echo "      (Safari: accept the Caddy local-CA cert on first visit)"
+      else
+        echo "   ❌ Caddy failed to start — local LLM will be offline in Safari"
+        echo "      Check /tmp/caddy-llama.log for details"
+        echo "      Install: brew install caddy"
+        CADDY_PID=""
+      fi
+    else
+      echo "   ❌ caddy not found — local LLM will be offline in Safari"
+      echo "      Install: brew install caddy"
+    fi
+
     break
   fi
   sleep 2
@@ -135,6 +168,7 @@ _cleanup() {
   echo ""
   echo "Shutting down llama-server…"
   kill "${LLM_PID}" 2>/dev/null || true
+  [[ -n "${CADDY_PID}" ]] && kill "${CADDY_PID}" 2>/dev/null || true
   echo "Done."
 }
 trap '_cleanup' EXIT INT TERM


### PR DESCRIPTION
## Summary

- **Safari**: `http://localhost:8080` was blocked by mixed-content policy (HTTPS page → HTTP). Fixed by routing through a Caddy HTTPS proxy on `:8443`; `run_llama.sh` now starts Caddy automatically after llama-server is ready.
- **Chrome**: 10 s timeout was too short for cold inference on a 7B model — the brief silently aborted and showed "offline" even with a healthy server. Raised to 45 s.
- Default `LLM_ENDPOINT` changed from `http://localhost:8080` → `https://localhost:8443` so no `VITE_LLM_ENDPOINT` override is needed for either browser.
- `docs/local-llm-setup.md` updated with Caddy install instructions for macOS, Linux (apt/dnf), and Windows (winget/choco).

## Test plan

- [ ] Run `./scripts/run_llama.sh` — confirm both `✅ llama-server ready` and `✅ Caddy HTTPS proxy` lines appear
- [ ] Open `https://demo.arktrace.edgesentry.io` in Chrome — analyst brief loads within 45 s
- [ ] Open `https://demo.arktrace.edgesentry.io` in Safari — accept Caddy local-CA cert on first visit, brief loads
- [ ] Confirm brief still works in `npm run dev` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)