### PR TITLE
fix(auth): popup opens /auth-success which auto-closes after CF Access login

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -31,6 +31,8 @@ jobs:
         working-directory: app
         # VITE_MANIFEST_URL left unset so opfs.ts falls back to the R2 URL.
         run: npm run build
+        env:
+          VITE_PRIVATE_MANIFEST_URL: ${{ vars.VITE_PRIVATE_MANIFEST_URL }}
 
       - name: Deploy to Cloudflare Pages
         working-directory: app

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -22,12 +22,13 @@ export async function checkPrivateAuth(): Promise<boolean> {
 }
 
 /**
- * Open the private manifest URL in a popup. CF Access intercepts it, redirects
- * to login, then back to the manifest. Once the popup closes the CF_Authorization
- * cookie is set and the caller should re-check auth.
+ * Open /auth-success on the Worker domain in a popup. CF Access intercepts it,
+ * redirects to login, then back to /auth-success which auto-closes the popup.
+ * Once the popup closes the CF_Authorization cookie is set; caller re-checks auth.
  */
 export function loginWithCFAccess(): Window | null {
-  return window.open(PRIVATE_MANIFEST_URL!, "cf-access-login", "width=520,height=620,noopener");
+  const origin = new URL(PRIVATE_MANIFEST_URL!).origin;
+  return window.open(`${origin}/auth-success`, "cf-access-login", "width=520,height=620,noopener");
 }
 
 /** Redirect to Cloudflare Access logout. */


### PR DESCRIPTION
## Summary
- Previously the popup opened the manifest URL, showing raw JSON after login with no auto-close
- `/auth-success` is a new Worker route that returns `window.close()` HTML
- CF Access protects it — popup goes through login then auto-closes, setting the cookie

## Depends on
arktrace-commercial#71 must be deployed first (adds `/auth-success` to the Worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)