### PR TITLE
fix: auto-sync after login to pull private merged review files

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -283,6 +283,9 @@ export default function App() {
                     clearInterval(timer);
                     const email = await checkPrivateAuth(appConfig);
                     setUserEmail(email);
+                    if (email) {
+                      await doSync(undefined, undefined, true, appConfig);
+                    }
                   }
                 }, 500);
               }}


### PR DESCRIPTION
## Summary
- After login the app called `setUserEmail` but never triggered `doSync`, so files marked `private: true` in the manifest (the three merged analyst review parquets) were never downloaded for the newly authenticated session
- Reviews submitted by other analysts were invisible until the user manually hit Sync
- Fix: call `doSync(auth=true)` immediately after the CF Access popup closes and an email is confirmed

## Root cause
`reviews_merged.parquet`, `reviews_audit_merged.parquet`, and `reviews_briefs_merged.parquet` are stored in the manifest with `"private": true`. `syncAndLoad` skips these files for unauthenticated sessions (`!f.private || privateAuth`). After login, the session became authenticated but no re-sync was triggered, so the private files were never fetched and `mergeDownloadedReviews` never ran.

## Test plan
- [ ] Log in as user A, add a review, push, run `merge-reviews`
- [ ] Log out, log in as user B — merged reviews from user A should appear after the auto-sync completes (no manual Sync button press needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)