### PR TITLE
feat(#47): expose causal model alpha threshold via sanction_regimes.yaml

### DIFF
--- a/pipeline/config/sanction_regimes.yaml
+++ b/pipeline/config/sanction_regimes.yaml
@@ -1,3 +1,10 @@
+# Significance threshold for the DiD causal model.
+# A vessel is flagged as causally significant when p < alpha.
+# Default: 0.05. Recommended range: 0.001 (very conservative) – 0.10 (permissive).
+# Lowering alpha reduces false positives; raising it increases recall at the cost
+# of more analyst review time.
+alpha: 0.05
+
 regimes:
   OFAC_Iran:
     label: "OFAC Iran"

--- a/pipeline/src/score/causal_sanction.py
+++ b/pipeline/src/score/causal_sanction.py
@@ -584,6 +584,7 @@ def run_causal_model(
     -------
     List of :class:`CausalEffect` dataclasses, one per regime.
     """
+    alpha = ALPHA
     if regimes is None:
         regimes = SANCTION_REGIMES
         if regimes_path and os.path.exists(regimes_path):
@@ -594,6 +595,8 @@ def run_causal_model(
                     data = yaml.safe_load(f)
                     if data and "regimes" in data:
                         regimes = data["regimes"]
+                    if data and "alpha" in data:
+                        alpha = float(data["alpha"])
             except Exception as e:
                 print(f"Failed to load regimes from {regimes_path}: {e}")
 
@@ -611,7 +614,7 @@ def run_causal_model(
                 per_date.append(result)
 
             pooled = _pool_estimates([r for r in per_date if r is not None])
-            is_sig = pooled["p"] < ALPHA and pooled["att"] != 0.0
+            is_sig = pooled["p"] < alpha and pooled["att"] != 0.0
 
             effect = CausalEffect(
                 regime=regime_key,


### PR DESCRIPTION
## Summary

Makes the DiD significance threshold operator-configurable without code changes.

**`pipeline/config/sanction_regimes.yaml`** — adds top-level `alpha` key:
```yaml
# Default: 0.05. Recommended range: 0.001–0.10.
alpha: 0.05
```

**`pipeline/src/score/causal_sanction.py`** — `run_causal_model()` now reads `alpha` from the YAML (falls back to module-level `ALPHA = 0.05` if absent), and uses it in the significance check instead of the global constant.

This makes the submission claim accurate: "configurable between p < 0.001 and p < 0.10 via `alpha` key in `pipeline/config/sanction_regimes.yaml`".

Companion doc PR: edgesentry/arktrace-commercial#XX (fixes risk mitigation table wording)

## Test plan

- [ ] Default behaviour unchanged (alpha still 0.05 when YAML key absent or default)
- [ ] Setting `alpha: 0.01` in YAML produces fewer significant results than `alpha: 0.10`
- [ ] `ALPHA` module constant still used as fallback when YAML is not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)