### PR TITLE
fix(ci): add singapore and europe to daily pipeline scoring

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -59,7 +59,7 @@ jobs:
           AWS_REGION: auto
         run: |
           uv run python scripts/sync_r2.py pull-ais-dbs \
-            --regions japansea,blacksea,middleeast
+            --regions japansea,blacksea,middleeast,singapore,europe
 
       # Pull proprietary feed files (AIS, SAR, cargo, custom sanctions) from the
       # private bucket via arktrace-private-capvista.edgesentry.io into
@@ -104,6 +104,18 @@ jobs:
         run: |
           uv run python scripts/run_pipeline.py \
             --region middleeast \
+            --non-interactive
+
+      - name: Run pipeline — Singapore
+        run: |
+          uv run python scripts/run_pipeline.py \
+            --region singapore \
+            --non-interactive
+
+      - name: Run pipeline — Europe
+        run: |
+          uv run python scripts/run_pipeline.py \
+            --region europe \
             --non-interactive
 
       # Run backtest against the pulled watchlists.
@@ -294,7 +306,7 @@ jobs:
           AWS_REGION: auto
         run: |
           uv run python scripts/sync_r2.py push-ais-dbs \
-            --regions japansea,blacksea,middleeast
+            --regions japansea,blacksea,middleeast,singapore,europe
 
       - name: Lead time validation (#268)
         run: |


### PR DESCRIPTION
## Summary

Singapore and europe were included in the backtest region list (`--regions singapore,japan,europe,blacksea`) but their AIS DBs were never pulled and their watchlists were never scored in CI. As a result their watchlist parquets in R2 were stale/absent, falling below `--min-watchlist-size=100` every run.

Both regions have substantial real AIS data in private R2:
- singapore: ~1,993 vessels
- europe: ~22,655 vessels

**Changes to `data-publish.yml`:**
- `pull-ais-dbs`: adds `singapore,europe` to the regions list
- Adds `Run pipeline — Singapore` and `Run pipeline — Europe` scoring steps after Middle East
- `push-ais-dbs`: adds `singapore,europe` to the regions list

## Test plan

- [ ] Verify singapore and europe watchlists are generated and pushed to R2 after this runs
- [ ] Confirm next data-publish email shows no skipped regions

Closes #462