### PR TITLE
fix(push): revert registerFileBuffer pre-registration to fix 0-byte uploads

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -168,11 +168,12 @@ export default function App() {
         identifier_basis: "mmsi",
         evidence: [],
       });
+      setPushStatus((prev) => prev.phase === "done" ? { phase: "idle" } : prev);
     } catch {
       // Roll back on failure
       await refreshQuery();
     }
-  }, [reviewStates, refreshQuery]);
+  }, [reviewStates, refreshQuery, setPushStatus]);
 
   // Re-query when filter changes (if data is already loaded)
   useEffect(() => {
@@ -357,6 +358,7 @@ export default function App() {
                     const states = await getBulkReviewStates(conn, vessels.map((v) => v.mmsi));
                     setReviewStates(states);
                   }
+                  setPushStatus((prev) => prev.phase === "done" ? { phase: "idle" } : prev);
                 }}
               />
             ) : null;

--- a/app/src/lib/push.test.ts
+++ b/app/src/lib/push.test.ts
@@ -31,7 +31,6 @@ const NONE_CONFIG: AppConfig = {
 
 function makeDb() {
   return {
-    registerFileBuffer: vi.fn().mockResolvedValue(undefined),
     copyFileToBuffer: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
     dropFile: vi.fn().mockResolvedValue(undefined),
   };
@@ -96,36 +95,6 @@ describe("pushReviews — endpoint routing", () => {
   });
 });
 
-describe("pushReviews — tmp file pre-registration", () => {
-  it("pre-registers both tmp_ and final filename for each export table", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true, status: 200,
-      json: async () => ({ updatedAt: "2026-04-21T00:00:00.000Z" }),
-    }));
-    const db = makeDb();
-    await pushReviews(db as never, makeConn() as never, CF_CONFIG, () => {});
-    const registeredNames = db.registerFileBuffer.mock.calls.map((c: unknown[]) => c[0]);
-    expect(registeredNames).toContain("tmp__push_reviews.parquet");
-    expect(registeredNames).toContain("_push_reviews.parquet");
-    expect(registeredNames).toContain("tmp__push_audit.parquet");
-    expect(registeredNames).toContain("_push_audit.parquet");
-    expect(registeredNames).toContain("tmp__push_briefs.parquet");
-    expect(registeredNames).toContain("_push_briefs.parquet");
-  });
-
-  it("registers tmp_ file before final file for each table", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true, status: 200,
-      json: async () => ({ updatedAt: "2026-04-21T00:00:00.000Z" }),
-    }));
-    const db = makeDb();
-    await pushReviews(db as never, makeConn() as never, CF_CONFIG, () => {});
-    const names = db.registerFileBuffer.mock.calls.map((c: unknown[]) => c[0] as string);
-    for (const file of ["_push_reviews.parquet", "_push_audit.parquet", "_push_briefs.parquet"]) {
-      expect(names.indexOf(`tmp_${file}`)).toBeLessThan(names.indexOf(file));
-    }
-  });
-});
 
 describe("pushReviews — status progression", () => {
   it("emits exporting → uploading → done on success", async () => {

--- a/app/src/lib/push.ts
+++ b/app/src/lib/push.ts
@@ -64,14 +64,9 @@ export async function pushReviews(
 
   const form = new FormData();
   for (const { table, file, field } of exports) {
-    // DuckDB safe-writes via a tmp_ staging file before renaming to the final path.
-    // Pre-register both so the WASM layer doesn't log "Buffering missing file".
-    await db.registerFileBuffer(`tmp_${file}`, new Uint8Array(0));
-    await db.registerFileBuffer(file, new Uint8Array(0));
     await conn.query(`COPY ${table} TO '${file}' (FORMAT PARQUET)`);
     const bytes = await db.copyFileToBuffer(file);
     await db.dropFile(file);
-    await db.dropFile(`tmp_${file}`).catch(() => {});
     form.append(
       field,
       new Blob([bytes.buffer as ArrayBuffer], { type: "application/octet-stream" }),


### PR DESCRIPTION
## Summary
- Removes `db.registerFileBuffer(tmp_file, …)` and `db.registerFileBuffer(file, …)` pre-registration calls added in PRs #410 and #414
- Pre-registering the export file with an empty `Uint8Array` before `COPY TO` caused `copyFileToBuffer` to return that empty buffer — all three review Parquet files were uploaded as 0 bytes (confirmed via R2 listing)
- The root cause: DuckDB-WASM's safe-write renames `tmp_file → file`; the rename updates the registry to the empty pre-registered slot rather than the written data
- The `Buffering missing file` console log is cosmetic WASM noise when DuckDB creates a new file — it does not affect push correctness
- Removes the 2 now-obsolete tmp file pre-registration tests; all remaining 12 tests pass

## Test plan
- [ ] `npx vitest run src/lib/push.test.ts` — 12 tests pass
- [ ] Deploy and push reviews; verify R2 files are non-zero bytes via `uv run python scripts/sync_r2.py list 2>&1 | grep reviews/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)