### PR TITLE
fix: guard mergeDownloadedReviews against unregistered parquet files

### DIFF
--- a/app/src/lib/push.test.ts
+++ b/app/src/lib/push.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { AppConfig } from "./config";
 
+vi.mock("./duckdb", () => ({
+  isParquetRegistered: vi.fn(),
+}));
+
+import { isParquetRegistered } from "./duckdb";
+
 const CF_CONFIG: AppConfig = {
   publicBucketUrl: "https://arktrace-public.edgesentry.io",
   privateManifestUrl: "https://worker.example.com/outputs/manifest.json",
@@ -38,7 +44,7 @@ beforeEach(() => {
   vi.restoreAllMocks();
 });
 
-const { pushReviews } = await import("./push");
+const { pushReviews, mergeDownloadedReviews } = await import("./push");
 
 describe("pushReviews — endpoint routing", () => {
   it("POSTs to private worker /push-reviews for cloudflare-access with privateManifestUrl", async () => {
@@ -117,5 +123,52 @@ describe("pushReviews — status progression", () => {
     await expect(
       pushReviews(makeDb() as never, makeConn() as never, CF_CONFIG, () => {})
     ).rejects.toThrow("Push failed: internal error");
+  });
+});
+
+describe("mergeDownloadedReviews — parquet guard", () => {
+  beforeEach(() => {
+    vi.mocked(isParquetRegistered).mockReturnValue(false);
+  });
+
+  it("skips all queries and returns 0 when no merged files are registered", async () => {
+    const conn = makeConn();
+    const count = await mergeDownloadedReviews(conn as never);
+    expect(conn.query).not.toHaveBeenCalled();
+    expect(count).toBe(0);
+  });
+
+  it("runs all three queries and returns 3 when all files are registered", async () => {
+    vi.mocked(isParquetRegistered).mockReturnValue(true);
+    const conn = makeConn();
+    const count = await mergeDownloadedReviews(conn as never);
+    expect(conn.query).toHaveBeenCalledTimes(3);
+    expect(count).toBe(3);
+  });
+
+  it("runs only the query for the one registered file", async () => {
+    vi.mocked(isParquetRegistered).mockImplementation(
+      (name) => name === "reviews_merged.parquet"
+    );
+    const conn = makeConn();
+    const count = await mergeDownloadedReviews(conn as never);
+    expect(conn.query).toHaveBeenCalledTimes(1);
+    expect(count).toBe(1);
+  });
+
+  it("does not throw and returns 0 when no files registered", async () => {
+    const conn = makeConn();
+    await expect(mergeDownloadedReviews(conn as never)).resolves.toBe(0);
+  });
+
+  it("returns 2 and skips the failed query on unexpected query error", async () => {
+    vi.mocked(isParquetRegistered).mockReturnValue(true);
+    const conn = makeConn();
+    conn.query
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("schema mismatch"))
+      .mockResolvedValueOnce(undefined);
+    const count = await mergeDownloadedReviews(conn as never);
+    expect(count).toBe(2);
   });
 });

--- a/app/src/lib/push.ts
+++ b/app/src/lib/push.ts
@@ -23,6 +23,7 @@
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import type { AsyncDuckDB } from "@duckdb/duckdb-wasm";
 import type { AppConfig } from "./config";
+import { isParquetRegistered } from "./duckdb";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -176,12 +177,13 @@ export async function mergeDownloadedReviews(
     },
   ];
 
-  for (const { sql } of ops) {
+  for (const { file, sql } of ops) {
+    if (!isParquetRegistered(file)) continue;
     try {
       await conn.query(sql);
       applied++;
     } catch {
-      // File not yet in the manifest (no pushes yet) — skip silently
+      // unexpected error — skip silently
     }
   }
 


### PR DESCRIPTION
Closes #407

## Summary

- Import `isParquetRegistered` in `push.ts`
- Skip each `mergeDownloadedReviews` SQL operation when the parquet file hasn't been registered in the DuckDB VFS yet, rather than letting DuckDB log an IO error at the WASM layer before the catch fires
- Consistent with the same guard applied to `score_history.parquet` and `causal_effects.parquet` in #403

## Test plan

- [ ] Push reviews from a fresh session (no prior sync) — no `IO Error` lines in console
- [ ] Push reviews after a full sync that includes merged review files — merge applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)