### PR TITLE
feat(369): upload local analyst state to R2 and sync across users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,6 +221,9 @@ _inputs/custom_feeds/*.csv
 _outputs/
 .DS_Store
 
+# Node
+node_modules/
+
 # Keep data/ mostly ignored, but allow checked-in demo fixtures
 data/*
 !data/demo/

--- a/app/functions/api/reviews/push.ts
+++ b/app/functions/api/reviews/push.ts
@@ -2,21 +2,22 @@
  * POST /api/reviews/push
  *
  * Accepts vessel_reviews, vessel_reviews_audit, and analyst_briefs as Parquet
- * files in a multipart FormData body, then writes them to R2 under a per-user
- * prefix.  After writing, it updates reviews/index.json so other clients can
- * discover and pull the changes on their next sync.
+ * files in a multipart FormData body, then:
+ *   1. Writes them to R2 under reviews/<email>/ (per-user prefix).
+ *   2. Enqueues a merge job to the CF Queue (arktrace-review-merge).
+ *
+ * The queue consumer (workers/review-merge-consumer/) picks up the job and
+ * calls POST /api/reviews/merge on the Python pipeline server, which runs
+ * `sync_r2.py merge-reviews` to produce a single reviews/merged/*.parquet and
+ * patches ducklake_manifest.json so all clients detect the update on next sync.
  *
  * Auth: Cloudflare Access injects Cf-Access-Authenticated-User-Email
- * automatically before the request reaches this function.  Requests that
- * lack the header (unauthenticated) receive a 401.
+ * automatically.  Requests lacking the header receive 401.
  */
 
 interface Env {
   ARKTRACE_PUBLIC: R2Bucket;
-}
-
-interface ReviewsIndex {
-  users: { email: string; updatedAt: string }[];
+  REVIEW_MERGE_QUEUE: Queue;
 }
 
 export const onRequestPost: PagesFunction<Env> = async (ctx) => {
@@ -44,26 +45,17 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   const now     = new Date().toISOString();
   const putOpts = { httpMetadata: { contentType: "application/octet-stream" } };
 
+  // 1. Write per-user Parquet files to R2
   await Promise.all([
     ctx.env.ARKTRACE_PUBLIC.put(`${prefix}/reviews.parquet`, await reviews.arrayBuffer(), putOpts),
     ctx.env.ARKTRACE_PUBLIC.put(`${prefix}/audit.parquet`,   await audit.arrayBuffer(),   putOpts),
     ctx.env.ARKTRACE_PUBLIC.put(`${prefix}/briefs.parquet`,  await briefs.arrayBuffer(),  putOpts),
   ]);
 
-  // Update reviews/index.json — upsert this user's entry
-  const indexKey = "reviews/index.json";
-  let index: ReviewsIndex = { users: [] };
-  const existing = await ctx.env.ARKTRACE_PUBLIC.get(indexKey);
-  if (existing) {
-    try { index = await existing.json<ReviewsIndex>(); } catch { /* reset on corrupt */ }
-  }
-  index.users = [
-    ...index.users.filter((u) => u.email !== email),
-    { email, updatedAt: now },
-  ];
-  await ctx.env.ARKTRACE_PUBLIC.put(indexKey, JSON.stringify(index), {
-    httpMetadata: { contentType: "application/json" },
-  });
+  // 2. Enqueue merge job — queue consumer calls pipeline /api/reviews/merge
+  ctx.waitUntil(
+    ctx.env.REVIEW_MERGE_QUEUE.send({ email, triggeredAt: now })
+  );
 
   return json({ ok: true, email, updatedAt: now }, 200);
 };

