### PR TITLE
fix(auth): open manifest URL in popup instead of /cdn-cgi/access/login

### DIFF
--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -22,14 +22,12 @@ export async function checkPrivateAuth(): Promise<boolean> {
 }
 
 /**
- * Open Cloudflare Access login in a popup. CF Access sets its cookie on the
- * Worker domain; once the popup closes, the caller should re-check auth.
- * redirect_url must stay on the same domain as the Access application.
+ * Open the private manifest URL in a popup. CF Access intercepts it, redirects
+ * to login, then back to the manifest. Once the popup closes the CF_Authorization
+ * cookie is set and the caller should re-check auth.
  */
 export function loginWithCFAccess(): Window | null {
-  const origin = new URL(PRIVATE_MANIFEST_URL!).origin;
-  const loginUrl = `${origin}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(origin + "/")}`;
-  return window.open(loginUrl, "cf-access-login", "width=520,height=620,noopener");
+  return window.open(PRIVATE_MANIFEST_URL!, "cf-access-login", "width=520,height=620,noopener");
 }
 
 /** Redirect to Cloudflare Access logout. */


### PR DESCRIPTION
## Summary
- The Worker intercepts `/cdn-cgi/access/login` before CF Access can handle it, returning 404
- Fix: open the manifest URL directly in the popup — CF Access intercepts the unauthenticated request, redirects to its login page, then back to the manifest
- After popup closes, app polls and re-checks auth

## Test plan
- [ ] Click Login → popup opens, CF Access redirects to login page
- [ ] Authenticate → popup shows manifest JSON, user closes it
- [ ] App detects popup closed, re-checks auth, updates to authenticated state

🤖 Generated with [Claude Code](https://claude.com/claude-code)