### PR TITLE
feat(sync_r2): add push-ais-dbs / pull-ais-dbs subcommands

### DIFF
--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1549,7 +1549,10 @@ def _ais_db_candidates(data_dir: Path, regions: list[str] | None) -> list[Path]:
     Otherwise every non-excluded .duckdb in data_dir is a candidate.
     """
     _EXCLUDE_STEMS = {
-        "backtest_demo", "public_eval", "mpol", "catalog",
+        "backtest_demo",
+        "public_eval",
+        "mpol",
+        "catalog",
     }
     candidates = []
     if regions:

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -80,6 +80,10 @@ Commands
                       arktrace-public/ (overwrites on every run — no rotation)
   push-ducklake-private upload DuckLake catalog.duckdb + private output files to
                       arktrace-private-capvista/outputs/ (authenticated analysts only)
+  push-ais-dbs        upload regional AIS .duckdb files to the private R2 bucket as a
+                      backup; skips files that are older than the remote copy
+  pull-ais-dbs        download regional AIS .duckdb files from the private R2 bucket;
+                      skips files that are older than the local copy
   list                show all snapshot zips and shared objects in R2
 
 Env vars (loaded from .env automatically)
@@ -112,6 +116,9 @@ Examples
   uv run python scripts/sync_r2.py pull-custom-feeds         # pull feeds from private bucket
   uv run python scripts/sync_r2.py push-ducklake-public      # upload DuckLake catalog to public bucket
   uv run python scripts/sync_r2.py push-ducklake-private     # upload private outputs to private bucket
+  uv run python scripts/sync_r2.py push-ais-dbs              # back up all active AIS .duckdb to private R2
+  uv run python scripts/sync_r2.py push-ais-dbs --regions japansea,blacksea,middleeast
+  uv run python scripts/sync_r2.py pull-ais-dbs              # restore AIS DBs on a new machine
   uv run python scripts/sync_r2.py list                      # show all generations in R2
 """
 
@@ -1531,6 +1538,155 @@ def cmd_push_ducklake_private(args: argparse.Namespace) -> int:
     return 0
 
 
