### PR TITLE
fix(deploy): pass VITE_PRIVATE_MANIFEST_URL to Vite build

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -31,6 +31,8 @@ jobs:
         working-directory: app
         # VITE_MANIFEST_URL left unset so opfs.ts falls back to the R2 URL.
         run: npm run build
+        env:
+          VITE_PRIVATE_MANIFEST_URL: ${{ vars.VITE_PRIVATE_MANIFEST_URL }}
 
       - name: Deploy to Cloudflare Pages
         working-directory: app


### PR DESCRIPTION
## Summary
- `deploy-app.yml` runs `npm run build` without `VITE_PRIVATE_MANIFEST_URL`, so Vite never inlines it and the Login button never renders
- Fix: pass the value from GitHub Actions repository variable `VITE_PRIVATE_MANIFEST_URL` to the build step env

## Setup required
Add a **repository variable** (not secret) in GitHub → Settings → Variables and secrets → Actions → Variables:
- Name: `VITE_PRIVATE_MANIFEST_URL`
- Value: `https://arktrace-private-capvista.edgesentry.io/outputs/ducklake_manifest.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)