### PR TITLE
fix: pre-register push export files to suppress DuckDB buffering warnings

### DIFF
--- a/app/src/lib/push.test.ts
+++ b/app/src/lib/push.test.ts
@@ -31,6 +31,7 @@ const NONE_CONFIG: AppConfig = {
 
 function makeDb() {
   return {
+    registerFileBuffer: vi.fn().mockResolvedValue(undefined),
     copyFileToBuffer: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
     dropFile: vi.fn().mockResolvedValue(undefined),
   };

--- a/app/src/lib/push.ts
+++ b/app/src/lib/push.ts
@@ -64,6 +64,7 @@ export async function pushReviews(
 
   const form = new FormData();
   for (const { table, file, field } of exports) {
+    await db.registerFileBuffer(file, new Uint8Array(0));
     await conn.query(`COPY ${table} TO '${file}' (FORMAT PARQUET)`);
     const bytes = await db.copyFileToBuffer(file);
     await db.dropFile(file);


### PR DESCRIPTION
Closes #409

## Summary

- Call `db.registerFileBuffer(file, new Uint8Array(0))` before each `COPY TO` in `pushReviews()`
- DuckDB-WASM emits `Buffering missing file` at the WASM layer when `COPY TO` creates a file that isn't pre-registered — this cannot be caught in JS, so the fix is to register an empty buffer first
- Updated `makeDb()` mock in tests to include `registerFileBuffer`

## Test plan

- [ ] Push reviews — no `Buffering missing file` warnings in console
- [ ] Push still succeeds and files are uploaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)