### PR TITLE
fix: reset push status to idle when a new review is saved after push

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -168,11 +168,12 @@ export default function App() {
         identifier_basis: "mmsi",
         evidence: [],
       });
+      setPushStatus((prev) => prev.phase === "done" ? { phase: "idle" } : prev);
     } catch {
       // Roll back on failure
       await refreshQuery();
     }
-  }, [reviewStates, refreshQuery]);
+  }, [reviewStates, refreshQuery, setPushStatus]);
 
   // Re-query when filter changes (if data is already loaded)
   useEffect(() => {
@@ -357,6 +358,7 @@ export default function App() {
                     const states = await getBulkReviewStates(conn, vessels.map((v) => v.mmsi));
                     setReviewStates(states);
                   }
+                  setPushStatus((prev) => prev.phase === "done" ? { phase: "idle" } : prev);
                 }}
               />
             ) : null;


### PR DESCRIPTION
## Problem

After pushing reviews, the button shows "Pushed just now". If the analyst then saves a new review decision, the button keeps showing the stale "Pushed just now" label — giving no indication that there are new local changes that haven't been pushed.

## Fix

After a successful `saveReview` (both from `VesselDetail.onReviewSaved` and from `handleClaim`), if `pushStatus` is currently `done`, reset it to `idle`. This makes the Push button revert to its default state, signalling that new local changes exist.

The reset only fires when the previous state was `done` — it does not interfere with in-progress pushes or error states.

## Test plan

- [ ] Push reviews → button shows "Pushed just now"
- [ ] Save a new review decision on any vessel → button reverts to "Push reviews" (idle)
- [ ] Claim a vessel → same reset behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)