+_AIS_DBS_R2_PREFIX = "ais-dbs/"  # private bucket sub-prefix for raw AIS DB backups
+_AIS_DB_MIN_SIZE_BYTES = 1_048_576  # skip placeholder DBs smaller than 1 MB
+
+
+def _ais_db_candidates(data_dir: Path, regions: list[str] | None) -> list[Path]:
+    """Return regional .duckdb paths that are large enough to be non-empty.
+
+    If *regions* is given, only those region prefixes are considered.
+    Otherwise every non-excluded .duckdb in data_dir is a candidate.
+    """
+    _EXCLUDE_STEMS = {
+        "backtest_demo", "public_eval", "mpol", "catalog",
+    }
+    candidates = []
+    if regions:
+        stems = [_REGION_PREFIX.get(r, r) for r in regions]
+        paths = [data_dir / f"{s}.duckdb" for s in stems]
+    else:
+        paths = sorted(data_dir.glob("*.duckdb"))
+
+    for p in paths:
+        if not p.exists():
+            continue
+        if p.stem in _EXCLUDE_STEMS:
+            continue
+        if p.stat().st_size < _AIS_DB_MIN_SIZE_BYTES:
+            continue
+        candidates.append(p)
+    return candidates
+
+
+def cmd_push_ais_dbs(args: argparse.Namespace) -> int:
+    """Upload regional AIS .duckdb files to the private R2 bucket for backup.
+
+    Each file is uploaded as:
+      arktrace-private-capvista/ais-dbs/<filename>.duckdb
+
+    Existing objects are overwritten (no rotation — the stream collector is the
+    source of truth and files grow continuously).
+    """
+    data_dir = Path(args.data_dir)
+    regions: list[str] | None = (
+        [r.strip() for r in args.regions.split(",")] if args.regions else None
+    )
+
+    candidates = _ais_db_candidates(data_dir, regions)
+    if not candidates:
+        print(
+            "No eligible AIS .duckdb files found. "
+            "Check --data-dir and --regions, or that files are > 1 MB.",
+            file=sys.stderr,
+        )
+        return 1
+
+    import pyarrow.fs as pafs
+
+    fs = _build_r2_fs()
+    print(f"Uploading {len(candidates)} AIS DB(s) to {_PRIVATE_BUCKET}/{_AIS_DBS_R2_PREFIX}")
+    for local_path in candidates:
+        r2_path = f"{_PRIVATE_BUCKET}/{_AIS_DBS_R2_PREFIX}{local_path.name}"
+        size_mb = local_path.stat().st_size / 1_048_576
+        print(f"  {local_path.name} ({size_mb:.1f} MB) → {r2_path} ...", end="", flush=True)
+
+        # Check remote LastModified — skip if local file is older (unless --force)
+        if not args.force:
+            try:
+                info = fs.get_file_info([r2_path])[0]
+                if info.type == pafs.FileType.File:
+                    local_mtime = local_path.stat().st_mtime
+                    remote_mtime = info.mtime.timestamp() if info.mtime else 0
+                    if local_mtime <= remote_mtime:
+                        print(" (skipped — remote is newer or same; use --force to overwrite)")
+                        continue
+            except Exception:
+                pass  # object doesn't exist yet — proceed with upload
+
+        _upload_file(fs, local_path, r2_path)
+        print(f" ✓ ({size_mb:.1f} MB)")
+
+    print(f"\nDone. AIS DBs backed up to {_PRIVATE_BUCKET}/{_AIS_DBS_R2_PREFIX}")
+    print("Restore on another machine with: uv run python scripts/sync_r2.py pull-ais-dbs")
+    return 0
+
+
+def cmd_pull_ais_dbs(args: argparse.Namespace) -> int:
+    """Download regional AIS .duckdb files from the private R2 bucket.
+
+    Only downloads a file if the remote copy is newer than the local file
+    (by LastModified timestamp), unless --force is set.
+    """
+    if not (os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY")):
+        print(
+            "Error: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY not set — "
+            "pull-ais-dbs requires private bucket credentials.",
+            file=sys.stderr,
+        )
+        return 1
+
+    import pyarrow.fs as pafs
+
+    data_dir = Path(args.data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    regions: list[str] | None = (
+        [r.strip() for r in args.regions.split(",")] if args.regions else None
+    )
+
+    fs = _build_r2_fs()
+    prefix = f"{_PRIVATE_BUCKET}/{_AIS_DBS_R2_PREFIX}"
+    selector = pafs.FileSelector(prefix, recursive=False)
+    try:
+        infos = fs.get_file_info(selector)
+    except Exception as exc:
+        print(f"Error listing {prefix}: {exc}", file=sys.stderr)
+        return 1
+
+    db_files = [i for i in infos if i.type == pafs.FileType.File and i.path.endswith(".duckdb")]
+    if not db_files:
+        print(f"No .duckdb files found at {prefix} — nothing to download.")
+        return 0
+
+    # Filter by requested regions if specified
+    if regions:
+        stems = {_REGION_PREFIX.get(r, r) for r in regions}
+        db_files = [i for i in db_files if Path(i.path).stem in stems]
+        if not db_files:
+            print(f"No matching files for regions: {regions}", file=sys.stderr)
+            return 1
+
+    print(f"Found {len(db_files)} AIS DB(s) in {_PRIVATE_BUCKET}/{_AIS_DBS_R2_PREFIX}")
+    for info in db_files:
+        filename = Path(info.path).name
+        local_path = data_dir / filename
+        size_mb = info.size / 1_048_576
+        print(f"  {filename} ({size_mb:.1f} MB) ...", end="", flush=True)
+
+        if not args.force and local_path.exists():
+            local_mtime = local_path.stat().st_mtime
+            remote_mtime = info.mtime.timestamp() if info.mtime else 0
+            if local_mtime >= remote_mtime:
+                print(" (skipped — local is same age or newer; use --force to overwrite)")
+                continue
+
+        _download_file(fs, info.path, local_path)
+        print(f" ✓ ({size_mb:.1f} MB)")
+
+    print(f"\nDone. AIS DBs restored to {data_dir}/")
+    return 0
+
+
 def cmd_list(args: argparse.Namespace) -> int:
     bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
     anon = not (os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY"))
@@ -1805,6 +1961,49 @@ def main() -> int:
         ),
     )
 
+    push_ais_dbs_p = sub.add_parser(
+        "push-ais-dbs",
+        help=(
+            "Upload regional AIS .duckdb files to arktrace-private-capvista/ais-dbs/ "
+            "(requires credentials; skips files older than the remote copy)"
+        ),
+    )
+    push_ais_dbs_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
+    push_ais_dbs_p.add_argument(
+        "--regions",
+        default=None,
+        metavar="REGIONS",
+        help=(
+            "Comma-separated region names to upload "
+            f"(default: all eligible DBs). Known regions: {', '.join(_REGION_PREFIX)}"
+        ),
+    )
+    push_ais_dbs_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite remote even if it is newer than the local file",
+    )
+
+    pull_ais_dbs_p = sub.add_parser(
+        "pull-ais-dbs",
+        help=(
+            "Download regional AIS .duckdb files from arktrace-private-capvista/ais-dbs/ "
+            "(requires credentials; skips files older than the local copy)"
+        ),
+    )
+    pull_ais_dbs_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
+    pull_ais_dbs_p.add_argument(
+        "--regions",
+        default=None,
+        metavar="REGIONS",
+        help="Comma-separated region names to download (default: all available in bucket)",
+    )
+    pull_ais_dbs_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite local file even if it is newer than the remote copy",
+    )
+
     sub.add_parser("list", help="List snapshot zips and shared objects in R2")
 
     args = parser.parse_args()
