### PR TITLE
fix(ci): seed demo files into ARKTRACE_DATA_DIR, not ~/.arktrace/data

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -147,18 +147,18 @@ jobs:
           echo "snapshot_mb=$snapshot_mb" >> "$GITHUB_OUTPUT"
 
       - name: Seed demo files for push-demo
-        # push-demo reads from ~/.arktrace/data/; the backtest writes outputs to
-        # data/processed/.  Copy/generate the three required demo files so
-        # push-demo can find them regardless of whether the full pipeline ran.
+        # Ensures all _DEMO_FILES exist in ARKTRACE_DATA_DIR (data/processed in CI)
+        # so push-demo can find them. Generates empty-schema fallbacks for files
+        # that the pipeline doesn't produce in --skip-pipeline mode.
         run: |
           uv run python - <<'EOF'
-          import json, shutil
+          import json, os, shutil
           from pathlib import Path
           import polars as pl
 
-          demo_dir = Path.home() / ".arktrace" / "data"
+          demo_dir = Path(os.environ.get("ARKTRACE_DATA_DIR", str(Path.home() / ".arktrace" / "data")))
           demo_dir.mkdir(parents=True, exist_ok=True)
-          processed = Path("data/processed")
+          processed = demo_dir
 
           # candidate_watchlist.parquet — primary demo file; must exist in demo_dir.
           # The backtest writes it to data/processed/; copy it across.


### PR DESCRIPTION
## Summary

Fixes the "Push demo bundle to R2" step failure from run [24804078201](https://github.com/edgesentry/arktrace/actions/runs/24804078201/job/72593878665).

**Root cause:** The "Seed demo files" step hardcoded `demo_dir = Path.home() / ".arktrace" / "data"`, but `push-demo` resolves its `--data-dir` via `ARKTRACE_DATA_DIR` (set to `data/processed` at job level). Files were written to `~/.arktrace/data/` but `push-demo` looked in `data/processed/`, causing it to fail with:
```
Error: the following demo files are missing from data/processed:
  causal_effects.parquet
  validation_metrics.json
```

**Fix:** Read `ARKTRACE_DATA_DIR` in the inline seed script (falling back to `~/.arktrace/data` for local runs), and derive `processed` from the same path so both variables point to the same directory.

## Test plan

- [ ] Next data-publish run completes "Push demo bundle to R2" without error
- [ ] demo.zip in R2 contains all 5 `_DEMO_FILES`