### PR TITLE
feat(auth): show logged-in email and Login→Logout switch (#395)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -56,7 +56,8 @@ export default function App() {
   const [alertDrawerOpen, setAlertDrawerOpen] = useState(false);
   const prevVesselsRef = useRef<VesselRow[]>([]);
   const privateMode = isPrivateModeEnabled();
-  const [privateAuth, setPrivateAuth] = useState<boolean>(false);
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+  const privateAuth = userEmail !== null;
 
   // ── Initialise DuckDB-WASM once ──────────────────────────────────────────
   useEffect(() => {
@@ -69,11 +70,11 @@ export default function App() {
         connRef.current = conn;
         await initReviewSchema(conn);
         await initBriefCache(conn);
-        const authed = privateMode ? await checkPrivateAuth() : false;
-        if (!cancelled) setPrivateAuth(authed);
+        const email = privateMode ? await checkPrivateAuth() : null;
+        if (!cancelled) setUserEmail(email);
         // Skip auto-sync if the region picker is waiting for user input.
         if (!showRegionPicker) {
-          await doSync(db, undefined, authed);
+          await doSync(db, undefined, email !== null);
         }
       } catch (err) {
         if (!cancelled) setInitError(String(err));
@@ -222,21 +223,26 @@ export default function App() {
 
         {privateMode && (
           privateAuth ? (
-            <button
-              onClick={logoutFromCFAccess}
-              title="Sign out"
-              style={{
-                background: "transparent",
-                border: "1px solid #2d3748",
-                color: "#a0aec0",
-                padding: "0.25rem 0.6rem",
-                borderRadius: 4,
-                fontSize: "0.75rem",
-                cursor: "pointer",
-              }}
-            >
-              Private · Sign out
-            </button>
+            <span style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <span style={{ color: "#a0aec0", fontSize: "0.75rem" }}>
+                Logged in as {userEmail}
+              </span>
+              <button
+                onClick={logoutFromCFAccess}
+                title="Sign out"
+                style={{
+                  background: "transparent",
+                  border: "1px solid #2d3748",
+                  color: "#a0aec0",
+                  padding: "0.25rem 0.6rem",
+                  borderRadius: 4,
+                  fontSize: "0.75rem",
+                  cursor: "pointer",
+                }}
+              >
+                Sign out
+              </button>
+            </span>
           ) : (
             <button
               onClick={() => {
@@ -245,8 +251,8 @@ export default function App() {
                 const timer = setInterval(async () => {
                   if (popup.closed) {
                     clearInterval(timer);
-                    const authed = await checkPrivateAuth();
-                    setPrivateAuth(authed);
+                    const email = await checkPrivateAuth();
+                    setUserEmail(email);
                   }
                 }, 500);
               }}

--- a/app/src/lib/auth.test.ts
+++ b/app/src/lib/auth.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// VITE_PRIVATE_MANIFEST_URL must be set before the module is imported because
+// auth.ts reads it at module-load time into a module-level constant.
+// Vitest injects import.meta.env from process.env for VITE_* vars.
+process.env.VITE_PRIVATE_MANIFEST_URL = "https://worker.example.com/outputs/manifest.json";
+
+const { checkPrivateAuth, isPrivateModeEnabled } = await import("./auth");
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("isPrivateModeEnabled", () => {
+  it("returns true when VITE_PRIVATE_MANIFEST_URL is set", () => {
+    expect(isPrivateModeEnabled()).toBe(true);
+  });
+});
+
+describe("checkPrivateAuth", () => {
+  it("returns email when /whoami responds with a non-empty email", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ email: "user@example.com" }),
+    }));
+    const result = await checkPrivateAuth();
+    expect(result).toBe("user@example.com");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://worker.example.com/whoami",
+      { credentials: "include" }
+    );
+  });
+
+  it("returns null when /whoami responds with an empty email (unauthenticated)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ email: "" }),
+    }));
+    expect(await checkPrivateAuth()).toBeNull();
+  });
+
+  it("returns null when /whoami returns a non-ok status", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    expect(await checkPrivateAuth()).toBeNull();
+  });
+
+  it("returns null when fetch throws (network error / CORS block)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("CORS")));
+    expect(await checkPrivateAuth()).toBeNull();
+  });
+});

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -4,20 +4,19 @@ const PRIVATE_MANIFEST_URL = import.meta.env.VITE_PRIVATE_MANIFEST_URL as string
 export const isPrivateModeEnabled = (): boolean => Boolean(PRIVATE_MANIFEST_URL);
 
 /**
- * Check whether the user is authenticated with Cloudflare Access by probing
- * the private manifest with credentials. Returns true if the request succeeds
- * (Access cookie present), false if redirected to login or blocked.
+ * Check CF Access authentication by calling /whoami on the Worker.
+ * Returns the authenticated user's email, or null if not authenticated.
  */
-export async function checkPrivateAuth(): Promise<boolean> {
-  if (!PRIVATE_MANIFEST_URL) return false;
+export async function checkPrivateAuth(): Promise<string | null> {
+  if (!PRIVATE_MANIFEST_URL) return null;
   try {
-    const resp = await fetch(PRIVATE_MANIFEST_URL, {
-      method: "HEAD",
-      credentials: "include",
-    });
-    return resp.ok;
+    const origin = new URL(PRIVATE_MANIFEST_URL).origin;
+    const resp = await fetch(`${origin}/whoami`, { credentials: "include" });
+    if (!resp.ok) return null;
+    const { email } = await resp.json() as { email: string };
+    return email || null;
   } catch {
-    return false;
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
Closes #395.

- `checkPrivateAuth()` now calls `/whoami` on the Worker and returns the user's email (or `null` if unauthenticated)
- App state changes from `privateAuth: boolean` → `userEmail: string | null`
- Header shows **"Logged in as \<email\>"** + **Sign out** button when authenticated; Login button otherwise

## Depends on
arktrace-commercial#74 must be deployed first (adds `/whoami` to the Worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)