@@ -1823,6 +2022,7 @@ def main() -> int:
         "pull-demo",
         "pull-reviews",
         "pull-custom-feeds",
+        "pull-ais-dbs",
         "list",
     )
     if not _check_env(require_credentials=not read_only):
@@ -1846,6 +2046,8 @@ def main() -> int:
         "pull-custom-feeds": cmd_pull_custom_feeds,
         "push-ducklake-public": cmd_push_ducklake_public,
         "push-ducklake-private": cmd_push_ducklake_private,
+        "push-ais-dbs": cmd_push_ais_dbs,
+        "pull-ais-dbs": cmd_pull_ais_dbs,
         "list": cmd_list,
     }
     return dispatch[args.command](args)

--- a/tests/test_sync_r2_ais_dbs.py
+++ b/tests/test_sync_r2_ais_dbs.py
@@ -1,0 +1,336 @@
+"""Tests for sync_r2.py push-ais-dbs / pull-ais-dbs subcommands."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+import scripts.sync_r2 as sync_r2
+
+
+# ---------------------------------------------------------------------------
+# _ais_db_candidates
+# ---------------------------------------------------------------------------
+
+
+def test_candidates_skips_excluded_stems(tmp_path):
+    """mpol, public_eval, backtest_demo, catalog are never returned."""
+    for name in ("mpol.duckdb", "public_eval.duckdb", "backtest_demo.duckdb", "catalog.duckdb"):
+        (tmp_path / name).write_bytes(b"x" * 2_000_000)
+
+    assert sync_r2._ais_db_candidates(tmp_path, None) == []
+
+
+def test_candidates_skips_small_dbs(tmp_path):
+    """Files smaller than 1 MB are treated as placeholders and excluded."""
+    (tmp_path / "japansea.duckdb").write_bytes(b"x" * 500_000)
+    assert sync_r2._ais_db_candidates(tmp_path, None) == []
+
+
+def test_candidates_returns_eligible_dbs(tmp_path):
+    """Large non-excluded .duckdb files are returned."""
+    for name in ("japansea.duckdb", "blacksea.duckdb"):
+        (tmp_path / name).write_bytes(b"x" * 2_000_000)
+
+    result = sync_r2._ais_db_candidates(tmp_path, None)
+    assert {p.name for p in result} == {"japansea.duckdb", "blacksea.duckdb"}
+
+
+def test_candidates_filters_by_region(tmp_path):
+    """Only requested regions are returned when --regions is specified."""
+    for name in ("japansea.duckdb", "blacksea.duckdb", "europe.duckdb"):
+        (tmp_path / name).write_bytes(b"x" * 2_000_000)
+
+    result = sync_r2._ais_db_candidates(tmp_path, ["japan", "europe"])
+    assert {p.name for p in result} == {"japansea.duckdb", "europe.duckdb"}
+
+
+def test_candidates_missing_region_db_skipped(tmp_path):
+    """A requested region whose .duckdb does not exist is silently skipped."""
+    (tmp_path / "japansea.duckdb").write_bytes(b"x" * 2_000_000)
+
+    result = sync_r2._ais_db_candidates(tmp_path, ["japan", "middleeast"])
+    assert [p.name for p in result] == ["japansea.duckdb"]
+
+
+# ---------------------------------------------------------------------------
+# cmd_push_ais_dbs
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def push_args(tmp_path):
+    return argparse.Namespace(data_dir=str(tmp_path), regions=None, force=False)
+
+
+def test_push_returns_1_when_no_candidates(push_args, tmp_path):
+    """Returns error code when no eligible DBs are found."""
+    result = sync_r2.cmd_push_ais_dbs(push_args)
+    assert result == 1
+
+
+def test_push_uploads_all_eligible_dbs(push_args, tmp_path):
+    """Calls _upload_file once per eligible DB."""
+    for name in ("japansea.duckdb", "blacksea.duckdb"):
+        (tmp_path / name).write_bytes(b"x" * 2_000_000)
+
+    import pyarrow.fs as pafs
+
+    mock_info = MagicMock()
+    mock_info.type = pafs.FileType.NotFound
+
+    mock_fs = MagicMock()
+    mock_fs.get_file_info.return_value = [mock_info]
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_upload_file", return_value=2_000_000) as mock_upload:
+            result = sync_r2.cmd_push_ais_dbs(push_args)
+
+    assert result == 0
+    assert mock_upload.call_count == 2
+    uploaded_names = {Path(c.args[1]).name for c in mock_upload.call_args_list}
+    assert uploaded_names == {"japansea.duckdb", "blacksea.duckdb"}
+
+
+def test_push_skips_when_remote_is_newer(push_args, tmp_path):
+    """File is skipped when remote LastModified is newer than local mtime."""
+    db = tmp_path / "japansea.duckdb"
+    db.write_bytes(b"x" * 2_000_000)
+
+    import datetime
+
+    import pyarrow.fs as pafs
+
+    mock_info = MagicMock()
+    mock_info.type = pafs.FileType.File
+    # Remote mtime far in the future
+    mock_info.mtime = datetime.datetime(2099, 1, 1, tzinfo=datetime.timezone.utc)
+
+    mock_fs = MagicMock()
+    mock_fs.get_file_info.return_value = [mock_info]
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_upload_file") as mock_upload:
+            result = sync_r2.cmd_push_ais_dbs(push_args)
+
+    assert result == 0
+    mock_upload.assert_not_called()
+
+
+def test_push_force_uploads_even_when_remote_newer(tmp_path):
+    """--force bypasses the mtime check and always uploads."""
+    db = tmp_path / "japansea.duckdb"
+    db.write_bytes(b"x" * 2_000_000)
+
+    args = argparse.Namespace(data_dir=str(tmp_path), regions=None, force=True)
+
+    mock_fs = MagicMock()
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_upload_file", return_value=2_000_000) as mock_upload:
+            result = sync_r2.cmd_push_ais_dbs(args)
+
+    assert result == 0
+    mock_upload.assert_called_once()
+
+
+def test_push_regions_arg_filters_uploads(tmp_path):
+    """--regions limits uploads to the specified subset."""
+    for name in ("japansea.duckdb", "blacksea.duckdb", "europe.duckdb"):
+        (tmp_path / name).write_bytes(b"x" * 2_000_000)
+
+    args = argparse.Namespace(data_dir=str(tmp_path), regions="japan,blacksea", force=True)
+
+    mock_fs = MagicMock()
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_upload_file", return_value=2_000_000) as mock_upload:
+            result = sync_r2.cmd_push_ais_dbs(args)
+
+    assert result == 0
+    uploaded_names = {Path(c.args[1]).name for c in mock_upload.call_args_list}
+    assert uploaded_names == {"japansea.duckdb", "blacksea.duckdb"}
+
+
+def test_push_r2_path_uses_private_bucket(tmp_path):
+    """Uploaded R2 paths are under arktrace-private-capvista/ais-dbs/."""
+    (tmp_path / "japansea.duckdb").write_bytes(b"x" * 2_000_000)
+    args = argparse.Namespace(data_dir=str(tmp_path), regions=None, force=True)
+
+    mock_fs = MagicMock()
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_upload_file", return_value=2_000_000) as mock_upload:
+            sync_r2.cmd_push_ais_dbs(args)
+
+    r2_path = mock_upload.call_args.args[2]
+    assert r2_path == f"{sync_r2._PRIVATE_BUCKET}/ais-dbs/japansea.duckdb"
+
+
+# ---------------------------------------------------------------------------
+# cmd_pull_ais_dbs
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pull_args(tmp_path):
+    return argparse.Namespace(data_dir=str(tmp_path), regions=None, force=False)
+
+
+def test_pull_returns_1_without_credentials(pull_args, monkeypatch):
+    """Returns error code when AWS credentials are absent."""
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    result = sync_r2.cmd_pull_ais_dbs(pull_args)
+    assert result == 1
+
+
+def test_pull_downloads_all_remote_dbs(pull_args, tmp_path, monkeypatch):
+    """Calls _download_file for each .duckdb found in the remote prefix."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    import datetime
+
+    import pyarrow.fs as pafs
+
+    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+
+    def make_info(name):
+        info = MagicMock()
+        info.type = pafs.FileType.File
+        info.path = f"{sync_r2._PRIVATE_BUCKET}/ais-dbs/{name}"
+        info.size = 2_000_000
+        info.mtime = past
+        return info
+
+    infos = [make_info("japansea.duckdb"), make_info("blacksea.duckdb")]
+
+    mock_fs = MagicMock()
+    mock_fs.get_file_info.return_value = infos
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_download_file", return_value=2_000_000) as mock_dl:
+            result = sync_r2.cmd_pull_ais_dbs(pull_args)
+
+    assert result == 0
+    assert mock_dl.call_count == 2
+    downloaded_names = {Path(c.args[2]).name for c in mock_dl.call_args_list}
+    assert downloaded_names == {"japansea.duckdb", "blacksea.duckdb"}
+
+
+def test_pull_skips_when_local_is_newer(tmp_path, monkeypatch):
+    """File is skipped when local mtime is newer than remote LastModified."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    import datetime
+
+    import pyarrow.fs as pafs
+
+    # Write a local file with a recent mtime
+    local = tmp_path / "japansea.duckdb"
+    local.write_bytes(b"x" * 2_000_000)
+
+    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+
+    info = MagicMock()
+    info.type = pafs.FileType.File
+    info.path = f"{sync_r2._PRIVATE_BUCKET}/ais-dbs/japansea.duckdb"
+    info.size = 2_000_000
+    info.mtime = past
+
+    mock_fs = MagicMock()
+    mock_fs.get_file_info.return_value = [info]
+
+    args = argparse.Namespace(data_dir=str(tmp_path), regions=None, force=False)
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_download_file") as mock_dl:
+            result = sync_r2.cmd_pull_ais_dbs(args)
+
+    assert result == 0
+    mock_dl.assert_not_called()
+
+
+def test_pull_force_downloads_even_when_local_newer(tmp_path, monkeypatch):
+    """--force bypasses mtime check and always downloads."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    import datetime
+
+    import pyarrow.fs as pafs
+
+    local = tmp_path / "japansea.duckdb"
+    local.write_bytes(b"x" * 2_000_000)
+
+    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+
+    info = MagicMock()
+    info.type = pafs.FileType.File
+    info.path = f"{sync_r2._PRIVATE_BUCKET}/ais-dbs/japansea.duckdb"
+    info.size = 2_000_000
+    info.mtime = past
+
+    mock_fs = MagicMock()
+    mock_fs.get_file_info.return_value = [info]
+
+    args = argparse.Namespace(data_dir=str(tmp_path), regions=None, force=True)
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_download_file", return_value=2_000_000) as mock_dl:
+            result = sync_r2.cmd_pull_ais_dbs(args)
+
+    assert result == 0
+    mock_dl.assert_called_once()
+
+
+def test_pull_regions_filter(tmp_path, monkeypatch):
+    """--regions limits downloads to the specified subset."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    import datetime
+
+    import pyarrow.fs as pafs
+
+    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+
+    def make_info(name):
+        info = MagicMock()
+        info.type = pafs.FileType.File
+        info.path = f"{sync_r2._PRIVATE_BUCKET}/ais-dbs/{name}"
+        info.size = 2_000_000
+        info.mtime = past
+        return info
+
+    infos = [make_info("japansea.duckdb"), make_info("blacksea.duckdb"), make_info("europe.duckdb")]
+
+    mock_fs = MagicMock()
+    mock_fs.get_file_info.return_value = infos
+
+    args = argparse.Namespace(data_dir=str(tmp_path), regions="japan", force=True)
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_download_file", return_value=2_000_000) as mock_dl:
+            result = sync_r2.cmd_pull_ais_dbs(args)
+
+    assert result == 0
+    assert mock_dl.call_count == 1
+    assert Path(mock_dl.call_args.args[2]).name == "japansea.duckdb"
+
+
+def test_pull_returns_0_when_bucket_empty(pull_args, monkeypatch):
+    """Returns 0 (not an error) when no .duckdb files are in the bucket."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    mock_fs = MagicMock()
+    mock_fs.get_file_info.return_value = []
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        result = sync_r2.cmd_pull_ais_dbs(pull_args)
+
+    assert result == 0

