### PR TITLE
fix(scripts): set PYTHONPATH and pipeline dir in launchd AIS agents

### DIFF
--- a/scripts/install_launchd_agents.sh
+++ b/scripts/install_launchd_agents.sh
@@ -33,6 +33,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${0:A}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PIPELINE_DIR="${PROJECT_DIR}/pipeline"
 PLIST_DIR="${HOME}/Library/LaunchAgents"
 LOG_DIR="${HOME}/.arktrace"
 UV_BIN="/opt/homebrew/bin/uv"
@@ -224,7 +225,7 @@ for region in ${=REGIONS}; do
   </array>
 
   <key>WorkingDirectory</key>
-  <string>${PROJECT_DIR}</string>
+  <string>${PIPELINE_DIR}</string>
 
   <key>EnvironmentVariables</key>
   <dict>
@@ -236,6 +237,8 @@ for region in ${=REGIONS}; do
     <string>${HOME}</string>
     <key>PATH</key>
     <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/.local/bin:${HOME}/.cargo/bin</string>
+    <key>PYTHONPATH</key>
+    <string>${PIPELINE_DIR}</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -283,10 +286,12 @@ if [[ ${INSTALL_R2SYNC} -eq 1 ]]; then
     <string>--project</string>
     <string>${PROJECT_DIR}</string>
     <string>python</string>
-    <string>scripts/sync_r2.py</string>
+    <string>${PROJECT_DIR}/scripts/sync_r2.py</string>
     <string>push-ais-dbs</string>
     <string>--regions</string>
     <string>${r2_regions}</string>
+    <string>--data-dir</string>
+    <string>${PROJECT_DIR}/data/processed</string>
   </array>
 
   <key>WorkingDirectory</key>


### PR DESCRIPTION
## Summary

- `install_launchd_agents.sh` was generating plists with `WorkingDirectory` set to the project root, but `src.ingest.ais_stream` lives in `pipeline/src/` — causing `No module named 'src'` on launchd-managed processes
- Adds `PYTHONPATH=${PIPELINE_DIR}` to each aisstream agent's `EnvironmentVariables` so Python finds the module regardless of working directory
- Sets `WorkingDirectory` to `pipeline/` for aisstream agents
- Adds `--data-dir ${PROJECT_DIR}/data/processed` to the r2sync agent so it finds the regional DuckDB files
- Introduces `PIPELINE_DIR` variable for reuse across both plist templates

## Test plan

- [x] All three agents (japansea, blacksea, middleeast) show active PIDs after reinstall
- [x] `blacksea.log` confirms successful WebSocket subscription and row flushes
- [x] `r2sync` completed with exit 0 and uploaded DBs to `arktrace-private-capvista/ais-dbs/`
- [x] `--status` shows clean list with no stale entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)