### PR TITLE
fix: treat GFW server disconnect as soft skip in step 6

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -584,9 +584,18 @@ def step_eo_ingest(p: RegionPreset, non_interactive: bool) -> bool:
     except Exception as exc:
         # Treat network timeouts as a soft skip so the pipeline continues.
         exc_str = str(exc)
-        _TRANSIENT = ("timed out", "timeout", "server disconnected", "connection reset", "connection refused", "remotedisconnected")
+        _TRANSIENT = (
+            "timed out",
+            "timeout",
+            "server disconnected",
+            "connection reset",
+            "connection refused",
+            "remotedisconnected",
+        )
         if any(t in exc_str.lower() for t in _TRANSIENT):
-            _ok(f"Skipping EO ingest — GFW API unreachable ({exc_str.splitlines()[0]}), will retry on next run")
+            _ok(
+                f"Skipping EO ingest — GFW API unreachable ({exc_str.splitlines()[0]}), will retry on next run"
+            )
             return True
         _fail(exc_str)
         if non_interactive:

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -584,8 +584,9 @@ def step_eo_ingest(p: RegionPreset, non_interactive: bool) -> bool:
     except Exception as exc:
         # Treat network timeouts as a soft skip so the pipeline continues.
         exc_str = str(exc)
-        if "timed out" in exc_str.lower() or "timeout" in exc_str.lower():
-            _ok("Skipping EO ingest — GFW API timed out (will retry on next run)")
+        _TRANSIENT = ("timed out", "timeout", "server disconnected", "connection reset", "connection refused", "remotedisconnected")
+        if any(t in exc_str.lower() for t in _TRANSIENT):
+            _ok(f"Skipping EO ingest — GFW API unreachable ({exc_str.splitlines()[0]}), will retry on next run")
             return True
         _fail(exc_str)
         if non_interactive:


### PR DESCRIPTION
## Problem

`run_pipeline.py` step 6 (GFW EO detections) aborts on:
```
Server disconnected without sending a response.
```
Only `"timed out"` / `"timeout"` were caught as transient errors. A server disconnect fell through to `_fail()` and stopped the whole run.

## Fix

Extended the transient-error match list in `step_eo_gfw()` to include `server disconnected`, `connection reset`, `connection refused`, and `remotedisconnected`. Any of these now soft-skips step 6 with a human-readable message, consistent with timeout handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)