--- a/tests/test_sync_r2_ais_dbs.py
+++ b/tests/test_sync_r2_ais_dbs.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import argparse
-import os
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 import scripts.sync_r2 as sync_r2
-
 
 # ---------------------------------------------------------------------------
 # _ais_db_candidates
@@ -108,7 +106,7 @@ def test_push_skips_when_remote_is_newer(push_args, tmp_path):
     mock_info = MagicMock()
     mock_info.type = pafs.FileType.File
     # Remote mtime far in the future
-    mock_info.mtime = datetime.datetime(2099, 1, 1, tzinfo=datetime.timezone.utc)
+    mock_info.mtime = datetime.datetime(2099, 1, 1, tzinfo=datetime.UTC)
 
     mock_fs = MagicMock()
     mock_fs.get_file_info.return_value = [mock_info]
@@ -198,7 +196,7 @@ def test_pull_downloads_all_remote_dbs(pull_args, tmp_path, monkeypatch):
 
     import pyarrow.fs as pafs
 
-    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
 
     def make_info(name):
         info = MagicMock()
@@ -236,7 +234,7 @@ def test_pull_skips_when_local_is_newer(tmp_path, monkeypatch):
     local = tmp_path / "japansea.duckdb"
     local.write_bytes(b"x" * 2_000_000)
 
