### PR TITLE
fix(#400): route push-reviews through private worker to fix 401

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -137,13 +137,13 @@ export default function App() {
   const handlePush = useCallback(async () => {
     const db = dbRef.current;
     const conn = connRef.current;
-    if (!db || !conn || !userEmail) return;
+    if (!db || !conn || !userEmail || !appConfig) return;
     try {
-      await pushReviews(db, conn, setPushStatus);
+      await pushReviews(db, conn, appConfig, setPushStatus);
     } catch (err) {
       setPushStatus({ phase: "error", message: String(err) });
     }
-  }, [userEmail]);
+  }, [userEmail, appConfig]);
 
   const handleClaim = useCallback(async (mmsi: string) => {
     const conn = connRef.current;

--- a/app/src/lib/push.test.ts
+++ b/app/src/lib/push.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AppConfig } from "./config";
+
+const CF_CONFIG: AppConfig = {
+  publicBucketUrl: "https://arktrace-public.edgesentry.io",
+  privateManifestUrl: "https://worker.example.com/outputs/manifest.json",
+  authProvider: "cloudflare-access",
+};
+
+const CF_NO_PRIVATE_CONFIG: AppConfig = {
+  publicBucketUrl: "https://arktrace-public.edgesentry.io",
+  authProvider: "cloudflare-access",
+};
+
+const OIDC_CONFIG: AppConfig = {
+  publicBucketUrl: "https://arktrace-public.edgesentry.io",
+  privateSigningEndpoint: "https://api.example.com/sign",
+  authProvider: "oidc",
+};
+
+const NONE_CONFIG: AppConfig = {
+  publicBucketUrl: "https://arktrace-public.edgesentry.io",
+  authProvider: "none",
+};
+
+function makeDb() {
+  return {
+    copyFileToBuffer: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+    dropFile: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeConn() {
+  return { query: vi.fn().mockResolvedValue(undefined) };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+const { pushReviews } = await import("./push");
+
+describe("pushReviews — endpoint routing", () => {
+  it("POSTs to private worker /push-reviews for cloudflare-access with privateManifestUrl", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ updatedAt: "2026-04-21T00:00:00.000Z" }),
+    }));
+    const statuses: string[] = [];
+    await pushReviews(makeDb() as never, makeConn() as never, CF_CONFIG, (s) => statuses.push(s.phase));
+    expect(fetch).toHaveBeenCalledWith(
+      "https://worker.example.com/push-reviews",
+      expect.objectContaining({ method: "POST", credentials: "include" })
+    );
+  });
+
+  it("falls back to /api/reviews/push for cloudflare-access without privateManifestUrl", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ updatedAt: "2026-04-21T00:00:00.000Z" }),
+    }));
+    await pushReviews(makeDb() as never, makeConn() as never, CF_NO_PRIVATE_CONFIG, () => {});
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/reviews/push",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("uses /api/reviews/push for oidc deployments", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ updatedAt: "2026-04-21T00:00:00.000Z" }),
+    }));
+    await pushReviews(makeDb() as never, makeConn() as never, OIDC_CONFIG, () => {});
+    expect(fetch).toHaveBeenCalledWith("/api/reviews/push", expect.anything());
+  });
+
+  it("uses /api/reviews/push for none deployments", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ updatedAt: "2026-04-21T00:00:00.000Z" }),
+    }));
+    await pushReviews(makeDb() as never, makeConn() as never, NONE_CONFIG, () => {});
+    expect(fetch).toHaveBeenCalledWith("/api/reviews/push", expect.anything());
+  });
+});
+
+describe("pushReviews — status progression", () => {
+  it("emits exporting → uploading → done on success", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ updatedAt: "2026-04-21T00:00:00.000Z" }),
+    }));
+    const phases: string[] = [];
+    await pushReviews(makeDb() as never, makeConn() as never, CF_CONFIG, (s) => phases.push(s.phase));
+    expect(phases).toEqual(["exporting", "uploading", "done"]);
+  });
+
+  it("throws on 401 with a sign-in message", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401, text: async () => "" }));
+    await expect(
+      pushReviews(makeDb() as never, makeConn() as never, CF_CONFIG, () => {})
+    ).rejects.toThrow("Sign in required to push changes");
+  });
+
+  it("throws on non-ok response with server message", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "internal error",
+    }));
+    await expect(
+      pushReviews(makeDb() as never, makeConn() as never, CF_CONFIG, () => {})
+    ).rejects.toThrow("Push failed: internal error");
+  });
+});

--- a/app/src/lib/push.ts
+++ b/app/src/lib/push.ts
@@ -22,6 +22,7 @@
 
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import type { AsyncDuckDB } from "@duckdb/duckdb-wasm";
+import type { AppConfig } from "./config";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -49,6 +50,7 @@ export type PushStatus =
 export async function pushReviews(
   db: AsyncDuckDB,
   conn: AsyncDuckDBConnection,
+  config: AppConfig,
   onStatus: (s: PushStatus) => void
 ): Promise<void> {
   onStatus({ phase: "exporting" });
@@ -73,9 +75,9 @@ export async function pushReviews(
 
   onStatus({ phase: "uploading" });
 
-  const resp = await fetch("/api/reviews/push", {
+  const resp = await fetch(pushEndpointUrl(config), {
     method: "POST",
-    credentials: "include", // send CF_Authorization cookie
+    credentials: "include",
     body: form,
   });
 
@@ -87,6 +89,24 @@ export async function pushReviews(
 
   const { updatedAt } = (await resp.json()) as { updatedAt: string };
   onStatus({ phase: "done", pushedAt: updatedAt });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * For cloudflare-access deployments, push through the private Worker which
+ * has CF Access enabled — the email header is reliably injected there.
+ * The Pages Function route (/api/reviews/push) lacks CF Access protection
+ * and always returns 401 because the header is never injected.
+ */
+function pushEndpointUrl(config: AppConfig): string {
+  if (config.authProvider === "cloudflare-access" && config.privateManifestUrl) {
+    const origin = new URL(config.privateManifestUrl).origin;
+    return `${origin}/push-reviews`;
+  }
+  return "/api/reviews/push";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Closes #400
- `pushReviews()` now accepts `config: AppConfig` and routes uploads to `{privateWorkerOrigin}/push-reviews` for `cloudflare-access` deployments, bypassing the Pages Function that lacks CF Access protection
- Falls back to `/api/reviews/push` for non-CF-Access deployments (on-prem / OIDC)

## Root cause

The `CF_Authorization` cookie from CF Access is scoped to `arktrace-private-capvista.edgesentry.io`. When the SPA POSTs to `demo.arktrace.edgesentry.io/api/reviews/push` (different domain), the cookie is never sent → CF Access never injects `Cf-Access-Authenticated-User-Email` → Pages Function returns 401.

## Changes

- `app/src/lib/push.ts` — accepts `config: AppConfig`; adds `pushEndpointUrl()` helper that returns `{privateWorkerOrigin}/push-reviews` for CF Access, `/api/reviews/push` otherwise
- `app/src/App.tsx` — passes `appConfig` to `pushReviews`

## Companion PR

Worker-side changes (new `/push-reviews` endpoint, R2 + Queue bindings): edgesentry/arktrace-commercial#<see companion PR>

## Test plan

- [ ] Log in on `demo.arktrace.edgesentry.io` → click **↑ Push reviews** → no 401, R2 receives `reviews/<email>/*.parquet`
- [ ] Unauthenticated push still returns 401
- [ ] On-prem / OIDC deployments unaffected (still POST to `/api/reviews/push`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)