### PR TITLE
fix: soft-skip GFW EO ingest on truncated JSON response

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -14,6 +14,7 @@ Available regions: singapore, japan, middleeast, europe, persiangulf, blacksea
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -581,8 +582,11 @@ def step_eo_ingest(p: RegionPreset, non_interactive: bool) -> bool:
     except PermissionError as exc:
         _ok(f"Skipping EO ingest — {exc}")
         return True
+    except json.JSONDecodeError as exc:
+        _ok(f"Skipping EO ingest — GFW response truncated ({exc}), will retry on next run")
+        return True
     except Exception as exc:
-        # Treat network timeouts as a soft skip so the pipeline continues.
+        # Treat network timeouts / disconnects as a soft skip so the pipeline continues.
         exc_str = str(exc)
         _TRANSIENT = (
             "timed out",
@@ -591,6 +595,7 @@ def step_eo_ingest(p: RegionPreset, non_interactive: bool) -> bool:
             "connection reset",
             "connection refused",
             "remotedisconnected",
+            "unterminated string",
         )
         if any(t in exc_str.lower() for t in _TRANSIENT):
             _ok(


### PR DESCRIPTION
Follow-up to #405.

## Problem

GFW returns a ~1.5 GB JSON response that gets cut off mid-stream, producing:

```
Unterminated string starting at: line 1 column 1501071911 (char 1501071910)
```

This is a `json.JSONDecodeError`, which the previous transient-error handler didn't catch, so the pipeline halted and prompted `[r]etry / [s]kip`.

## Fix

- Add `except json.JSONDecodeError` as a named handler (requires `import json`) — skips EO ingest with a clear message and continues the pipeline
- Also add `"unterminated string"` to the `_TRANSIENT` string list as a belt-and-suspenders fallback for the same error surfacing through a wrapper exception

## Test plan

- [ ] Run pipeline when GFW returns a truncated response — step 6 shows `✓ Skipping EO ingest — GFW response truncated (…)` and continues to step 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)