-    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
 
     info = MagicMock()
     info.type = pafs.FileType.File
@@ -268,7 +266,7 @@ def test_pull_force_downloads_even_when_local_newer(tmp_path, monkeypatch):
     local = tmp_path / "japansea.duckdb"
     local.write_bytes(b"x" * 2_000_000)
 
-    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
 
     info = MagicMock()
     info.type = pafs.FileType.File
@@ -297,7 +295,7 @@ def test_pull_regions_filter(tmp_path, monkeypatch):
 
     import pyarrow.fs as pafs
 
-    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+    past = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
 
     def make_info(name):
         info = MagicMock()


### PR DESCRIPTION
Closes #447

## Summary

- `push-ais-dbs`: uploads regional AIS `.duckdb` files to `arktrace-private-capvista/ais-dbs/`; skips files where the remote is newer (use `--force` to override)
- `pull-ais-dbs`: downloads from the private bucket; skips files where local is same age or newer (use `--force` to override)
- Both support `--regions japansea,blacksea,middleeast` for targeted sync
- `_ais_db_candidates()` helper — excludes `mpol`, `public_eval`, `backtest_demo`, and any DB < 1 MB (placeholder)

Currently detected files: `blacksea` (21 MB), `europe` (217 MB), `gulfofmexico` (2 MB), `japansea` (38 MB), `middleeast` (21 MB), `singapore` (76 MB)

## Test plan

- [ ] `uv run python scripts/sync_r2.py push-ais-dbs --help` — shows correct options
- [ ] `uv run python scripts/sync_r2.py pull-ais-dbs --help` — shows correct options
- [ ] With credentials: `push-ais-dbs --regions japansea,blacksea,middleeast` uploads 3 files to private bucket
- [ ] Re-run without `--force` — all 3 skipped (remote is now newer)
- [ ] `pull-ais-dbs` on another machine restores the files

🤖 Generated with [Claude Code](https://claude.com/claude-code)