### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@
 
 Please **do not** report security vulnerabilities through public GitHub issues.
 
-Instead, report them by emailing **yohei.onishi11@gmail.com**. You should receive a response within 48 hours. If you do not, please follow up to ensure the original message was received.
+Instead, report them by emailing **admin@edgesentry.io**. You should receive a response within 48 hours. If you do not, please follow up to ensure the original message was received.
 
 Please include as much of the following information as possible to help us better understand and resolve the issue:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues.
+
+Instead, report them by emailing **yohei.onishi11@gmail.com**. You should receive a response within 48 hours. If you do not, please follow up to ensure the original message was received.
+
+Please include as much of the following information as possible to help us better understand and resolve the issue:
+
+- Type of vulnerability (e.g. SQL injection, data exposure, privilege escalation)
+- Full paths of any source files related to the issue
+- Steps to reproduce
+- Proof-of-concept or exploit code (if available)
+- Impact assessment — how an attacker could exploit the issue
+
+We will acknowledge receipt, investigate, and keep you informed of progress toward a fix. We ask that you give us reasonable time to address the issue before any public disclosure.


### PR DESCRIPTION
Adds a `SECURITY.md` so GitHub surfaces the security policy in the repo header and Security tab.

- Supported versions table (0.1.x — current)
- Private disclosure instructions via email (no public issues)
- Guidance on what to include in a report and expected response time (48h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)