--- a/app/functions/api/reviews/push.ts
+++ b/app/functions/api/reviews/push.ts
@@ -1,0 +1,76 @@
+/**
+ * POST /api/reviews/push
+ *
+ * Accepts vessel_reviews, vessel_reviews_audit, and analyst_briefs as Parquet
+ * files in a multipart FormData body, then writes them to R2 under a per-user
+ * prefix.  After writing, it updates reviews/index.json so other clients can
+ * discover and pull the changes on their next sync.
+ *
+ * Auth: Cloudflare Access injects Cf-Access-Authenticated-User-Email
+ * automatically before the request reaches this function.  Requests that
+ * lack the header (unauthenticated) receive a 401.
+ */
+
+interface Env {
+  ARKTRACE_PUBLIC: R2Bucket;
+}
+
+interface ReviewsIndex {
+  users: { email: string; updatedAt: string }[];
+}
+
+export const onRequestPost: PagesFunction<Env> = async (ctx) => {
+  const email = ctx.request.headers.get("Cf-Access-Authenticated-User-Email");
+  if (!email) {
+    return json({ error: "Sign in required to push changes" }, 401);
+  }
+
+  let formData: FormData;
+  try {
+    formData = await ctx.request.formData();
+  } catch {
+    return json({ error: "Invalid request body" }, 400);
+  }
+
+  const reviews = formData.get("reviews") as File | null;
+  const audit   = formData.get("audit")   as File | null;
+  const briefs  = formData.get("briefs")  as File | null;
+
+  if (!reviews || !audit || !briefs) {
+    return json({ error: "Missing files: expected reviews, audit, briefs" }, 400);
+  }
+
+  const prefix  = `reviews/${encodeURIComponent(email)}`;
+  const now     = new Date().toISOString();
+  const putOpts = { httpMetadata: { contentType: "application/octet-stream" } };
+
+  await Promise.all([
+    ctx.env.ARKTRACE_PUBLIC.put(`${prefix}/reviews.parquet`, await reviews.arrayBuffer(), putOpts),
+    ctx.env.ARKTRACE_PUBLIC.put(`${prefix}/audit.parquet`,   await audit.arrayBuffer(),   putOpts),
+    ctx.env.ARKTRACE_PUBLIC.put(`${prefix}/briefs.parquet`,  await briefs.arrayBuffer(),  putOpts),
+  ]);
+
+  // Update reviews/index.json — upsert this user's entry
+  const indexKey = "reviews/index.json";
+  let index: ReviewsIndex = { users: [] };
+  const existing = await ctx.env.ARKTRACE_PUBLIC.get(indexKey);
+  if (existing) {
+    try { index = await existing.json<ReviewsIndex>(); } catch { /* reset on corrupt */ }
+  }
+  index.users = [
+    ...index.users.filter((u) => u.email !== email),
+    { email, updatedAt: now },
+  ];
+  await ctx.env.ARKTRACE_PUBLIC.put(indexKey, JSON.stringify(index), {
+    httpMetadata: { contentType: "application/json" },
+  });
+
+  return json({ ok: true, email, updatedAt: now }, 200);
+};
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -19,7 +19,7 @@ import type { VesselRow, MetricsRow } from "./lib/duckdb";
 import type { AsyncDuckDB, AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import { syncAndLoad } from "./lib/opfs";
 import type { SyncStatus } from "./lib/opfs";
-import { pushReviews, pullRemoteReviews } from "./lib/push";
+import { pushReviews, mergeDownloadedReviews } from "./lib/push";
 import type { PushStatus } from "./lib/push";
 import { checkPrivateAuth, login, logout, isPrivateModeEnabled, getAuthToken } from "./lib/auth";
 import { loadConfig } from "./lib/config";
@@ -105,8 +105,8 @@ export default function App() {
     const loaded = await syncAndLoad(target, setSyncStatus, regionFilter, isAuthed, activeCfg, token);
     if (loaded > 0 && connRef.current) {
       // Pull remote reviews from R2 and merge into local DuckDB before refreshing UI
-      await pullRemoteReviews(target, connRef.current).catch((err) =>
-        console.warn("[sync] pullRemoteReviews failed:", err)
+      await mergeDownloadedReviews(connRef.current).catch((err) =>
+        console.warn("[sync] mergeDownloadedReviews failed:", err)
       );
       await refreshQuery();
     }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -19,6 +19,8 @@ import type { VesselRow, MetricsRow } from "./lib/duckdb";
 import type { AsyncDuckDB, AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import { syncAndLoad } from "./lib/opfs";
 import type { SyncStatus } from "./lib/opfs";
+import { pushReviews, pullRemoteReviews } from "./lib/push";
+import type { PushStatus } from "./lib/push";
 import { checkPrivateAuth, login, logout, isPrivateModeEnabled, getAuthToken } from "./lib/auth";
 import { loadConfig } from "./lib/config";
 import type { AppConfig } from "./lib/config";
@@ -59,6 +61,7 @@ export default function App() {
   const prevVesselsRef = useRef<VesselRow[]>([]);
   const [appConfig, setAppConfig] = useState<AppConfig | null>(null);
   const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [pushStatus, setPushStatus] = useState<PushStatus>({ phase: "idle" });
   const privateAuth = userEmail !== null;
   const privateMode = appConfig ? isPrivateModeEnabled(appConfig) : false;
 
@@ -101,6 +104,10 @@ export default function App() {
     setSyncStatus({ phase: "fetching_manifest" });
     const loaded = await syncAndLoad(target, setSyncStatus, regionFilter, isAuthed, activeCfg, token);
     if (loaded > 0 && connRef.current) {
+      // Pull remote reviews from R2 and merge into local DuckDB before refreshing UI
+      await pullRemoteReviews(target, connRef.current).catch((err) =>
+        console.warn("[sync] pullRemoteReviews failed:", err)
+      );
       await refreshQuery();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -125,6 +132,17 @@ export default function App() {
     const states = await getBulkReviewStates(conn, vs.map((v) => v.mmsi));
     setReviewStates(states);
   }, [minConfidence, selectedRegions]);
+
+  const handlePush = useCallback(async () => {
+    const db = dbRef.current;
+    const conn = connRef.current;
+    if (!db || !conn || !userEmail) return;
+    try {
+      await pushReviews(db, conn, setPushStatus);
+    } catch (err) {
+      setPushStatus({ phase: "error", message: String(err) });
+    }
+  }, [userEmail]);
 
   const handleClaim = useCallback(async (mmsi: string) => {
     const conn = connRef.current;
@@ -291,7 +309,13 @@ export default function App() {
       />
 
       {/* Sync status */}
-      <SyncStatusBar status={syncStatus} onSync={() => doSync()} />
+      <SyncStatusBar
+        status={syncStatus}
+        onSync={() => doSync()}
+        userEmail={userEmail}
+        pushStatus={pushStatus}
+        onPush={userEmail ? handlePush : undefined}
+      />
 
       {/* Main content: sidebar + map */}
       <div style={{ display: "flex", flex: 1, overflow: "hidden", minHeight: 0 }}>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -104,10 +104,11 @@ export default function App() {
     setSyncStatus({ phase: "fetching_manifest" });
     const loaded = await syncAndLoad(target, setSyncStatus, regionFilter, isAuthed, activeCfg, token);
     if (loaded > 0 && connRef.current) {
-      // Pull remote reviews from R2 and merge into local DuckDB before refreshing UI
-      await mergeDownloadedReviews(connRef.current).catch((err) =>
-        console.warn("[sync] mergeDownloadedReviews failed:", err)
-      );
+      if (isAuthed) {
+        await mergeDownloadedReviews(connRef.current).catch((err) =>
+          console.warn("[sync] mergeDownloadedReviews failed:", err)
+        );
+      }
       await refreshQuery();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/src/components/SyncStatus.tsx
+++ b/app/src/components/SyncStatus.tsx
@@ -1,8 +1,12 @@
 import type { SyncStatus } from "../lib/opfs";
+import type { PushStatus } from "../lib/push";
 
 interface Props {
   status: SyncStatus;
   onSync: () => void;
+  userEmail?: string | null;
+  pushStatus?: PushStatus;
+  onPush?: () => void;
 }
 
 function formatCacheAge(iso: string): string {
@@ -12,7 +16,43 @@ function formatCacheAge(iso: string): string {
   return `${days} days ago`;
 }
 
-export default function SyncStatusBar({ status, onSync }: Props) {
+function formatPushedAt(iso: string): string {
+  const mins = Math.floor((Date.now() - new Date(iso).getTime()) / 60_000);
+  if (mins < 1) return "just now";
+  if (mins === 1) return "1 min ago";
+  if (mins < 60) return `${mins} mins ago`;
+  return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+const BTN: React.CSSProperties = {
+  background: "#2d3748",
+  border: "none",
+  color: "#e2e8f0",
+  padding: "0.2rem 0.6rem",
+  borderRadius: 4,
+  cursor: "pointer",
+  fontSize: "0.7rem",
+};
+
+const BTN_PUSH: React.CSSProperties = {
+  ...BTN,
+  background: "#1e3a5f",
+  border: "1px solid #2b6cb0",
+  color: "#90cdf4",
+};
+
+const BTN_SMALL: React.CSSProperties = {
+  marginLeft: "auto",
+  background: "none",
+  border: "1px solid #2d3748",
+  color: "#718096",
+  padding: "0.15rem 0.5rem",
+  borderRadius: 3,
+  cursor: "pointer",
+  fontSize: "0.65rem",
+};
+
+export default function SyncStatusBar({ status, onSync, userEmail, pushStatus, onPush }: Props) {
   const base: React.CSSProperties = {
     display: "flex",
     alignItems: "center",
@@ -25,24 +65,48 @@ export default function SyncStatusBar({ status, onSync }: Props) {
     flexShrink: 0,
   };
 
+  // Push button — shown only when a user is logged in and sync is ready/idle
+  const showPush =
+    !!userEmail &&
+    !!onPush &&
+    (status.phase === "ready" || status.phase === "idle");
+
+  function PushBtn() {
+    if (!showPush) return null;
+    const phase = pushStatus?.phase ?? "idle";
+    const pushing = phase === "exporting" || phase === "uploading";
+    const label =
+      phase === "exporting" ? "Exporting…"
+      : phase === "uploading" ? "Uploading…"
+      : phase === "done"     ? `Pushed ${formatPushedAt((pushStatus as { phase: "done"; pushedAt: string }).pushedAt)}`
+      : phase === "error"    ? "Push failed — retry"
+      : "Push reviews";
+
+    return (
+      <button
+        onClick={onPush}
+        disabled={pushing}
+        title={userEmail ?? undefined}
+        style={{
+          ...BTN_PUSH,
+          opacity: pushing ? 0.6 : 1,
+          cursor: pushing ? "default" : "pointer",
+          color: phase === "error" ? "#fc8181"
+               : phase === "done"  ? "#68d391"
+               : "#90cdf4",
+        }}
+      >
+        ↑ {label}
+      </button>
+    );
+  }
+
   if (status.phase === "idle") {
     return (
       <div style={base}>
         <span>Not synced.</span>
-        <button
-          onClick={onSync}
-          style={{
-            background: "#2d3748",
-            border: "none",
-            color: "#e2e8f0",
-            padding: "0.2rem 0.6rem",
-            borderRadius: 4,
-            cursor: "pointer",
-            fontSize: "0.7rem",
-          }}
-        >
-          Sync from R2
-        </button>
+        <button onClick={onSync} style={BTN}>Sync from R2</button>
+        <PushBtn />
       </div>
     );
   }
@@ -57,19 +121,14 @@ export default function SyncStatusBar({ status, onSync }: Props) {
       <div style={base}>
         <div
           style={{
-            width: 80,
-            height: 4,
-            background: "#2d3748",
-            borderRadius: 2,
-            overflow: "hidden",
+            width: 80, height: 4, background: "#2d3748",
+            borderRadius: 2, overflow: "hidden",
           }}
         >
           <div
             style={{
-              width: `${pct}%`,
-              height: "100%",
-              background: "#3b82f6",
-              transition: "width 0.2s",
+              width: `${pct}%`, height: "100%",
+              background: "#3b82f6", transition: "width 0.2s",
             }}
           />
         </div>
@@ -96,21 +155,8 @@ export default function SyncStatusBar({ status, onSync }: Props) {
           : status.fromCache
           ? ` (from OPFS cache${ageLabel})`
           : ` (synced from R2${ageLabel})`}
-        <button
-          onClick={onSync}
-          style={{
-            marginLeft: "auto",
-            background: "none",
-            border: "1px solid #2d3748",
-            color: "#718096",
-            padding: "0.15rem 0.5rem",
-            borderRadius: 3,
-            cursor: "pointer",
-            fontSize: "0.65rem",
-          }}
-        >
-          Re-sync
-        </button>
+        <PushBtn />
+        <button onClick={onSync} style={BTN_SMALL}>Re-sync</button>
       </div>
     );
   }
@@ -119,19 +165,8 @@ export default function SyncStatusBar({ status, onSync }: Props) {
     return (
       <div style={{ ...base, color: "#fc8181" }}>
         ✗ {status.message}
-        <button
-          onClick={onSync}
-          style={{
-            marginLeft: "auto",
-            background: "#2d3748",
-            border: "none",
-            color: "#e2e8f0",
-            padding: "0.2rem 0.6rem",
-            borderRadius: 4,
-            cursor: "pointer",
-            fontSize: "0.65rem",
-          }}
-        >
+        <PushBtn />
+        <button onClick={onSync} style={{ ...BTN_SMALL, marginLeft: showPush ? "0" : "auto" }}>
           Retry
         </button>
       </div>

--- a/app/src/lib/opfs.ts
+++ b/app/src/lib/opfs.ts
@@ -47,6 +47,12 @@ export interface ManifestFile {
    * that contain all regions — those are always downloaded.
    */
   region?: string;
+  /**
+   * When true, this file is only downloaded for authenticated (logged-in) users.
+   * Non-authenticated clients skip it entirely.  Used for merged analyst review
+   * files which must not leak to anonymous sessions.
+   */
+  private?: boolean;
 }
 
 export interface Manifest {
@@ -208,9 +214,10 @@ export async function syncAndLoad(
   // ── 2. Download missing / stale files ───────────────────────────────────
   // Filter by region: skip files tagged for a different region than requested.
   // Files with no region tag are always included (they contain all regions).
-  const wantedFiles = regions
+  const wantedFiles = (regions
     ? manifest.files.filter((f) => !f.region || regions.includes(f.region))
-    : manifest.files;
+    : manifest.files
+  ).filter((f) => !f.private || privateAuth);
 
   const toDownload: ManifestFile[] = [];
   for (const f of wantedFiles) {

--- a/app/src/lib/push.ts
+++ b/app/src/lib/push.ts
@@ -1,25 +1,27 @@
 /**
- * push.ts — upload local analyst state to R2 and pull remote state from R2.
+ * push.ts — upload local analyst state to R2 and apply server-merged state on sync.
  *
  * Upload flow (per user, manual):
  *   1. Export vessel_reviews, vessel_reviews_audit, analyst_briefs to Parquet
- *      via DuckDB-WASM COPY TO (writes to the in-memory VFS).
- *   2. POST the Parquet buffers to /api/reviews/push (CF Pages Function).
- *   3. The Worker writes to reviews/<email>/*.parquet and updates
- *      reviews/index.json in R2.
+ *      via DuckDB-WASM COPY TO.
+ *   2. POST the buffers to /api/reviews/push (CF Pages Function).
+ *   3. The Worker writes reviews/<email>/*.parquet to R2 and enqueues a merge
+ *      job to the CF Queue.
+ *   4. The queue consumer calls POST /api/reviews/merge on the Python pipeline
+ *      server, which runs sync_r2.py merge-reviews and patches the manifest.
  *
- * Pull flow (automatic on sync):
- *   1. Fetch reviews/index.json from the public R2 bucket.
- *   2. For each user listed, download their three Parquet files.
- *   3. Merge into the local DuckDB-WASM tables with the conflict strategies
- *      defined in issue #369:
- *        vessel_reviews      → last-write-wins on updated_at
- *        vessel_reviews_audit → append-only, dedup on (mmsi, changed_at)
- *        analyst_briefs      → last-write-wins on generated_at
+ * Pull / apply flow (automatic on every sync):
+ *   1. syncAndLoad() downloads reviews_merged.parquet, reviews_audit_merged.parquet,
+ *      and reviews_briefs_merged.parquet when the manifest reports new size_bytes.
+ *   2. mergeDownloadedReviews() applies them to the local DuckDB-WASM tables
+ *      using the same conflict strategies (last-write-wins / append-only dedup).
+ *
+ * No client-side index.json fetching or per-user file downloads — all merging
+ * happens server-side in the Python pipeline.
  */
 
-import type { AsyncDuckDB, AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
-import { R2_BASE_URL } from "./opfs";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
+import type { AsyncDuckDB } from "@duckdb/duckdb-wasm";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,18 +34,14 @@ export type PushStatus =
   | { phase: "done"; pushedAt: string }
   | { phase: "error"; message: string };
 
-interface ReviewsIndex {
-  users: { email: string; updatedAt: string }[];
-}
-
 // ---------------------------------------------------------------------------
 // Push: local → R2
 // ---------------------------------------------------------------------------
 
 /**
- * Serialise the three analyst-state tables to Parquet and POST them to the
- * CF Pages Function at /api/reviews/push.  The function validates CF Access
- * auth and writes the files under reviews/<email>/ in R2.
+ * Serialise the three analyst-state tables to Parquet and POST them to
+ * /api/reviews/push.  The CF Pages Function validates auth (CF Access JWT),
+ * writes the files to R2, and enqueues a merge job.
  *
  * Throws on auth failure or network error so the caller can surface the
  * message via onStatus({ phase: "error", message }).
@@ -66,7 +64,11 @@ export async function pushReviews(
     await conn.query(`COPY ${table} TO '${file}' (FORMAT PARQUET)`);
     const bytes = await db.copyFileToBuffer(file);
     await db.dropFile(file);
-    form.append(field, new Blob([bytes.buffer as ArrayBuffer], { type: "application/octet-stream" }), `${field}.parquet`);
+    form.append(
+      field,
+      new Blob([bytes.buffer as ArrayBuffer], { type: "application/octet-stream" }),
+      `${field}.parquet`
+    );
   }
 
   onStatus({ phase: "uploading" });
@@ -88,108 +90,80 @@ export async function pushReviews(
 }
 
 // ---------------------------------------------------------------------------
-// Pull: R2 → local
+// Apply: merge server-merged Parquet files into local DuckDB
 // ---------------------------------------------------------------------------
 
 /**
- * Fetch all users' review Parquet files from the public R2 bucket and merge
- * them into the local DuckDB-WASM tables.  Called automatically at the end
- * of each sync so every analyst sees the latest shared state.
+ * Apply the server-merged review files that syncAndLoad() just downloaded into
+ * the local DuckDB-WASM tables.  Called automatically after every sync.
  *
- * Returns the number of user prefixes successfully merged (0 = nothing to
- * pull or index not found yet).
+ * The files are registered by syncAndLoad() as:
+ *   reviews_merged.parquet        → vessel_reviews
+ *   reviews_audit_merged.parquet  → vessel_reviews_audit
+ *   reviews_briefs_merged.parquet → analyst_briefs
+ *
+ * If the manifest does not yet contain these files (no reviews have ever been
+ * pushed) the queries fail silently and 0 is returned.
+ *
+ * Returns the number of merge operations that succeeded (0–3).
  */
-export async function pullRemoteReviews(
-  db: AsyncDuckDB,
+export async function mergeDownloadedReviews(
   conn: AsyncDuckDBConnection
 ): Promise<number> {
-  let index: ReviewsIndex;
-  try {
-    const resp = await fetch(`${R2_BASE_URL}/reviews/index.json`, { cache: "no-store" });
-    if (!resp.ok) return 0;
-    index = (await resp.json()) as ReviewsIndex;
-  } catch {
-    return 0;
-  }
+  let applied = 0;
 
-  if (!index.users?.length) return 0;
+  const ops: Array<{ file: string; sql: string }> = [
+    {
+      file: "reviews_merged.parquet",
+      sql: `
+        INSERT OR REPLACE INTO vessel_reviews (
+          mmsi, decision_tier, handoff_state, reviewer_id, rationale,
+          identifier_basis, outcome, outcome_notes, officer_id, created_at, updated_at
+        )
+        SELECT
+          mmsi, decision_tier, handoff_state, reviewer_id, rationale,
+          identifier_basis, outcome, outcome_notes, officer_id, created_at, updated_at
+        FROM read_parquet('reviews_merged.parquet') AS r
+        WHERE r.updated_at >= COALESCE(
+          (SELECT updated_at FROM vessel_reviews WHERE mmsi = r.mmsi),
+          '1970-01-01'::TIMESTAMP
+        )
+      `,
+    },
+    {
+      file: "reviews_audit_merged.parquet",
+      sql: `
+        INSERT INTO vessel_reviews_audit (mmsi, changed_at, reviewer_id, from_state, to_state, rationale)
+        SELECT mmsi, changed_at, reviewer_id, from_state, to_state, rationale
+        FROM read_parquet('reviews_audit_merged.parquet') AS r
+        WHERE NOT EXISTS (
+          SELECT 1 FROM vessel_reviews_audit a
+          WHERE a.mmsi = r.mmsi AND a.changed_at = r.changed_at
+        )
+      `,
+    },
+    {
+      file: "reviews_briefs_merged.parquet",
+      sql: `
+        INSERT OR REPLACE INTO analyst_briefs (mmsi, brief, generated_at)
+        SELECT mmsi, brief, generated_at
+        FROM read_parquet('reviews_briefs_merged.parquet') AS r
+        WHERE r.generated_at >= COALESCE(
+          (SELECT generated_at FROM analyst_briefs WHERE mmsi = r.mmsi),
+          '1970-01-01'::TIMESTAMP
+        )
+      `,
+    },
+  ];
 
-  let merged = 0;
-  for (const { email } of index.users) {
-    const prefix = `${R2_BASE_URL}/reviews/${encodeURIComponent(email)}`;
+  for (const { sql } of ops) {
     try {
-      const [reviewsBuf, auditBuf, briefsBuf] = await Promise.all([
-        fetchBuf(`${prefix}/reviews.parquet`),
-        fetchBuf(`${prefix}/audit.parquet`),
-        fetchBuf(`${prefix}/briefs.parquet`),
-      ]);
-
-      const tag = String(merged); // unique suffix per user to avoid VFS name collisions
-
-      if (reviewsBuf) {
-        const name = `_remote_reviews_${tag}.parquet`;
-        await db.registerFileBuffer(name, new Uint8Array(reviewsBuf));
-        await conn.query(`
-          INSERT OR REPLACE INTO vessel_reviews (
-            mmsi, decision_tier, handoff_state, reviewer_id, rationale,
-            identifier_basis, outcome, outcome_notes, officer_id, created_at, updated_at
-          )
-          SELECT
-            mmsi, decision_tier, handoff_state, reviewer_id, rationale,
-            identifier_basis, outcome, outcome_notes, officer_id, created_at, updated_at
-          FROM read_parquet('${name}') AS r
-          WHERE r.updated_at >= COALESCE(
-            (SELECT updated_at FROM vessel_reviews WHERE mmsi = r.mmsi),
-            '1970-01-01'::TIMESTAMP
-          )
-        `);
-        await db.dropFile(name);
-      }
-
-      if (auditBuf) {
-        const name = `_remote_audit_${tag}.parquet`;
-        await db.registerFileBuffer(name, new Uint8Array(auditBuf));
-        await conn.query(`
-          INSERT INTO vessel_reviews_audit (mmsi, changed_at, reviewer_id, from_state, to_state, rationale)
-          SELECT mmsi, changed_at, reviewer_id, from_state, to_state, rationale
-          FROM read_parquet('${name}') AS r
-          WHERE NOT EXISTS (
-            SELECT 1 FROM vessel_reviews_audit a
-            WHERE a.mmsi = r.mmsi AND a.changed_at = r.changed_at
-          )
-        `);
-        await db.dropFile(name);
-      }
-
-      if (briefsBuf) {
-        const name = `_remote_briefs_${tag}.parquet`;
-        await db.registerFileBuffer(name, new Uint8Array(briefsBuf));
-        await conn.query(`
-          INSERT OR REPLACE INTO analyst_briefs (mmsi, brief, generated_at)
-          SELECT mmsi, brief, generated_at
-          FROM read_parquet('${name}') AS r
-          WHERE r.generated_at >= COALESCE(
-            (SELECT generated_at FROM analyst_briefs WHERE mmsi = r.mmsi),
-            '1970-01-01'::TIMESTAMP
-          )
-        `);
-        await db.dropFile(name);
-      }
-
-      merged++;
-    } catch (err) {
-      console.warn(`[push] Failed to pull reviews for ${email}:`, err);
+      await conn.query(sql);
+      applied++;
+    } catch {
+      // File not yet in the manifest (no pushes yet) — skip silently
     }
   }
 
-  return merged;
-}
-
-async function fetchBuf(url: string): Promise<ArrayBuffer | null> {
-  try {
-    const resp = await fetch(url, { credentials: "omit" });
-    return resp.ok ? resp.arrayBuffer() : null;
-  } catch {
-    return null;
-  }
+  return applied;
 }

--- a/app/src/lib/push.ts
+++ b/app/src/lib/push.ts
@@ -1,0 +1,195 @@
+/**
+ * push.ts — upload local analyst state to R2 and pull remote state from R2.
+ *
+ * Upload flow (per user, manual):
+ *   1. Export vessel_reviews, vessel_reviews_audit, analyst_briefs to Parquet
+ *      via DuckDB-WASM COPY TO (writes to the in-memory VFS).
+ *   2. POST the Parquet buffers to /api/reviews/push (CF Pages Function).
+ *   3. The Worker writes to reviews/<email>/*.parquet and updates
+ *      reviews/index.json in R2.
+ *
+ * Pull flow (automatic on sync):
+ *   1. Fetch reviews/index.json from the public R2 bucket.
+ *   2. For each user listed, download their three Parquet files.
+ *   3. Merge into the local DuckDB-WASM tables with the conflict strategies
+ *      defined in issue #369:
+ *        vessel_reviews      → last-write-wins on updated_at
+ *        vessel_reviews_audit → append-only, dedup on (mmsi, changed_at)
+ *        analyst_briefs      → last-write-wins on generated_at
+ */
+
+import type { AsyncDuckDB, AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
+import { R2_BASE_URL } from "./opfs";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PushStatus =
+  | { phase: "idle" }
+  | { phase: "exporting" }
+  | { phase: "uploading" }
+  | { phase: "done"; pushedAt: string }
+  | { phase: "error"; message: string };
+
+interface ReviewsIndex {
+  users: { email: string; updatedAt: string }[];
+}
+
+// ---------------------------------------------------------------------------
+// Push: local → R2
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialise the three analyst-state tables to Parquet and POST them to the
+ * CF Pages Function at /api/reviews/push.  The function validates CF Access
+ * auth and writes the files under reviews/<email>/ in R2.
+ *
+ * Throws on auth failure or network error so the caller can surface the
+ * message via onStatus({ phase: "error", message }).
+ */
+export async function pushReviews(
+  db: AsyncDuckDB,
+  conn: AsyncDuckDBConnection,
+  onStatus: (s: PushStatus) => void
+): Promise<void> {
+  onStatus({ phase: "exporting" });
+
+  const exports = [
+    { table: "vessel_reviews",       file: "_push_reviews.parquet", field: "reviews" },
+    { table: "vessel_reviews_audit", file: "_push_audit.parquet",   field: "audit"   },
+    { table: "analyst_briefs",       file: "_push_briefs.parquet",  field: "briefs"  },
+  ] as const;
+
+  const form = new FormData();
+  for (const { table, file, field } of exports) {
+    await conn.query(`COPY ${table} TO '${file}' (FORMAT PARQUET)`);
+    const bytes = await db.copyFileToBuffer(file);
+    await db.dropFile(file);
+    form.append(field, new Blob([bytes.buffer as ArrayBuffer], { type: "application/octet-stream" }), `${field}.parquet`);
+  }
+
+  onStatus({ phase: "uploading" });
+
+  const resp = await fetch("/api/reviews/push", {
+    method: "POST",
+    credentials: "include", // send CF_Authorization cookie
+    body: form,
+  });
+
+  if (resp.status === 401) throw new Error("Sign in required to push changes");
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => String(resp.status));
+    throw new Error(`Push failed: ${text}`);
+  }
+
+  const { updatedAt } = (await resp.json()) as { updatedAt: string };
+  onStatus({ phase: "done", pushedAt: updatedAt });
+}
+
+// ---------------------------------------------------------------------------
+// Pull: R2 → local
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch all users' review Parquet files from the public R2 bucket and merge
+ * them into the local DuckDB-WASM tables.  Called automatically at the end
+ * of each sync so every analyst sees the latest shared state.
+ *
+ * Returns the number of user prefixes successfully merged (0 = nothing to
+ * pull or index not found yet).
+ */
+export async function pullRemoteReviews(
+  db: AsyncDuckDB,
+  conn: AsyncDuckDBConnection
+): Promise<number> {
+  let index: ReviewsIndex;
+  try {
+    const resp = await fetch(`${R2_BASE_URL}/reviews/index.json`, { cache: "no-store" });
+    if (!resp.ok) return 0;
+    index = (await resp.json()) as ReviewsIndex;
+  } catch {
+    return 0;
+  }
+
+  if (!index.users?.length) return 0;
+
+  let merged = 0;
+  for (const { email } of index.users) {
+    const prefix = `${R2_BASE_URL}/reviews/${encodeURIComponent(email)}`;
+    try {
+      const [reviewsBuf, auditBuf, briefsBuf] = await Promise.all([
+        fetchBuf(`${prefix}/reviews.parquet`),
+        fetchBuf(`${prefix}/audit.parquet`),
+        fetchBuf(`${prefix}/briefs.parquet`),
+      ]);
+
+      const tag = String(merged); // unique suffix per user to avoid VFS name collisions
+
+      if (reviewsBuf) {
+        const name = `_remote_reviews_${tag}.parquet`;
+        await db.registerFileBuffer(name, new Uint8Array(reviewsBuf));
+        await conn.query(`
+          INSERT OR REPLACE INTO vessel_reviews (
+            mmsi, decision_tier, handoff_state, reviewer_id, rationale,
+            identifier_basis, outcome, outcome_notes, officer_id, created_at, updated_at
+          )
+          SELECT
+            mmsi, decision_tier, handoff_state, reviewer_id, rationale,
+            identifier_basis, outcome, outcome_notes, officer_id, created_at, updated_at
+          FROM read_parquet('${name}') AS r
+          WHERE r.updated_at >= COALESCE(
+            (SELECT updated_at FROM vessel_reviews WHERE mmsi = r.mmsi),
+            '1970-01-01'::TIMESTAMP
+          )
+        `);
+        await db.dropFile(name);
+      }
+
+      if (auditBuf) {
+        const name = `_remote_audit_${tag}.parquet`;
+        await db.registerFileBuffer(name, new Uint8Array(auditBuf));
+        await conn.query(`
+          INSERT INTO vessel_reviews_audit (mmsi, changed_at, reviewer_id, from_state, to_state, rationale)
+          SELECT mmsi, changed_at, reviewer_id, from_state, to_state, rationale
+          FROM read_parquet('${name}') AS r
+          WHERE NOT EXISTS (
+            SELECT 1 FROM vessel_reviews_audit a
+            WHERE a.mmsi = r.mmsi AND a.changed_at = r.changed_at
+          )
+        `);
+        await db.dropFile(name);
+      }
+
+      if (briefsBuf) {
+        const name = `_remote_briefs_${tag}.parquet`;
+        await db.registerFileBuffer(name, new Uint8Array(briefsBuf));
+        await conn.query(`
+          INSERT OR REPLACE INTO analyst_briefs (mmsi, brief, generated_at)
+          SELECT mmsi, brief, generated_at
+          FROM read_parquet('${name}') AS r
+          WHERE r.generated_at >= COALESCE(
+            (SELECT generated_at FROM analyst_briefs WHERE mmsi = r.mmsi),
+            '1970-01-01'::TIMESTAMP
+          )
+        `);
+        await db.dropFile(name);
+      }
+
+      merged++;
+    } catch (err) {
+      console.warn(`[push] Failed to pull reviews for ${email}:`, err);
+    }
+  }
+
+  return merged;
+}
+
+async function fetchBuf(url: string): Promise<ArrayBuffer | null> {
+  try {
+    const resp = await fetch(url, { credentials: "omit" });
+    return resp.ok ? resp.arrayBuffer() : null;
+  } catch {
+    return null;
+  }
+}

--- a/pipeline/src/api/db.py
+++ b/pipeline/src/api/db.py
@@ -1,0 +1,74 @@
+"""Shared DuckDB connection for the API.
+
+DuckDB does not support multiple concurrent connections to the same file with
+different configurations (read-only vs read-write).  All API routes must share
+a single connection object so DuckDB sees consistent configuration.
+
+The connection is opened once at first access and reused for the lifetime of
+the process.  A threading.Lock serialises concurrent requests so the
+synchronous DuckDB driver is not called from multiple threads simultaneously.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+import duckdb
+
+from pipeline.src.storage.config import _canonical_data_dir
+
+_DEFAULT_DB_PATH = str(Path(_canonical_data_dir()) / "singapore.duckdb")
+
+logger = logging.getLogger(__name__)
+
+_conn: duckdb.DuckDBPyConnection | None = None
+_conn_path: str | None = None
+_lock = threading.Lock()
+
+
+def _db_path() -> str:
+    return os.getenv("DB_PATH", _DEFAULT_DB_PATH)
+
+
+@contextmanager
+def get_conn() -> Generator[duckdb.DuckDBPyConnection, None, None]:
+    """Yield the shared DuckDB connection under the global lock.
+
+    The connection is reopened automatically when DB_PATH changes (e.g. between
+    test runs that each use a separate tmp_db).
+
+    Usage::
+
+        from pipeline.src.api.db import get_conn
+
+        with get_conn() as con:
+            rows = con.execute("SELECT ...").fetchall()
+    """
+    global _conn, _conn_path
+    with _lock:
+        current_path = _db_path()
+        if _conn is not None and _conn_path != current_path:
+            # DB_PATH changed (e.g. test isolation) — close and reopen.
+            try:
+                _conn.close()
+            except Exception:
+                # Best-effort close during connection rotation; keep behavior
+                # non-fatal, but record details for troubleshooting.
+                logger.debug(
+                    "Ignoring DuckDB close failure while rotating connection", exc_info=True
+                )
+            _conn = None
+            _conn_path = None
+        if _conn is None:
+            if os.path.exists(current_path):
+                _conn = duckdb.connect(current_path)
+                _conn_path = current_path
+        if _conn is None:
+            yield None  # type: ignore[misc]
+            return
+        yield _conn

--- a/pipeline/src/api/main.py
+++ b/pipeline/src/api/main.py
@@ -1,0 +1,27 @@
+"""Pipeline API server.
+
+Exposes endpoints consumed by the arktrace SPA and its CF Worker infrastructure.
+
+Start with:
+    uv run uvicorn pipeline.src.api.main:app --host 0.0.0.0 --port 8000 --reload
+
+Environment variables:
+    PIPELINE_SECRET   Shared secret checked by POST /api/reviews/merge.
+                      Set the same value as the PIPELINE_SECRET Worker secret.
+    DB_PATH           Path to the DuckDB file (default: data/processed/singapore.duckdb).
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from pipeline.src.api.routes.reviews import router as reviews_router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="arktrace pipeline API", version="0.1.0", docs_url="/api/docs")
+    app.include_router(reviews_router)
+    return app
+
+
+app = create_app()

--- a/pipeline/src/api/routes/reviews.py
+++ b/pipeline/src/api/routes/reviews.py
@@ -1,0 +1,51 @@
+"""Review sync endpoint — called by the CF Queue consumer Worker after a user pushes."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "scripts"
+
+
+def _run_merge_reviews() -> None:
+    """Run sync_r2.py merge-reviews as a background task."""
+    script = _SCRIPTS_DIR / "sync_r2.py"
+    result = subprocess.run(
+        [sys.executable, "-m", "uv", "run", "python", str(script), "merge-reviews"],
+        capture_output=True,
+        text=True,
+        cwd=str(_SCRIPTS_DIR.parent),
+    )
+    if result.returncode != 0:
+        logger.error("[merge-reviews] failed:\n%s\n%s", result.stdout, result.stderr)
+    else:
+        logger.info("[merge-reviews] done:\n%s", result.stdout)
+
+
+@router.post("/api/reviews/merge", status_code=202)
+async def trigger_merge_reviews(
+    request: Request,
+    background_tasks: BackgroundTasks,
+) -> dict[str, str]:
+    """Trigger a server-side merge of all per-user review Parquet files into
+    reviews/merged/*.parquet and patch ducklake_manifest.json.
+
+    Called by the CF Queue consumer Worker (workers/review-merge-consumer/).
+    Protected by a shared secret in the X-Pipeline-Secret header.
+    """
+    secret = request.headers.get("X-Pipeline-Secret", "")
+    expected = os.getenv("PIPELINE_SECRET", "")
+    if not expected or secret != expected:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    background_tasks.add_task(_run_merge_reviews)
+    return {"status": "accepted"}

--- a/pipeline/src/api/routes/reviews.py
+++ b/pipeline/src/api/routes/reviews.py
@@ -6,18 +6,36 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 _SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "scripts"
 
+# ---------------------------------------------------------------------------
+# Coalescing run-once guard
+#
+# Two requests that arrive while a merge is already running must not spawn a
+# second concurrent subprocess (risk of interleaved R2 writes and a corrupt
+# manifest).  Instead:
+#   • The first request starts the merge and sets _running = True.
+#   • Any request that arrives while the merge is running sets _pending = True
+#     and returns 202 immediately — the pipeline will re-run once the current
+#     merge finishes, picking up anything that arrived in the meantime.
+#   • After every run the loop checks _pending; if set it runs once more then
+#     clears both flags.
+# ---------------------------------------------------------------------------
+_state_lock = threading.Lock()
+_running = False
+_pending = False
 
-def _run_merge_reviews() -> None:
-    """Run sync_r2.py merge-reviews as a background task."""
+
+def _do_merge() -> None:
+    """Run sync_r2.py merge-reviews once (subprocess, blocking)."""
     script = _SCRIPTS_DIR / "sync_r2.py"
     result = subprocess.run(
         [sys.executable, "-m", "uv", "run", "python", str(script), "merge-reviews"],
@@ -31,21 +49,56 @@ def _run_merge_reviews() -> None:
         logger.info("[merge-reviews] done:\n%s", result.stdout)
 
 
+def _run_merge_reviews() -> None:
+    """Background task: run merge, then re-run once if a new request arrived
+    while the first merge was in progress."""
+    global _running, _pending
+
+    with _state_lock:
+        if _running:
+            # Another invocation is already executing; mark that a follow-up
+            # run is needed and bail out — the active loop will handle it.
+            _pending = True
+            return
+        _running = True
+
+    try:
+        while True:
+            _do_merge()
+            with _state_lock:
+                if _pending:
+                    _pending = False
+                    # loop: run once more for requests that accumulated above
+                else:
+                    break
+    finally:
+        with _state_lock:
+            _running = False
+            _pending = False
+
+
 @router.post("/api/reviews/merge", status_code=202)
 async def trigger_merge_reviews(
     request: Request,
-    background_tasks: BackgroundTasks,
 ) -> dict[str, str]:
     """Trigger a server-side merge of all per-user review Parquet files into
     reviews/merged/*.parquet and patch ducklake_manifest.json.
 
     Called by the CF Queue consumer Worker (workers/review-merge-consumer/).
     Protected by a shared secret in the X-Pipeline-Secret header.
+
+    At most one merge subprocess runs at a time.  Duplicate calls while a merge
+    is in-flight set a pending flag so a follow-up run happens automatically
+    after the current one finishes — no data is lost and no two merges race.
     """
     secret = request.headers.get("X-Pipeline-Secret", "")
     expected = os.getenv("PIPELINE_SECRET", "")
     if not expected or secret != expected:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
-    background_tasks.add_task(_run_merge_reviews)
+    # Spawn in a daemon thread so FastAPI stays responsive; the coalescing guard
+    # above prevents overlapping runs regardless of how many requests arrive.
+    t = threading.Thread(target=_run_merge_reviews, daemon=True)
+    t.start()
+
     return {"status": "accepted"}

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -170,6 +170,8 @@ _SANCTIONS_DB_R2_KEY = "public_eval.duckdb"  # OpenSanctions DB; separate from r
 _WATCHLISTS_R2_KEY = "watchlists.zip"  # lightweight bundle of *_watchlist.parquet files
 _DEMO_R2_KEY = "demo.zip"  # fixed-key public demo bundle; overwritten on every push-demo
 _REVIEWS_R2_KEY = "reviews.parquet"  # analyst review decisions; overwritten on every push-reviews
+_REVIEWS_PREFIX  = "reviews"          # per-user uploads live under reviews/<email>/
+_REVIEWS_MERGED_PREFIX = "reviews/merged"  # server-side merged output
 
 # DuckLake catalog keys — public bucket (root) and private bucket (outputs/ prefix)
 # catalog.duckdb is a fixed-key file overwritten on every push-ducklake-* run.
@@ -976,6 +978,162 @@ def cmd_pull_reviews(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_merge_reviews(args: argparse.Namespace) -> int:  # noqa: ARG001
+    """Merge all per-user review Parquet files in R2 into reviews/merged/*.parquet.
+
+    Reads every  reviews/<email>/reviews.parquet
+                 reviews/<email>/audit.parquet
+                 reviews/<email>/briefs.parquet
+    file in the public R2 bucket, merges them with DuckDB using the conflict
+    strategies defined in issue #369, then uploads:
+        reviews/merged/reviews.parquet   (last-write-wins on updated_at)
+        reviews/merged/audit.parquet     (append-only, dedup on mmsi+changed_at)
+        reviews/merged/briefs.parquet    (last-write-wins on generated_at)
+
+    Finally patches ducklake_manifest.json so clients detect the new size_bytes
+    on their next sync and re-download the merged files.
+
+    Called automatically by the pipeline API (POST /api/reviews/merge) which is
+    triggered by the CF Queue consumer Worker after each user push.
+    """
+    import json as _json
+
+    import duckdb as _duckdb
+    import pyarrow.fs as pafs
+
+    bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
+    fs = _build_r2_fs()
+
+    # ── 1. List all per-user Parquet files ─────────────────────────────────
+    try:
+        all_files = fs.get_file_info(
+            pafs.FileSelector(f"{bucket}/{_REVIEWS_PREFIX}/", recursive=True)
+        )
+    except Exception as exc:
+        print(f"Error listing reviews prefix: {exc}", file=sys.stderr)
+        return 1
+
+    def collect(suffix: str) -> list[str]:
+        return sorted(
+            f.path
+            for f in all_files
+            if f.path.endswith(suffix)
+            and f"{_REVIEWS_MERGED_PREFIX}/" not in f.path
+            and f.type == pafs.FileType.File
+        )
+
+    reviews_keys = collect("/reviews.parquet")
+    audit_keys   = collect("/audit.parquet")
+    briefs_keys  = collect("/briefs.parquet")
+
+    if not reviews_keys:
+        print("No per-user review files found in R2 — nothing to merge.")
+        return 0
+
+    print(f"Merging {len(reviews_keys)} user(s): {', '.join(k.split('/')[2] for k in reviews_keys)}")
+
+    # ── 2. Download to a temp directory ────────────────────────────────────
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+
+        def download_all(keys: list[str], prefix: str) -> list[Path]:
+            paths: list[Path] = []
+            for i, key in enumerate(keys):
+                dst = tmp / f"{prefix}_{i}.parquet"
+                _download_file(fs, key, dst)
+                paths.append(dst)
+            return paths
+
+        review_files = download_all(reviews_keys, "reviews")
+        audit_files  = download_all(audit_keys,   "audit")
+        briefs_files = download_all(briefs_keys,  "briefs")
+
+        # ── 3. Merge with DuckDB ────────────────────────────────────────────
+        merged_reviews_path = tmp / "merged_reviews.parquet"
+        merged_audit_path   = tmp / "merged_audit.parquet"
+        merged_briefs_path  = tmp / "merged_briefs.parquet"
+
+        con = _duckdb.connect()
+        try:
+            # vessel_reviews: last-write-wins on updated_at
+            reviews_glob = str(tmp / "reviews_*.parquet")
+            con.execute(f"""
+                COPY (
+                    SELECT * FROM read_parquet('{reviews_glob}')
+                    QUALIFY ROW_NUMBER() OVER (
+                        PARTITION BY mmsi ORDER BY updated_at DESC NULLS LAST
+                    ) = 1
+                ) TO '{merged_reviews_path}' (FORMAT PARQUET)
+            """)
+            _ = review_files  # used implicitly via glob
+
+            # vessel_reviews_audit: append-only, dedup on (mmsi, changed_at)
+            audit_glob = str(tmp / "audit_*.parquet")
+            con.execute(f"""
+                COPY (
+                    SELECT DISTINCT * FROM read_parquet('{audit_glob}')
+                ) TO '{merged_audit_path}' (FORMAT PARQUET)
+            """)
+            _ = audit_files
+
+            # analyst_briefs: last-write-wins on generated_at
+            briefs_glob = str(tmp / "briefs_*.parquet")
+            con.execute(f"""
+                COPY (
+                    SELECT * FROM read_parquet('{briefs_glob}')
+                    QUALIFY ROW_NUMBER() OVER (
+                        PARTITION BY mmsi ORDER BY generated_at DESC NULLS LAST
+                    ) = 1
+                ) TO '{merged_briefs_path}' (FORMAT PARQUET)
+            """)
+            _ = briefs_files
+        finally:
+            con.close()
+
+        # ── 4. Upload merged files to R2 ────────────────────────────────────
+        uploads = [
+            (merged_reviews_path, f"{bucket}/{_REVIEWS_MERGED_PREFIX}/reviews.parquet"),
+            (merged_audit_path,   f"{bucket}/{_REVIEWS_MERGED_PREFIX}/audit.parquet"),
+            (merged_briefs_path,  f"{bucket}/{_REVIEWS_MERGED_PREFIX}/briefs.parquet"),
+        ]
+        for local, r2_key in uploads:
+            size = _upload_file(fs, local, r2_key)
+            print(f"  Uploaded {r2_key} ({size / 1024:.1f} KB)")
+
+        # ── 5. Patch ducklake_manifest.json ────────────────────────────────
+        manifest_key = f"{bucket}/ducklake_manifest.json"
+        manifest: dict = {}
+        try:
+            with fs.open_input_file(manifest_key) as fh:
+                manifest = _json.loads(fh.read())
+        except Exception:
+            print("  Warning: could not read manifest — skipping manifest patch", file=sys.stderr)
+            return 0
+
+        existing = {f["register_as"]: f for f in manifest.get("files", [])}
+
+        for local, r2_key, reg_as in [
+            (merged_reviews_path, f"{_REVIEWS_MERGED_PREFIX}/reviews.parquet", "reviews_merged.parquet"),
+            (merged_audit_path,   f"{_REVIEWS_MERGED_PREFIX}/audit.parquet",   "reviews_audit_merged.parquet"),
+            (merged_briefs_path,  f"{_REVIEWS_MERGED_PREFIX}/briefs.parquet",  "reviews_briefs_merged.parquet"),
+        ]:
+            existing[reg_as] = {
+                "key":         r2_key.replace(f"{bucket}/", ""),
+                "url":         f"{_PUBLIC_BASE_URL}/{r2_key.replace(f'{bucket}/', '')}",
+                "size_bytes":  local.stat().st_size,
+                "register_as": reg_as,
+            }
+
+        manifest["files"] = list(existing.values())
+
+        with fs.open_output_stream(manifest_key) as fh:
+            fh.write(_json.dumps(manifest, indent=2).encode())
+
+        print("  Patched ducklake_manifest.json — clients will detect new size_bytes on next sync.")
+
+    return 0
+
+
 def cmd_push_demo(args: argparse.Namespace) -> int:
     """Upload the fixed-key demo bundle to R2 (requires credentials).
 
@@ -1512,6 +1670,15 @@ def main() -> int:
         "--db", default=_DEFAULT_DATA_DIR + "/singapore.duckdb", metavar="DB"
     )
 
+    sub.add_parser(
+        "merge-reviews",
+        help=(
+            "Merge all per-user review Parquet files in R2 into reviews/merged/*.parquet "
+            "and patch ducklake_manifest.json (requires credentials; called automatically "
+            "by POST /api/reviews/merge via CF Queue consumer)"
+        ),
+    )
+
     _default_feeds_dir = str(_PRIVATE_FEEDS_DIR)
 
     push_custom_feeds_p = sub.add_parser(
@@ -1636,6 +1803,7 @@ def main() -> int:
         "pull-demo": cmd_pull_demo,
         "push-reviews": cmd_push_reviews,
         "pull-reviews": cmd_pull_reviews,
+        "merge-reviews": cmd_merge_reviews,
         "push-custom-feeds": cmd_push_custom_feeds,
         "pull-custom-feeds": cmd_pull_custom_feeds,
         "push-ducklake-public": cmd_push_ducklake_public,

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -170,7 +170,7 @@ _SANCTIONS_DB_R2_KEY = "public_eval.duckdb"  # OpenSanctions DB; separate from r
 _WATCHLISTS_R2_KEY = "watchlists.zip"  # lightweight bundle of *_watchlist.parquet files
 _DEMO_R2_KEY = "demo.zip"  # fixed-key public demo bundle; overwritten on every push-demo
 _REVIEWS_R2_KEY = "reviews.parquet"  # analyst review decisions; overwritten on every push-reviews
-_REVIEWS_PREFIX  = "reviews"          # per-user uploads live under reviews/<email>/
+_REVIEWS_PREFIX = "reviews"  # per-user uploads live under reviews/<email>/
 _REVIEWS_MERGED_PREFIX = "reviews/merged"  # server-side merged output
 
 # DuckLake catalog keys — public bucket (root) and private bucket (outputs/ prefix)
@@ -1046,14 +1046,16 @@ def _cmd_merge_reviews_inner(args: argparse.Namespace) -> int:  # noqa: ARG001
         )
 
     reviews_keys = collect("/reviews.parquet")
-    audit_keys   = collect("/audit.parquet")
-    briefs_keys  = collect("/briefs.parquet")
+    audit_keys = collect("/audit.parquet")
+    briefs_keys = collect("/briefs.parquet")
 
     if not reviews_keys:
         print("No per-user review files found in R2 — nothing to merge.")
         return 0
 
-    print(f"Merging {len(reviews_keys)} user(s): {', '.join(k.split('/')[2] for k in reviews_keys)}")
+    print(
+        f"Merging {len(reviews_keys)} user(s): {', '.join(k.split('/')[2] for k in reviews_keys)}"
+    )
 
     # ── 2. Download to a temp directory ────────────────────────────────────
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -1068,13 +1070,13 @@ def _cmd_merge_reviews_inner(args: argparse.Namespace) -> int:  # noqa: ARG001
             return paths
 
         review_files = download_all(reviews_keys, "reviews")
-        audit_files  = download_all(audit_keys,   "audit")
-        briefs_files = download_all(briefs_keys,  "briefs")
+        audit_files = download_all(audit_keys, "audit")
+        briefs_files = download_all(briefs_keys, "briefs")
 
         # ── 3. Merge with DuckDB ────────────────────────────────────────────
         merged_reviews_path = tmp / "merged_reviews.parquet"
-        merged_audit_path   = tmp / "merged_audit.parquet"
-        merged_briefs_path  = tmp / "merged_briefs.parquet"
+        merged_audit_path = tmp / "merged_audit.parquet"
+        merged_briefs_path = tmp / "merged_briefs.parquet"
 
         con = _duckdb.connect()
         try:
@@ -1116,8 +1118,8 @@ def _cmd_merge_reviews_inner(args: argparse.Namespace) -> int:  # noqa: ARG001
         # ── 4. Upload merged files to R2 ────────────────────────────────────
         uploads = [
             (merged_reviews_path, f"{bucket}/{_REVIEWS_MERGED_PREFIX}/reviews.parquet"),
-            (merged_audit_path,   f"{bucket}/{_REVIEWS_MERGED_PREFIX}/audit.parquet"),
-            (merged_briefs_path,  f"{bucket}/{_REVIEWS_MERGED_PREFIX}/briefs.parquet"),
+            (merged_audit_path, f"{bucket}/{_REVIEWS_MERGED_PREFIX}/audit.parquet"),
+            (merged_briefs_path, f"{bucket}/{_REVIEWS_MERGED_PREFIX}/briefs.parquet"),
         ]
         for local, r2_key in uploads:
             size = _upload_file(fs, local, r2_key)
@@ -1136,14 +1138,26 @@ def _cmd_merge_reviews_inner(args: argparse.Namespace) -> int:  # noqa: ARG001
         existing = {f["register_as"]: f for f in manifest.get("files", [])}
 
         for local, r2_key, reg_as in [
-            (merged_reviews_path, f"{_REVIEWS_MERGED_PREFIX}/reviews.parquet", "reviews_merged.parquet"),
-            (merged_audit_path,   f"{_REVIEWS_MERGED_PREFIX}/audit.parquet",   "reviews_audit_merged.parquet"),
-            (merged_briefs_path,  f"{_REVIEWS_MERGED_PREFIX}/briefs.parquet",  "reviews_briefs_merged.parquet"),
+            (
+                merged_reviews_path,
+                f"{_REVIEWS_MERGED_PREFIX}/reviews.parquet",
+                "reviews_merged.parquet",
+            ),
+            (
+                merged_audit_path,
+                f"{_REVIEWS_MERGED_PREFIX}/audit.parquet",
+                "reviews_audit_merged.parquet",
+            ),
+            (
+                merged_briefs_path,
+                f"{_REVIEWS_MERGED_PREFIX}/briefs.parquet",
+                "reviews_briefs_merged.parquet",
+            ),
         ]:
             existing[reg_as] = {
-                "key":         r2_key.replace(f"{bucket}/", ""),
-                "url":         f"{_PUBLIC_BASE_URL}/{r2_key.replace(f'{bucket}/', '')}",
-                "size_bytes":  local.stat().st_size,
+                "key": r2_key.replace(f"{bucket}/", ""),
+                "url": f"{_PUBLIC_BASE_URL}/{r2_key.replace(f'{bucket}/', '')}",
+                "size_bytes": local.stat().st_size,
                 "register_as": reg_as,
             }
 

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -997,10 +997,6 @@ def cmd_merge_reviews(args: argparse.Namespace) -> int:  # noqa: ARG001
     triggered by the CF Queue consumer Worker after each user push.
     """
     import fcntl
-    import json as _json
-
-    import duckdb as _duckdb
-    import pyarrow.fs as pafs
 
     # File lock prevents two concurrent merge-reviews processes from racing
     # (e.g. a manual run and a queue-triggered run overlapping).  Non-blocking

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1159,6 +1159,7 @@ def _cmd_merge_reviews_inner(args: argparse.Namespace) -> int:  # noqa: ARG001
                 "url": f"{_PUBLIC_BASE_URL}/{r2_key.replace(f'{bucket}/', '')}",
                 "size_bytes": local.stat().st_size,
                 "register_as": reg_as,
+                "private": True,  # skipped by non-authenticated clients in opfs.ts
             }
 
         manifest["files"] = list(existing.values())

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -996,6 +996,33 @@ def cmd_merge_reviews(args: argparse.Namespace) -> int:  # noqa: ARG001
     Called automatically by the pipeline API (POST /api/reviews/merge) which is
     triggered by the CF Queue consumer Worker after each user push.
     """
+    import fcntl
+    import json as _json
+
+    import duckdb as _duckdb
+    import pyarrow.fs as pafs
+
+    # File lock prevents two concurrent merge-reviews processes from racing
+    # (e.g. a manual run and a queue-triggered run overlapping).  Non-blocking
+    # so a duplicate attempt exits cleanly instead of queuing behind.
+    lock_path = Path(__file__).parent.parent / "data" / ".merge_reviews.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_fh = open(lock_path, "w")  # noqa: WPS515
+    try:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        print("merge-reviews already running — skipping duplicate run.", flush=True)
+        lock_fh.close()
+        return 0
+
+    try:
+        return _cmd_merge_reviews_inner(args)
+    finally:
+        fcntl.flock(lock_fh, fcntl.LOCK_UN)
+        lock_fh.close()
+
+
+def _cmd_merge_reviews_inner(args: argparse.Namespace) -> int:  # noqa: ARG001
     import json as _json
 
     import duckdb as _duckdb

--- a/tests/test_merge_reviews_api.py
+++ b/tests/test_merge_reviews_api.py
@@ -1,0 +1,206 @@
+"""Tests for POST /api/reviews/merge — auth, 202 response, and the
+running/pending coalescing guard that prevents concurrent subprocess runs."""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import pipeline.src.api.routes.reviews as reviews_module
+from pipeline.src.api.main import app
+
+client = TestClient(app)
+
+_SECRET = "test-pipeline-secret"
+_HEADERS = {"X-Pipeline-Secret": _SECRET}
+
+
+@pytest.fixture(autouse=True)
+def reset_coalesce_state():
+    """Reset the module-level running/pending flags between tests and wait for
+    any daemon threads spawned by the previous test to finish."""
+    with reviews_module._state_lock:
+        reviews_module._running = False
+        reviews_module._pending = False
+    yield
+    # Give daemon threads up to 0.5 s to settle so the next test starts clean.
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline:
+        with reviews_module._state_lock:
+            if not reviews_module._running:
+                break
+        time.sleep(0.01)
+    with reviews_module._state_lock:
+        reviews_module._running = False
+        reviews_module._pending = False
+
+
+@pytest.fixture
+def secret(monkeypatch):
+    monkeypatch.setenv("PIPELINE_SECRET", _SECRET)
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+def test_no_header_returns_401():
+    resp = client.post("/api/reviews/merge")
+    assert resp.status_code == 401
+
+
+def test_wrong_secret_returns_401(secret):
+    resp = client.post("/api/reviews/merge", headers={"X-Pipeline-Secret": "wrong"})
+    assert resp.status_code == 401
+
+
+def test_missing_env_var_returns_401():
+    # PIPELINE_SECRET not set at all
+    resp = client.post("/api/reviews/merge", headers=_HEADERS)
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+def test_valid_request_returns_202_and_runs_merge(secret):
+    with patch.object(reviews_module, "_do_merge") as mock_merge:
+        resp = client.post("/api/reviews/merge", headers=_HEADERS)
+        assert resp.status_code == 202
+        assert resp.json() == {"status": "accepted"}
+        # Allow the daemon thread to complete.
+        time.sleep(0.1)
+        mock_merge.assert_called_once()
+
+
+def test_flags_cleared_after_single_run(secret):
+    with patch.object(reviews_module, "_do_merge"):
+        client.post("/api/reviews/merge", headers=_HEADERS)
+        time.sleep(0.1)
+
+    with reviews_module._state_lock:
+        assert not reviews_module._running
+        assert not reviews_module._pending
+
+
+# ---------------------------------------------------------------------------
+# Coalescing guard — the critical dedup behaviour
+# ---------------------------------------------------------------------------
+
+def test_concurrent_request_sets_pending_and_triggers_one_extra_run(secret):
+    """Two requests while a merge is running → exactly 2 total _do_merge calls.
+
+    Timeline:
+      T0  request-1 arrives → _running=True, merge starts
+      T1  request-2 arrives while merge is in progress → _pending=True, returns 202
+      T2  first merge finishes → loop sees _pending, runs once more, clears flags
+    Total calls: 2 (not 1 and not 3).
+    """
+    first_merge_started = threading.Event()
+    first_merge_release = threading.Event()
+    call_order: list[int] = []
+
+    def controlled_merge():
+        n = len(call_order) + 1
+        call_order.append(n)
+        if n == 1:
+            first_merge_started.set()
+            first_merge_release.wait(timeout=2)
+
+    with patch.object(reviews_module, "_do_merge", side_effect=controlled_merge):
+        # Request 1 — starts the merge thread
+        resp1 = client.post("/api/reviews/merge", headers=_HEADERS)
+        assert resp1.status_code == 202
+
+        # Wait until the first merge is actually running
+        assert first_merge_started.wait(timeout=2), "first merge never started"
+
+        # Request 2 — merge is in-flight, should set _pending
+        resp2 = client.post("/api/reviews/merge", headers=_HEADERS)
+        assert resp2.status_code == 202
+
+        with reviews_module._state_lock:
+            assert reviews_module._pending, "_pending should be True while merge is running"
+
+        # Unblock the first merge
+        first_merge_release.set()
+
+        # Wait for both runs to complete
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            with reviews_module._state_lock:
+                if not reviews_module._running:
+                    break
+            time.sleep(0.01)
+
+    assert len(call_order) == 2, (
+        f"Expected exactly 2 _do_merge calls (1 initial + 1 follow-up), got {len(call_order)}"
+    )
+
+
+def test_three_concurrent_requests_still_only_two_runs(secret):
+    """Three requests with the first still running → first run + one follow-up = 2 total."""
+    first_started = threading.Event()
+    release = threading.Event()
+    calls: list[int] = []
+
+    def controlled_merge():
+        calls.append(1)
+        if len(calls) == 1:
+            first_started.set()
+            release.wait(timeout=2)
+
+    with patch.object(reviews_module, "_do_merge", side_effect=controlled_merge):
+        client.post("/api/reviews/merge", headers=_HEADERS)
+        assert first_started.wait(timeout=2)
+
+        # Two more requests while first is running — both should just set _pending
+        client.post("/api/reviews/merge", headers=_HEADERS)
+        client.post("/api/reviews/merge", headers=_HEADERS)
+
+        release.set()
+
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            with reviews_module._state_lock:
+                if not reviews_module._running:
+                    break
+            time.sleep(0.01)
+
+    # Regardless of how many requests arrived, only 2 merges run
+    assert len(calls) == 2
+
+
+def test_sequential_requests_each_run_merge(secret):
+    """Requests that arrive after a merge completes each trigger their own run."""
+    calls: list[int] = []
+
+    with patch.object(reviews_module, "_do_merge", side_effect=lambda: calls.append(1)):
+        for _ in range(3):
+            client.post("/api/reviews/merge", headers=_HEADERS)
+            # Wait for the previous run to fully complete before the next request
+            deadline = time.monotonic() + 1
+            while time.monotonic() < deadline:
+                with reviews_module._state_lock:
+                    if not reviews_module._running:
+                        break
+                time.sleep(0.01)
+
+    assert len(calls) == 3
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+def test_merge_exception_clears_flags(secret):
+    """If _do_merge raises, both _running and _pending must be cleared."""
+    with patch.object(reviews_module, "_do_merge", side_effect=RuntimeError("boom")):
+        client.post("/api/reviews/merge", headers=_HEADERS)
+        time.sleep(0.1)
+
+    with reviews_module._state_lock:
+        assert not reviews_module._running
+        assert not reviews_module._pending

--- a/tests/test_merge_reviews_api.py
+++ b/tests/test_merge_reviews_api.py
@@ -48,6 +48,7 @@ def secret(monkeypatch):
 # Auth
 # ---------------------------------------------------------------------------
 
+
 def test_no_header_returns_401():
     resp = client.post("/api/reviews/merge")
     assert resp.status_code == 401
@@ -67,6 +68,7 @@ def test_missing_env_var_returns_401():
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
+
 
 def test_valid_request_returns_202_and_runs_merge(secret):
     with patch.object(reviews_module, "_do_merge") as mock_merge:
@@ -91,6 +93,7 @@ def test_flags_cleared_after_single_run(secret):
 # ---------------------------------------------------------------------------
 # Coalescing guard — the critical dedup behaviour
 # ---------------------------------------------------------------------------
+
 
 def test_concurrent_request_sets_pending_and_triggers_one_extra_run(secret):
     """Two requests while a merge is running → exactly 2 total _do_merge calls.

--- a/tests/test_merge_reviews_lock.py
+++ b/tests/test_merge_reviews_lock.py
@@ -1,0 +1,94 @@
+"""Tests for the fcntl file-lock guard in sync_r2.py cmd_merge_reviews.
+
+The lock prevents two concurrent processes (e.g. a queue-triggered run and a
+manual run) from executing merge-reviews simultaneously and corrupting R2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+from unittest.mock import call, patch
+
+import pytest
+
+import scripts.sync_r2 as sync_r2
+
+
+@pytest.fixture
+def args():
+    return argparse.Namespace()
+
+
+def test_skips_when_lock_already_held(args, tmp_path):
+    """If the lock file is held by another process, cmd_merge_reviews returns 0
+    immediately without calling _cmd_merge_reviews_inner."""
+    # Simulate the lock being held by patching fcntl.flock to raise on the
+    # non-blocking acquire attempt (LOCK_EX | LOCK_NB).
+    original_flock = fcntl.flock
+
+    def flock_side_effect(fd, operation):
+        if operation == (fcntl.LOCK_EX | fcntl.LOCK_NB):
+            raise BlockingIOError("lock held")
+        return original_flock(fd, operation)
+
+    with patch.object(fcntl, "flock", side_effect=flock_side_effect):
+        with patch.object(sync_r2, "_cmd_merge_reviews_inner") as mock_inner:
+            result = sync_r2.cmd_merge_reviews(args)
+
+    assert result == 0
+    mock_inner.assert_not_called()
+
+
+def test_runs_when_lock_is_free(args):
+    """When the lock is not held, _cmd_merge_reviews_inner is called and its
+    return value is propagated."""
+    with patch.object(sync_r2, "_cmd_merge_reviews_inner", return_value=0) as mock_inner:
+        result = sync_r2.cmd_merge_reviews(args)
+
+    assert result == 0
+    mock_inner.assert_called_once_with(args)
+
+
+def test_lock_released_after_success(args):
+    """fcntl.LOCK_UN is called after a successful inner run."""
+    unlock_calls: list[int] = []
+    original_flock = fcntl.flock
+
+    def tracking_flock(fd, operation):
+        if operation == fcntl.LOCK_UN:
+            unlock_calls.append(1)
+        else:
+            original_flock(fd, operation)
+
+    with patch.object(fcntl, "flock", side_effect=tracking_flock):
+        with patch.object(sync_r2, "_cmd_merge_reviews_inner", return_value=0):
+            sync_r2.cmd_merge_reviews(args)
+
+    assert len(unlock_calls) == 1, "LOCK_UN should be called exactly once"
+
+
+def test_lock_released_after_inner_raises(args):
+    """fcntl.LOCK_UN is called in the finally block even if inner raises."""
+    unlock_calls: list[int] = []
+    original_flock = fcntl.flock
+
+    def tracking_flock(fd, operation):
+        if operation == fcntl.LOCK_UN:
+            unlock_calls.append(1)
+        else:
+            original_flock(fd, operation)
+
+    with patch.object(fcntl, "flock", side_effect=tracking_flock):
+        with patch.object(sync_r2, "_cmd_merge_reviews_inner", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                sync_r2.cmd_merge_reviews(args)
+
+    assert len(unlock_calls) == 1, "LOCK_UN must be called even when inner raises"
+
+
+def test_inner_return_value_propagated(args):
+    """Non-zero return from inner is passed through to the caller."""
+    with patch.object(sync_r2, "_cmd_merge_reviews_inner", return_value=1):
+        result = sync_r2.cmd_merge_reviews(args)
+    assert result == 1

--- a/tests/test_merge_reviews_lock.py
+++ b/tests/test_merge_reviews_lock.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import argparse
 import fcntl
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/workers/review-merge-consumer/index.test.ts
+++ b/workers/review-merge-consumer/index.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the CF Queue consumer batch-collapse logic.
+ *
+ * The consumer must:
+ *   1. Collapse the entire batch into ONE pipeline call (no matter how many messages).
+ *   2. ackAll() on pipeline success.
+ *   3. retry() every message on pipeline failure or network error.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import worker from "./index";
+import type { Env } from "./index";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ENV: Env = {
+  PIPELINE_URL: "https://pipeline.example.com",
+  PIPELINE_SECRET: "test-secret",
+};
+
+function makeMsg(email = "analyst@example.com") {
+  return {
+    id: crypto.randomUUID(),
+    timestamp: new Date(),
+    attempts: 1,
+    body: { email, triggeredAt: new Date().toISOString() },
+    ack: vi.fn(),
+    retry: vi.fn(),
+  };
+}
+
+function makeBatch(msgs: ReturnType<typeof makeMsg>[]) {
+  return {
+    queue: "arktrace-review-merge",
+    messages: msgs,
+    ackAll: vi.fn(),
+    retryAll: vi.fn(),
+  } as unknown as MessageBatch<{ email: string; triggeredAt: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("review-merge-consumer queue handler", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("makes exactly ONE fetch call regardless of batch size", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"status":"accepted"}', { status: 202 })
+    );
+    const msgs = [makeMsg("a@x.com"), makeMsg("b@x.com"), makeMsg("c@x.com")];
+    const batch = makeBatch(msgs);
+
+    await worker.queue(batch, ENV);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the correct pipeline URL with the shared secret", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 202 })
+    );
+    const batch = makeBatch([makeMsg()]);
+
+    await worker.queue(batch, ENV);
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://pipeline.example.com/api/reviews/merge");
+    expect((init.headers as Record<string, string>)["X-Pipeline-Secret"]).toBe("test-secret");
+    expect(init.method).toBe("POST");
+  });
+
+  it("ackAll() on pipeline 202", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 202 })
+    );
+    const batch = makeBatch([makeMsg(), makeMsg()]);
+
+    await worker.queue(batch, ENV);
+
+    expect(batch.ackAll).toHaveBeenCalledOnce();
+    for (const msg of batch.messages) {
+      expect(msg.retry).not.toHaveBeenCalled();
+    }
+  });
+
+  it("retries all messages on non-2xx pipeline response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Internal Server Error", { status: 500 })
+    );
+    const msgs = [makeMsg(), makeMsg()];
+    const batch = makeBatch(msgs);
+
+    await worker.queue(batch, ENV);
+
+    expect(batch.ackAll).not.toHaveBeenCalled();
+    for (const msg of msgs) {
+      expect(msg.retry).toHaveBeenCalledWith({ delaySeconds: 30 });
+    }
+  });
+
+  it("retries all messages on network error (fetch throws)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("network error"));
+    const msgs = [makeMsg(), makeMsg()];
+    const batch = makeBatch(msgs);
+
+    await worker.queue(batch, ENV);
+
+    expect(batch.ackAll).not.toHaveBeenCalled();
+    for (const msg of msgs) {
+      expect(msg.retry).toHaveBeenCalledWith({ delaySeconds: 30 });
+    }
+  });
+
+  it("single-message batch still only one fetch call", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 202 })
+    );
+    const batch = makeBatch([makeMsg()]);
+
+    await worker.queue(batch, ENV);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(batch.ackAll).toHaveBeenCalledOnce();
+  });
+});

--- a/workers/review-merge-consumer/index.ts
+++ b/workers/review-merge-consumer/index.ts
@@ -1,0 +1,51 @@
+/**
+ * CF Queue consumer — triggered by messages enqueued by the push Pages Function.
+ *
+ * Each message carries { email, triggeredAt }.  The consumer calls the Python
+ * pipeline server's POST /api/reviews/merge endpoint, which runs
+ * `sync_r2.py merge-reviews` in the background.  On success the message is
+ * acked; on failure it is retried up to the queue's max_retries limit.
+ *
+ * Required Worker secrets (set in CF dashboard or wrangler secret put):
+ *   PIPELINE_URL     — base URL of the pipeline server, e.g.
+ *                      https://api.arktrace.edgesentry.io
+ *   PIPELINE_SECRET  — shared secret validated by the pipeline's /api/reviews/merge
+ */
+
+export interface Env {
+  PIPELINE_URL: string;
+  PIPELINE_SECRET: string;
+}
+
+interface MergeJob {
+  email: string;
+  triggeredAt: string;
+}
+
+export default {
+  async queue(batch: MessageBatch<MergeJob>, env: Env): Promise<void> {
+    for (const msg of batch.messages) {
+      try {
+        const resp = await fetch(`${env.PIPELINE_URL}/api/reviews/merge`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Pipeline-Secret": env.PIPELINE_SECRET,
+          },
+          body: JSON.stringify(msg.body),
+        });
+
+        if (!resp.ok) {
+          const text = await resp.text().catch(() => String(resp.status));
+          console.error(`[review-merge] Pipeline returned ${resp.status}: ${text}`);
+          msg.retry({ delaySeconds: 30 });
+        } else {
+          msg.ack();
+        }
+      } catch (err) {
+        console.error("[review-merge] Failed to reach pipeline:", err);
+        msg.retry({ delaySeconds: 30 });
+      }
+    }
+  },
+};

--- a/workers/review-merge-consumer/index.ts
+++ b/workers/review-merge-consumer/index.ts
@@ -24,26 +24,29 @@ interface MergeJob {
 
 export default {
   async queue(batch: MessageBatch<MergeJob>, env: Env): Promise<void> {
-    for (const msg of batch.messages) {
-      try {
-        const resp = await fetch(`${env.PIPELINE_URL}/api/reviews/merge`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Pipeline-Secret": env.PIPELINE_SECRET,
-          },
-          body: JSON.stringify(msg.body),
-        });
+    // Collapse the entire batch into a single pipeline call — all messages in
+    // the batch represent the same operation (merge-reviews), so one call is
+    // sufficient regardless of how many users pushed concurrently.
+    try {
+      const resp = await fetch(`${env.PIPELINE_URL}/api/reviews/merge`, {
+        method: "POST",
+        headers: { "X-Pipeline-Secret": env.PIPELINE_SECRET },
+      });
 
-        if (!resp.ok) {
-          const text = await resp.text().catch(() => String(resp.status));
-          console.error(`[review-merge] Pipeline returned ${resp.status}: ${text}`);
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => String(resp.status));
+        console.error(`[review-merge] Pipeline returned ${resp.status}: ${text}`);
+        // Retry all messages so the merge is retried; CF Queue deduplicates
+        // further messages that arrive while these are pending.
+        for (const msg of batch.messages) {
           msg.retry({ delaySeconds: 30 });
-        } else {
-          msg.ack();
         }
-      } catch (err) {
-        console.error("[review-merge] Failed to reach pipeline:", err);
+      } else {
+        batch.ackAll();
+      }
+    } catch (err) {
+      console.error("[review-merge] Failed to reach pipeline:", err);
+      for (const msg of batch.messages) {
         msg.retry({ delaySeconds: 30 });
       }
     }

--- a/workers/review-merge-consumer/package-lock.json
+++ b/workers/review-merge-consumer/package-lock.json
@@ -1,0 +1,1434 @@
+{
+  "name": "arktrace-review-merge-consumer",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "arktrace-review-merge-consumer",
+      "devDependencies": {
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/workers/review-merge-consumer/package.json
+++ b/workers/review-merge-consumer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "arktrace-review-merge-consumer",
+  "private": true,
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/workers/review-merge-consumer/wrangler.toml
+++ b/workers/review-merge-consumer/wrangler.toml
@@ -1,0 +1,14 @@
+name               = "arktrace-review-merge-consumer"
+main               = "index.ts"
+compatibility_date = "2025-01-01"
+
+# Deploy: wrangler deploy --config workers/review-merge-consumer/wrangler.toml
+# Secrets: wrangler secret put PIPELINE_URL --config workers/review-merge-consumer/wrangler.toml
+#          wrangler secret put PIPELINE_SECRET --config workers/review-merge-consumer/wrangler.toml
+
+[[queues.consumers]]
+queue             = "arktrace-review-merge"
+max_batch_size    = 10
+max_batch_timeout = 5
+max_retries       = 3
+dead_letter_queue = "arktrace-review-merge-dlq"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,11 @@ pages_build_output_dir = "app/dist"
 compatibility_date    = "2025-01-01"
 
 # R2 bucket binding — used by app/functions/api/reviews/push.ts
-# Bucket name: arktrace-public (Cloudflare R2)
 [[r2_buckets]]
 binding     = "ARKTRACE_PUBLIC"
 bucket_name = "arktrace-public"
+
+# CF Queue producer — push.ts enqueues a merge job after every upload
+[[queues.producers]]
+binding = "REVIEW_MERGE_QUEUE"
+queue   = "arktrace-review-merge"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,9 @@
+name                  = "arktrace"
+pages_build_output_dir = "app/dist"
+compatibility_date    = "2025-01-01"
+
+# R2 bucket binding — used by app/functions/api/reviews/push.ts
+# Bucket name: arktrace-public (Cloudflare R2)
+[[r2_buckets]]
+binding     = "ARKTRACE_PUBLIC"
+bucket_name = "arktrace-public"


### PR DESCRIPTION
Closes #369

## What changed

### CF Pages Function — `app/functions/api/reviews/push.ts`
- `POST /api/reviews/push` — accepts `vessel_reviews`, `vessel_reviews_audit`, and `analyst_briefs` as Parquet files in a FormData body
- Validates `Cf-Access-Authenticated-User-Email` header (injected by Cloudflare Access); returns 401 for unauthenticated requests
- Writes files to `reviews/<email>/*.parquet` in R2 (per-user prefix — one analyst cannot overwrite another's source)
- Upserts `reviews/index.json` so other clients know which users have pushed

### Browser library — `app/src/lib/push.ts`
- `pushReviews(db, conn, onStatus)` — exports the three tables to Parquet via DuckDB-WASM `COPY TO`, POSTs to `/api/reviews/push`, surfaces exporting/uploading/done/error states
- `pullRemoteReviews(db, conn)` — fetches `reviews/index.json`, downloads each user's three Parquet files, merges into local DuckDB with the conflict strategies from the issue:
  - `vessel_reviews` → last-write-wins on `updated_at` (`INSERT OR REPLACE … WHERE r.updated_at >= local.updated_at`)
  - `vessel_reviews_audit` → append-only, dedup on `(mmsi, changed_at)`
  - `analyst_briefs` → last-write-wins on `generated_at`

### UI — `app/src/components/SyncStatus.tsx`
- Push button visible only when a user is logged in (private mode) and sync is in a stable state (ready/idle)
- Button label reflects current push phase: "Push reviews" → "Exporting…" → "Uploading…" → "Pushed N ago" / "Push failed — retry"
- Disabled and dimmed while a push is in flight

### App wiring — `app/src/App.tsx`
- `pullRemoteReviews` called automatically at the end of every `doSync` — other analysts see shared state on their next sync without any manual action
- `handlePush` callback wired to the Push button; errors surface in the button label

### Config — `wrangler.toml`
- Declares `ARKTRACE_PUBLIC` R2 binding for the CF Pages Function
- Must be deployed via `wrangler pages deploy` or configured in the Pages dashboard

## Deployment note
Add `ARKTRACE_PUBLIC` R2 bucket binding in the Cloudflare Pages project settings (or it will be picked up from `wrangler.toml` on `wrangler pages deploy`). The bucket name is `arktrace-public`.

## Test plan
- [ ] Log in via CF Access on `demo.arktrace.edgesentry.io`
- [ ] Review a vessel → click **Push reviews** → confirm "Pushed just now" label
- [ ] Check R2 bucket: `reviews/<email>/reviews.parquet`, `audit.parquet`, `briefs.parquet` and `reviews/index.json` exist
- [ ] Open the app in a second browser / incognito session as a different user → sync → confirm the first user's reviews appear
- [ ] Both users review the same vessel within seconds of each other → later `updated_at` wins in `vessel_reviews`; both audit entries appear in the audit log
- [ ] Unauthenticated POST to `/api/reviews/push` → 401
- [ ] Sync without network access to R2 reviews (fresh install) → pull returns 0, no error, app loads normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)