### PR TITLE
docs: clarify AIS historical baseline vs. live collection start date

### DIFF
--- a/docs/trial-specification.md
+++ b/docs/trial-specification.md
@@ -76,7 +76,9 @@ Proposed trial scope: **30–60 days** on Singapore / Malacca Strait as the prim
 ### Week 1 — Setup and baseline ingestion
 
 - Deploy pipeline on provided VM or edge hardware using `docker compose up`
-- Ingest 6 months of historical AIS for the Singapore / Malacca Strait bounding box
+- Load 6-month historical AIS baseline for the Singapore / Malacca Strait bounding box
+
+  > **Data source note:** The 6-month historical baseline is pre-computed AIS data hosted on Cloudflare R2 and pulled at trial setup via `scripts/fetch_demo_data.sh` — it is available from Day 1 without waiting for live collection to accumulate. Live aisstream.io ingestion supplements this baseline from Week 1 onwards. The March 2026 date mentioned in evaluation notes refers to when *live* WebSocket collection started; it does not limit the historical depth available at trial start.
 - Load OFAC SDN, EU FSF, and UN 1267 sanctions lists via OpenSanctions
 - Pull vessel ownership chains from Equasis; build Lance Graph
 - Run full feature engineering and scoring pipeline; generate initial `candidate_watchlist.parquet`


### PR DESCRIPTION
Closes #430

## Problem

`docs/trial-specification.md` Week 1 stated "ingest 6 months of historical AIS" while evaluation notes said "AIS collection began March 2026" — appearing contradictory to anyone reading the proposal.

## Fix

Added a clarification note directly under the Week 1 historical ingestion bullet in `docs/trial-specification.md`:

- The 6-month historical baseline is **pre-computed AIS data hosted on R2**, pulled at trial setup via `scripts/fetch_demo_data.sh` — available from Day 1
- Live aisstream.io ingestion supplements this baseline from Week 1 onwards
- The March 2026 date refers to live WebSocket collection start only; it does not limit historical depth available at trial start

## Acceptance criteria
- [x] Discrepancy addressed clearly in a doc visible to Cap Vista

🤖 Generated with [Claude Code](https://claude.com/claude-code)