### PR TITLE
fix(auth): open CF Access login in popup

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -239,7 +239,17 @@ export default function App() {
             </button>
           ) : (
             <button
-              onClick={loginWithCFAccess}
+              onClick={() => {
+                const popup = loginWithCFAccess();
+                if (!popup) return;
+                const timer = setInterval(async () => {
+                  if (popup.closed) {
+                    clearInterval(timer);
+                    const authed = await checkPrivateAuth();
+                    setPrivateAuth(authed);
+                  }
+                }, 500);
+              }}
               style={{
                 background: "transparent",
                 border: "1px solid #3b82f6",

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -21,10 +21,15 @@ export async function checkPrivateAuth(): Promise<boolean> {
   }
 }
 
-/** Redirect to Cloudflare Access login, returning to the current page after. */
-export function loginWithCFAccess(): void {
+/**
+ * Open Cloudflare Access login in a popup. CF Access sets its cookie on the
+ * Worker domain; once the popup closes, the caller should re-check auth.
+ * redirect_url must stay on the same domain as the Access application.
+ */
+export function loginWithCFAccess(): Window | null {
   const origin = new URL(PRIVATE_MANIFEST_URL!).origin;
-  window.location.href = `${origin}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(window.location.href)}`;
+  const loginUrl = `${origin}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(origin + "/")}`;
+  return window.open(loginUrl, "cf-access-login", "width=520,height=620,noopener");
 }
 
 /** Redirect to Cloudflare Access logout. */


### PR DESCRIPTION
## Summary
- CF Access rejects `redirect_url` pointing to a different domain (e.g. the app's Pages domain)
- Open login in a popup window with `redirect_url` pointing back to the Worker origin instead
- Poll every 500ms for popup close, then re-check auth and update app state

## Test plan
- [ ] Click Login button — popup opens to CF Access login page
- [ ] Complete login — popup closes (or user closes it)
- [ ] App detects closed popup and re-checks auth, updating state to authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)