### PR TITLE
docs: add LLM grounding doc and system prompt anti-hallucination constraints

### DIFF
--- a/app/src/components/VesselDetail.test.ts
+++ b/app/src/components/VesselDetail.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Stub heavy browser dependencies before importing the component.
+vi.mock("../lib/duckdb", () => ({
+  isParquetRegistered: vi.fn(),
+}));
+vi.mock("../lib/briefCache", () => ({
+  getCachedBrief: vi.fn(),
+  saveCachedBrief: vi.fn(),
+  initBriefCache: vi.fn(),
+}));
+vi.mock("../lib/reviews", () => ({
+  getReview: vi.fn(),
+  tierColor: vi.fn(),
+  handoffLabel: vi.fn(),
+}));
+vi.mock("../lib/humanise", () => ({
+  formatLastSeen: vi.fn((v) => v ?? "—"),
+  confidenceTier: vi.fn(() => "HIGH"),
+  confidenceTierColor: vi.fn(() => "#f00"),
+  signalLabel: vi.fn((f: string) => f),
+  signalSeverity: vi.fn(() => null),
+  severityColor: vi.fn(() => "#f00"),
+}));
+
+import { SYSTEM_PROMPT, buildUserContent } from "./VesselDetail";
+import type { VesselRow } from "../lib/duckdb";
+
+const BASE_VESSEL: VesselRow = {
+  mmsi: "123456789",
+  imo: null,
+  vessel_name: "TEST VESSEL",
+  flag: "SG",
+  vessel_type: "Tanker",
+  region: "singapore",
+  last_seen: "2026-04-22T10:00:00Z",
+  last_lat: 1.3521,
+  last_lon: 103.8198,
+  confidence: 0.87,
+  top_signals: null,
+  sanctions_distance: null,
+  causal_att: null,
+  causal_p_value: null,
+};
+
+// ── SYSTEM_PROMPT constraints ────────────────────────────────────────────────
+
+describe("SYSTEM_PROMPT", () => {
+  it("prohibits inventing MMSIs and vessel identifiers", () => {
+    expect(SYSTEM_PROMPT).toContain("Do NOT invent");
+    expect(SYSTEM_PROMPT).toContain("MMSI");
+    expect(SYSTEM_PROMPT).toContain("IMO number");
+    expect(SYSTEM_PROMPT).toContain("vessel name");
+  });
+
+  it("prohibits adding unverified sanctions or ownership claims", () => {
+    expect(SYSTEM_PROMPT).toContain("sanctions designations");
+    expect(SYSTEM_PROMPT).toContain("ownership links");
+  });
+
+  it("requires plain text output only", () => {
+    expect(SYSTEM_PROMPT).toContain("plain text only");
+    expect(SYSTEM_PROMPT).toContain("no markdown");
+  });
+
+  it("enforces a 3-sentence maximum", () => {
+    expect(SYSTEM_PROMPT).toContain("Maximum 3 sentences");
+  });
+
+  it("references the context block as the sole source of truth", () => {
+    expect(SYSTEM_PROMPT).toContain("context block");
+  });
+});
+
+// ── buildUserContent ─────────────────────────────────────────────────────────
+
+describe("buildUserContent", () => {
+  it("includes MMSI and confidence", () => {
+    const content = buildUserContent(BASE_VESSEL);
+    expect(content).toContain("MMSI: 123456789");
+    expect(content).toContain("Anomaly confidence: 0.870");
+  });
+
+  it("includes vessel name when present", () => {
+    const content = buildUserContent(BASE_VESSEL);
+    expect(content).toContain("Vessel: TEST VESSEL");
+  });
+
+  it("falls back to MMSI in vessel line when name is absent", () => {
+    const content = buildUserContent({ ...BASE_VESSEL, vessel_name: "" });
+    expect(content).toContain("Vessel: 123456789");
+  });
+
+  it("omits null fields — flag", () => {
+    const content = buildUserContent({ ...BASE_VESSEL, flag: null });
+    expect(content).not.toContain("Flag:");
+  });
+
+  it("omits null fields — vessel type", () => {
+    const content = buildUserContent({ ...BASE_VESSEL, vessel_type: null });
+    expect(content).not.toContain("Type:");
+  });
+
+  it("omits null fields — region", () => {
+    const content = buildUserContent({ ...BASE_VESSEL, region: null });
+    expect(content).not.toContain("Region:");
+  });
+
+  it("omits null fields — last_seen", () => {
+    const content = buildUserContent({ ...BASE_VESSEL, last_seen: null });
+    expect(content).not.toContain("Last seen:");
+  });
+
+  it("omits position when lat/lon are null", () => {
+    const content = buildUserContent({ ...BASE_VESSEL, last_lat: null, last_lon: null });
+    expect(content).not.toContain("Position:");
+  });
+
+  it("includes position when both lat and lon are present", () => {
+    const content = buildUserContent(BASE_VESSEL);
+    expect(content).toContain("Position:");
+    expect(content).toContain("1.3521");
+    expect(content).toContain("103.8198");
+  });
+
+  it("does not include any field not in the vessel row", () => {
+    const content = buildUserContent(BASE_VESSEL);
+    // Ensure no invented data markers leak in
+    expect(content).not.toContain("undefined");
+    expect(content).not.toContain("null");
+    expect(content).not.toContain("NaN");
+  });
+});

