### PR TITLE
feat(#313): private bucket auth + VITE_PRIVATE_MANIFEST_URL

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -19,6 +19,8 @@ import type { VesselRow, MetricsRow } from "./lib/duckdb";
 import type { AsyncDuckDB, AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import { syncAndLoad } from "./lib/opfs";
 import type { SyncStatus } from "./lib/opfs";
+import { getToken, clearToken, isPrivateModeEnabled } from "./lib/auth";
+import LoginGate from "./components/LoginGate";
 import { loadAlerts, diffAndAppend } from "./lib/alerts";
 import type { AlertEntry } from "./lib/alerts";
 import KpiBar from "./components/KpiBar";
@@ -54,6 +56,9 @@ export default function App() {
   const [alerts, setAlerts] = useState<AlertEntry[]>(() => loadAlerts());
   const [alertDrawerOpen, setAlertDrawerOpen] = useState(false);
   const prevVesselsRef = useRef<VesselRow[]>([]);
+  const [authToken, setAuthToken] = useState<string | null>(() => getToken());
+  const privateMode = isPrivateModeEnabled();
+  const [showLogin, setShowLogin] = useState<boolean>(() => privateMode && !getToken());
 
   // ── Initialise DuckDB-WASM once ──────────────────────────────────────────
   useEffect(() => {
@@ -82,12 +87,9 @@ export default function App() {
     const target = db ?? dbRef.current;
     if (!target) return;
     const activeRegions = regions ?? selectedRegions;
-    // Pass region list so syncAndLoad can filter region-tagged manifest files.
-    // Currently manifest files have no region tags (combined dataset), so this
-    // is a no-op until the pipeline adds them.
     const regionFilter = activeRegions.length > 0 ? activeRegions : undefined;
     setSyncStatus({ phase: "fetching_manifest" });
-    const loaded = await syncAndLoad(target, setSyncStatus, regionFilter);
+    const loaded = await syncAndLoad(target, setSyncStatus, regionFilter, authToken ?? undefined);
     if (loaded > 0 && connRef.current) {
       await refreshQuery();
     }
@@ -217,6 +219,41 @@ export default function App() {
         <span style={{ marginLeft: "auto", fontSize: "0.65rem", color: "#4a5568" }}>
           DuckDB-WASM · OPFS · R2
         </span>
+
+        {privateMode && (
+          authToken ? (
+            <button
+              onClick={() => { clearToken(); setAuthToken(null); setShowLogin(true); }}
+              title="Sign out"
+              style={{
+                background: "transparent",
+                border: "1px solid #2d3748",
+                color: "#a0aec0",
+                padding: "0.25rem 0.6rem",
+                borderRadius: 4,
+                fontSize: "0.75rem",
+                cursor: "pointer",
+              }}
+            >
+              Private · Sign out
+            </button>
+          ) : (
+            <button
+              onClick={() => setShowLogin(true)}
+              style={{
+                background: "transparent",
+                border: "1px solid #3b82f6",
+                color: "#93c5fd",
+                padding: "0.25rem 0.6rem",
+                borderRadius: 4,
+                fontSize: "0.75rem",
+                cursor: "pointer",
+              }}
+            >
+              Sign in
+            </button>
+          )
+        )}
       </header>
 
       {/* KPI bar */}
@@ -290,6 +327,18 @@ export default function App() {
           onClose={() => setAlertDrawerOpen(false)}
           onSelectVessel={(mmsi) => setSelectedMmsi(mmsi)}
           onAlertsChange={setAlerts}
+        />
+      )}
+
+      {/* Private data login gate */}
+      {showLogin && privateMode && (
+        <LoginGate
+          onLogin={() => {
+            const token = getToken();
+            setAuthToken(token);
+            setShowLogin(false);
+            if (dbRef.current) doSync(dbRef.current);
+          }}
         />
       )}
 

--- a/app/src/components/LoginGate.tsx
+++ b/app/src/components/LoginGate.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { setToken } from "../lib/auth";
+
+interface Props {
+  onLogin: () => void;
+}
+
+export default function LoginGate({ onLogin }: Props) {
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setError("Access token required");
+      return;
+    }
+    setToken(trimmed);
+    onLogin();
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.75)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          background: "#1a1f2e",
+          border: "1px solid #2d3748",
+          borderRadius: 8,
+          padding: "2rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+          minWidth: 320,
+        }}
+      >
+        <h2 style={{ margin: 0, fontSize: "1rem", fontWeight: 600, color: "#93c5fd" }}>
+          Private Data Access
+        </h2>
+        <p style={{ margin: 0, fontSize: "0.8rem", color: "#a0aec0" }}>
+          Enter your Cap Vista access token to load private vessel data.
+        </p>
+        <input
+          type="password"
+          autoFocus
+          placeholder="Access token"
+          value={value}
+          onChange={(e) => { setValue(e.target.value); setError(null); }}
+          style={{
+            background: "#0f1117",
+            border: "1px solid #2d3748",
+            borderRadius: 4,
+            color: "#e2e8f0",
+            padding: "0.5rem 0.75rem",
+            fontSize: "0.875rem",
+            outline: "none",
+          }}
+        />
+        {error && (
+          <span style={{ fontSize: "0.75rem", color: "#fc8181" }}>{error}</span>
+        )}
+        <button
+          type="submit"
+          style={{
+            background: "#3b82f6",
+            border: "none",
+            borderRadius: 4,
+            color: "#fff",
+            padding: "0.5rem",
+            fontSize: "0.875rem",
+            cursor: "pointer",
+            fontWeight: 600,
+          }}
+        >
+          Sign in
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -1,0 +1,9 @@
+const TOKEN_KEY = "arktrace_access_token";
+
+export const getToken = (): string | null => localStorage.getItem(TOKEN_KEY);
+export const setToken = (token: string): void => localStorage.setItem(TOKEN_KEY, token);
+export const clearToken = (): void => localStorage.removeItem(TOKEN_KEY);
+
+/** True when a private manifest URL is configured in the build. */
+export const isPrivateModeEnabled = (): boolean =>
+  Boolean(import.meta.env.VITE_PRIVATE_MANIFEST_URL);

--- a/app/src/lib/opfs.ts
+++ b/app/src/lib/opfs.ts
@@ -22,6 +22,9 @@ export const R2_BASE_URL = "https://arktrace-public.edgesentry.io";
 // In dev, VITE_MANIFEST_URL can point to local fixture files served by Vite.
 const MANIFEST_URL =
   import.meta.env.VITE_MANIFEST_URL ?? `${R2_BASE_URL}/ducklake_manifest.json`;
+// Private manifest URL — set in production to enable token-gated private data.
+const PRIVATE_MANIFEST_URL: string | undefined =
+  import.meta.env.VITE_PRIVATE_MANIFEST_URL;
 
 // Default TTL: 7 days. Override with VITE_CACHE_TTL_DAYS env var.
 const CACHE_TTL_MS =
@@ -134,12 +137,12 @@ export function isStale(
 // Manifest fetch
 // ---------------------------------------------------------------------------
 
-export async function fetchManifest(): Promise<Manifest> {
-  const resp = await fetch(MANIFEST_URL, { cache: "no-store" });
+export async function fetchManifest(authToken?: string): Promise<Manifest> {
+  const url = authToken && PRIVATE_MANIFEST_URL ? PRIVATE_MANIFEST_URL : MANIFEST_URL;
+  const headers: HeadersInit = authToken ? { Authorization: `Bearer ${authToken}` } : {};
+  const resp = await fetch(url, { cache: "no-store", headers });
   if (!resp.ok) {
-    throw new Error(
-      `Failed to fetch manifest (${resp.status}): ${MANIFEST_URL}`
-    );
+    throw new Error(`Failed to fetch manifest (${resp.status}): ${url}`);
   }
   return resp.json() as Promise<Manifest>;
 }
@@ -163,13 +166,14 @@ export async function fetchManifest(): Promise<Manifest> {
 export async function syncAndLoad(
   db: AsyncDuckDB,
   onStatus: (s: SyncStatus) => void,
-  regions?: string[]
+  regions?: string[],
+  authToken?: string
 ): Promise<number> {
   // ── 1. Fetch manifest ───────────────────────────────────────────────────
   onStatus({ phase: "fetching_manifest" });
   let manifest: Manifest;
   try {
-    manifest = await fetchManifest();
+    manifest = await fetchManifest(authToken);
   } catch {
     // No network — try OPFS cache first, then bundled fixtures
     onStatus({ phase: "loading" });
@@ -217,7 +221,8 @@ export async function syncAndLoad(
       current: f.register_as,
     });
     try {
-      const resp = await fetch(f.url);
+      const headers: HeadersInit = authToken ? { Authorization: `Bearer ${authToken}` } : {};
+      const resp = await fetch(f.url, { headers });
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const buf = await resp.arrayBuffer();
       await opfsWriteBuffer(f.register_as, buf);

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1302,9 +1302,34 @@ def cmd_push_ducklake_private(args: argparse.Namespace) -> int:
         _upload_file(fs, local, r2_path)
         print("  ✓")
 
+    # Generate and upload private ducklake_manifest.json — rewrites the public
+    # manifest URLs to point at the private bucket so the browser OPFS sync can
+    # discover private files when the user is authenticated.
+    public_manifest_file = catalog_dir / "ducklake_manifest.json"
+    if public_manifest_file.exists():
+        import json as _json
+
+        private_base = f"{_PRIVATE_ENDPOINT}/{_DUCKLAKE_PRIVATE_PREFIX.rstrip('/')}"
+        public_base = "https://arktrace-public.edgesentry.io"
+        manifest_data = _json.loads(public_manifest_file.read_text())
+        for entry in manifest_data.get("files", []):
+            entry["url"] = entry["url"].replace(public_base, private_base)
+            entry["key"] = f"{_DUCKLAKE_PRIVATE_PREFIX}{entry['key']}"
+        manifest_data["base_url"] = private_base
+        private_manifest_bytes = _json.dumps(manifest_data, indent=2).encode()
+        manifest_r2 = f"{prefix}ducklake_manifest.json"
+        print(
+            f"Uploading private ducklake_manifest.json ({len(private_manifest_bytes)} B) → {manifest_r2} ..."
+        )
+        fs.pipe(manifest_r2, private_manifest_bytes)
+        print("  ✓")
+    else:
+        print("[warn] ducklake_manifest.json not found — private browser OPFS sync will not work.")
+
     print(
         f"\nDone. Private DuckLake outputs available at:\n"
-        f"  {_PRIVATE_ENDPOINT}/{_DUCKLAKE_PRIVATE_PREFIX}  (authenticated access only)"
+        f"  {_PRIVATE_ENDPOINT}/{_DUCKLAKE_PRIVATE_PREFIX}  (authenticated access only)\n"
+        f"  Manifest: {_PRIVATE_ENDPOINT}/{_DUCKLAKE_PRIVATE_PREFIX}ducklake_manifest.json"
     )
     return 0
 


### PR DESCRIPTION
## Summary

Implements token-gated access to the `arktrace-private-capvista` R2 bucket so Cap Vista reviewers load private data in the browser app.

- **`app/src/lib/auth.ts`** — `getToken` / `setToken` / `clearToken` (localStorage) + `isPrivateModeEnabled()` (checks `VITE_PRIVATE_MANIFEST_URL`)
- **`app/src/components/LoginGate.tsx`** — password overlay that appears on first visit when private mode is enabled; stores token in localStorage
- **`app/src/lib/opfs.ts`** — `syncAndLoad` / `fetchManifest` accept `authToken?`; when token is present, fetches from `VITE_PRIVATE_MANIFEST_URL` with `Authorization: Bearer <token>` header on manifest + every Parquet download
- **`app/src/App.tsx`** — shows `LoginGate` overlay when `VITE_PRIVATE_MANIFEST_URL` is set and no token is stored; header shows "Private · Sign out" or "Sign in" button; re-syncs after login
- **`scripts/sync_r2.py`** — `push-ducklake-private` now also generates and uploads a private `ducklake_manifest.json` (rewrites public URLs to `arktrace-private-capvista.edgesentry.io/outputs/`) so the browser can discover private files

## Configuration

Add to `.env.production` (private deployment only):
```
VITE_PRIVATE_MANIFEST_URL=https://arktrace-private-capvista.edgesentry.io/outputs/ducklake_manifest.json
```

When `VITE_PRIVATE_MANIFEST_URL` is **not** set (public build), login UI is hidden and behavior is unchanged.

## Infrastructure note

The `arktrace-private-capvista.edgesentry.io` custom domain needs a Cloudflare Worker in front to validate the `Authorization: Bearer <token>` header and proxy requests to R2. Token validation worker is tracked in #344.

## Test plan

- [ ] Build without `VITE_PRIVATE_MANIFEST_URL` — no login UI visible, public data loads as before
- [ ] Build with `VITE_PRIVATE_MANIFEST_URL` set — login overlay appears on first visit
- [ ] Enter valid token → overlay dismisses, re-sync triggers with private manifest URL + auth header
- [ ] "Sign out" clears token and shows login again
- [ ] `uv run python scripts/sync_r2.py push-ducklake-private` writes `outputs/ducklake_manifest.json` to private bucket with private URLs

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)