### PR TITLE
feat: wire GFW_API_TOKEN into pipeline steps to enable EO ingest

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -89,30 +89,40 @@ jobs:
         run: uv run python scripts/sync_r2.py pull-watchlists
 
       - name: Run pipeline — Japan Sea
+        env:
+          GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region japan \
             --non-interactive
 
       - name: Run pipeline — Black Sea
+        env:
+          GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region blacksea \
             --non-interactive
 
       - name: Run pipeline — Middle East
+        env:
+          GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region middleeast \
             --non-interactive
 
       - name: Run pipeline — Singapore
+        env:
+          GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region singapore \
             --non-interactive
 
       - name: Run pipeline — Europe
+        env:
+          GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region europe \


### PR DESCRIPTION
## Summary

- Adds `GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}` to the `env:` block of all five `Run pipeline —` steps in `data-publish.yml`

## What this enables

Once `GFW_API_TOKEN` is added as a GitHub Actions secret (repo Settings → Secrets → Actions), pipeline step 6/11 will call the GFW 4Wings API for each region instead of printing:

```
✓  GFW_API_TOKEN not set — skipping EO ingest (set token to enable)
```

This populates the `eo_detections` table, activating the `eo_dark_count_30d` and `eo_ais_mismatch_ratio` feature columns that currently produce zeros.

If the secret is not yet set, behaviour is unchanged — the step skips gracefully as before.

## Test plan

- [x] Add `GFW_API_TOKEN` secret in repo Settings → Secrets and variables → Actions (free token from https://globalfishingwatch.org/data/vessel-presence/)
- [ ] Trigger a manual `workflow_dispatch` run of `data-publish.yml`
- [ ] Confirm step 6/11 logs show detections ingested rather than the skip message

Closes #475