--- a/app/src/components/VesselDetail.tsx
+++ b/app/src/components/VesselDetail.tsx
@@ -35,7 +35,7 @@ const LLM_TIMEOUT_MS = 45_000;
 
 type BriefStatus = "idle" | "loading" | "cached" | "ready" | "offline" | "error";
 
-const SYSTEM_PROMPT =
+export const SYSTEM_PROMPT =
   `You are a maritime intelligence analyst writing patrol dispatch briefs. ` +
   `You will be given a structured vessel context block containing pre-computed scores, ` +
   `SHAP signal attributions, and verified registry data. Your only job is to synthesise ` +
@@ -48,7 +48,7 @@ const SYSTEM_PROMPT =
   `- Output plain text only — no markdown, no bullet points, no headers.\n` +
   `- Maximum 3 sentences.`;
 
-function buildUserContent(v: VesselRow): string {
+export function buildUserContent(v: VesselRow): string {
   const parts = [
     `Vessel: ${v.vessel_name || v.mmsi}`,
     `MMSI: ${v.mmsi}`,

--- a/app/src/components/VesselDetail.tsx
+++ b/app/src/components/VesselDetail.tsx
@@ -35,7 +35,20 @@ const LLM_TIMEOUT_MS = 45_000;
 
 type BriefStatus = "idle" | "loading" | "cached" | "ready" | "offline" | "error";
 
-function buildPrompt(v: VesselRow): string {
+const SYSTEM_PROMPT =
+  `You are a maritime intelligence analyst writing patrol dispatch briefs. ` +
+  `You will be given a structured vessel context block containing pre-computed scores, ` +
+  `SHAP signal attributions, and verified registry data. Your only job is to synthesise ` +
+  `that context into a concise plain-language brief.\n\n` +
+  `STRICT CONSTRAINTS — violation invalidates the brief:\n` +
+  `- Do NOT invent, infer, or guess any MMSI, IMO number, vessel name, flag, owner, or position not present in the context block.\n` +
+  `- Do NOT add sanctions designations, ownership links, or cargo claims not stated in the context block.\n` +
+  `- Do NOT speculate about intent beyond what the provided signals support.\n` +
+  `- Every factual claim must be traceable to a field in the context block.\n` +
+  `- Output plain text only — no markdown, no bullet points, no headers.\n` +
+  `- Maximum 3 sentences.`;
+
+function buildUserContent(v: VesselRow): string {
   const parts = [
     `Vessel: ${v.vessel_name || v.mmsi}`,
     `MMSI: ${v.mmsi}`,
@@ -52,9 +65,9 @@ function buildPrompt(v: VesselRow): string {
     .join("\n");
 
   return (
-    `You are a maritime intelligence analyst. Provide a concise 2-3 sentence risk assessment ` +
-    `for the following vessel flagged by an anomaly-detection system. Focus on probable cause ` +
-    `of the anomaly, regional context, and recommended follow-up action. Be direct — no preamble.\n\n` +
+    `Write a 2-3 sentence risk assessment for the vessel below. ` +
+    `Focus on probable cause of the anomaly, regional context, and recommended follow-up action. ` +
+    `Only reference data present in the context block below.\n\n` +
     parts
   );
 }
@@ -70,7 +83,10 @@ async function fetchBrief(v: VesselRow, signal: AbortSignal): Promise<string> {
       model: "local",
       max_tokens: 200,
       temperature: 0.3,
-      messages: [{ role: "user", content: buildPrompt(v) }],
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user",   content: buildUserContent(v) },
+      ],
     }),
     signal,
   });

--- a/docs/llm-grounding.md
+++ b/docs/llm-grounding.md
@@ -1,0 +1,94 @@
+# LLM Grounding and Anti-Hallucination Policy
+
+arktrace uses a local LLM exclusively for **text synthesis** — converting pre-computed, deterministic scores into plain-language patrol briefs. The LLM has no access to external data, cannot modify scores, and cannot query the pipeline.
+
+---
+
+## Two-Phase Architecture
+
+```
+Phase 1 — Deterministic scoring  (no LLM)
+  AIS positions → feature engineering → DiD causal model → SHAP attribution
+  Output: confidence score, ATT ± CI, top_signals JSON, ownership graph path
+          ↓  immutable — passed as read-only context to Phase 2
+
+Phase 2 — Bounded text synthesis  (LLM)
+  Context block (vessel metadata + Phase 1 outputs) → system prompt + user prompt
+  Output: 2-3 sentence plain-language brief
+```
+
+The LLM only sees what Phase 1 produces. It cannot alter scores, fetch external data, or access any information outside the context block.
+
+---
+
+## System Prompt
+
+Injected as `role: "system"` on every brief request:
+
+```
+You are a maritime intelligence analyst writing patrol dispatch briefs.
+You will be given a structured vessel context block containing pre-computed scores,
+SHAP signal attributions, and verified registry data. Your only job is to synthesise
+that context into a concise plain-language brief.
+
+STRICT CONSTRAINTS — violation invalidates the brief:
+- Do NOT invent, infer, or guess any MMSI, IMO number, vessel name, flag, owner,
+  or position not present in the context block.
+- Do NOT add sanctions designations, ownership links, or cargo claims not stated
+  in the context block.
+- Do NOT speculate about intent beyond what the provided signals support.
+- Every factual claim must be traceable to a field in the context block.
+- Output plain text only — no markdown, no bullet points, no headers.
+- Maximum 3 sentences.
+```
+
+---
+
+## User Prompt (context block)
+
+Injected as `role: "user"`. Contains only fields present in the scored vessel row:
+
+```
+Write a 2-3 sentence risk assessment for the vessel below.
+Focus on probable cause of the anomaly, regional context, and recommended follow-up action.
+Only reference data present in the context block below.
+
+Vessel: <vessel_name or mmsi>
+MMSI: <mmsi>
+Flag: <flag>               ← omitted if null
+Type: <vessel_type>        ← omitted if null
+Region: <region>           ← omitted if null
+Last seen: <last_seen>     ← omitted if null
+Position: <lat>°, <lon>°   ← omitted if null
+Anomaly confidence: <confidence>
+```
+
+No SHAP signal values, ownership paths, or ATT coefficients are included in the user prompt at this stage — the brief is intentionally scoped to vessel-level summary. The full signal breakdown is displayed separately in the SHAP panel.
+
+---
+
+## Output Constraints
+
+| Parameter | Value | Rationale |
+|---|---|---|
+| `max_tokens` | 200 | Hard ceiling — prevents rambling or invented detail |
+| `temperature` | 0.3 | Low variance — reproducible, factual tone |
+| Output format | Plain text, ≤ 3 sentences | No markdown structures that could embed unverified claims |
+
+---
+
+## What the LLM Cannot Do
+
+| Prohibited action | Enforced by |
+|---|---|
+| Invent MMSIs, IMO numbers, or vessel names | System prompt constraint + context block contains only verified registry fields |
+| Add sanctions designations not in the context | System prompt constraint; sanctions data is displayed from the deterministic pipeline, not the brief |
+| Modify the confidence score or ATT estimate | LLM output is stored in `analyst_briefs` table; scores are stored separately and never overwritten by brief generation |
+| Access external APIs or the internet | Local inference endpoint only (`localhost`); no outbound network access from the LLM process |
+| Persist state between requests | Stateless API call; no conversation history is maintained |
+
+---
+
+## Verifiability
+
+Every claim in an analyst brief can be verified against the displayed SHAP panel and vessel detail row. The brief is clearly labelled "Analyst brief" and visually separated from the deterministic SHAP attribution and ATT outputs. Analysts are instructed in the [SOP](sop.md) to treat the brief as a synthesis aid, not a primary evidence source.


### PR DESCRIPTION
Closes #435

## Changes

### `app/src/components/VesselDetail.tsx`
- Extracted `SYSTEM_PROMPT` constant with explicit anti-hallucination constraints injected as `role: "system"` on every brief request
- Renamed `buildPrompt` → `buildUserContent` — constraints now enforced at the protocol level (system message), not mixed into user content
- Prohibitions: no invented MMSIs/IMOs/vessel names, no unverified sanctions claims, no speculation beyond provided signals, plain text only, max 3 sentences

### `docs/llm-grounding.md` (new)
- Two-phase architecture diagram: deterministic scoring first, bounded LLM text synthesis second
- Full system prompt and user prompt templates with field-level annotations
- Output constraints table (`max_tokens: 200`, `temperature: 0.3`, plain text)
- "What the LLM cannot do" table with enforcement mechanism for each prohibition
- Verifiability section for Cap Vista evaluators

## Acceptance criteria
- [x] Sample prompt template documented
- [x] Anti-hallucination constraints explicitly stated in docs and enforced in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)