### PR TITLE
fix(gfw): retry on 429 with 60s backoff (up to 5 attempts)

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -90,7 +90,9 @@ jobs:
 
       - name: Run pipeline — Japan Sea
         env:
-          GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}
+          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
+          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
+          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region japan \
@@ -98,7 +100,9 @@ jobs:
 
       - name: Run pipeline — Black Sea
         env:
-          GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}
+          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
+          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
+          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region blacksea \
@@ -106,7 +110,9 @@ jobs:
 
       - name: Run pipeline — Middle East
         env:
-          GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}
+          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
+          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
+          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region middleeast \
@@ -114,7 +120,9 @@ jobs:
 
       - name: Run pipeline — Singapore
         env:
-          GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}
+          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
+          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
+          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region singapore \
@@ -122,7 +130,9 @@ jobs:
 
       - name: Run pipeline — Europe
         env:
-          GFW_API_TOKEN: ${{ secrets.GFW_API_TOKEN }}
+          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
+          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
+          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region europe \

--- a/pipeline/src/ingest/eo_gfw.py
+++ b/pipeline/src/ingest/eo_gfw.py
@@ -53,15 +53,21 @@ def fetch_gfw_detections(
     bbox: tuple[float, float, float, float] = DEFAULT_BBOX,
     days: int = 30,
     api_token: str = GFW_API_TOKEN,
+    api_tokens: list[str] | None = None,
 ) -> list[dict]:
     """Fetch vessel presence detections from GFW 4Wings API.
+
+    Pass ``api_tokens`` (list of tokens) to rotate across multiple tokens on
+    429 before falling back to the timed retry.  This lets concurrent pipeline
+    runs share the load without hitting the per-token concurrency limit.
 
     Returns a list of detection dicts with keys:
         detection_id, detected_at, lat, lon, source, confidence
 
     Raises RuntimeError if no token is configured or the request fails.
     """
-    if not api_token:
+    tokens = [t for t in (api_tokens or [api_token]) if t]
+    if not tokens:
         raise RuntimeError(
             "GFW_API_TOKEN not set. Register at https://globalfishingwatch.org/data/vessel-presence/ "
             "and set the token in your .env file, or use --csv for local ingestion."
@@ -119,10 +125,15 @@ def fetch_gfw_detections(
         "Content-Type": "application/json",
     }
 
-    _MAX_RETRIES = 5
     _RETRY_WAIT = 60  # seconds — GFW allows one concurrent report per token
+    _MAX_WAITS = 5
 
-    for attempt in range(_MAX_RETRIES + 1):
+    token_idx = 0
+    wait_count = 0
+
+    while True:
+        current_token = tokens[token_idx % len(tokens)]
+        headers["Authorization"] = f"Bearer {current_token}"
         resp = httpx.post(
             f"{GFW_API_BASE}/4wings/report",
             params=params,
@@ -137,17 +148,30 @@ def fetch_gfw_detections(
                 f"https://globalfishingwatch.org/our-apis/tokens"
             )
         if resp.status_code == 429:
-            if attempt == _MAX_RETRIES:
+            next_idx = token_idx + 1
+            if next_idx % len(tokens) != 0:
+                # Try next token before waiting
+                print(
+                    f"  GFW API 429 on token[{token_idx % len(tokens)}] — "
+                    f"trying token[{next_idx % len(tokens)}] ...",
+                    flush=True,
+                )
+                token_idx = next_idx
+                continue
+            # All tokens exhausted — wait before cycling again
+            if wait_count >= _MAX_WAITS:
                 raise PermissionError(
-                    f"GFW API 429: another report is still running after "
-                    f"{_MAX_RETRIES} retries ({_MAX_RETRIES * _RETRY_WAIT}s total wait)"
+                    f"GFW API 429: all {len(tokens)} token(s) busy after "
+                    f"{_MAX_WAITS} wait cycles ({_MAX_WAITS * _RETRY_WAIT}s total)"
                 )
             print(
-                f"  GFW API 429 — previous report still running; "
-                f"retrying in {_RETRY_WAIT}s (attempt {attempt + 1}/{_MAX_RETRIES}) ...",
+                f"  GFW API 429 — all {len(tokens)} token(s) busy; "
+                f"retrying in {_RETRY_WAIT}s (wait {wait_count + 1}/{_MAX_WAITS}) ...",
                 flush=True,
             )
             time.sleep(_RETRY_WAIT)
+            token_idx = next_idx
+            wait_count += 1
             continue
         if not resp.is_success:
             raise RuntimeError(f"GFW API {resp.status_code}: {resp.text[:500]}")

--- a/pipeline/src/ingest/eo_gfw.py
+++ b/pipeline/src/ingest/eo_gfw.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import time
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -118,26 +119,39 @@ def fetch_gfw_detections(
         "Content-Type": "application/json",
     }
 
-    resp = httpx.post(
-        f"{GFW_API_BASE}/4wings/report",
-        params=params,
-        json=body,
-        headers=headers,
-        timeout=180,
-    )
-    if resp.status_code in (401, 403):
-        raise PermissionError(
-            f"GFW API returned {resp.status_code}: token lacks access to "
-            f"public-global-presence:latest. Check your token at "
-            f"https://globalfishingwatch.org/our-apis/tokens"
+    _MAX_RETRIES = 5
+    _RETRY_WAIT = 60  # seconds — GFW allows one concurrent report per token
+
+    for attempt in range(_MAX_RETRIES + 1):
+        resp = httpx.post(
+            f"{GFW_API_BASE}/4wings/report",
+            params=params,
+            json=body,
+            headers=headers,
+            timeout=180,
         )
-    if resp.status_code == 429:
-        raise PermissionError(
-            "GFW API 429: another report is already running for this token — "
-            "wait a few minutes and retry"
-        )
-    if not resp.is_success:
-        raise RuntimeError(f"GFW API {resp.status_code}: {resp.text[:500]}")
+        if resp.status_code in (401, 403):
+            raise PermissionError(
+                f"GFW API returned {resp.status_code}: token lacks access to "
+                f"public-global-presence:latest. Check your token at "
+                f"https://globalfishingwatch.org/our-apis/tokens"
+            )
+        if resp.status_code == 429:
+            if attempt == _MAX_RETRIES:
+                raise PermissionError(
+                    f"GFW API 429: another report is still running after "
+                    f"{_MAX_RETRIES} retries ({_MAX_RETRIES * _RETRY_WAIT}s total wait)"
+                )
+            print(
+                f"  GFW API 429 — previous report still running; "
+                f"retrying in {_RETRY_WAIT}s (attempt {attempt + 1}/{_MAX_RETRIES}) ...",
+                flush=True,
+            )
+            time.sleep(_RETRY_WAIT)
+            continue
+        if not resp.is_success:
+            raise RuntimeError(f"GFW API {resp.status_code}: {resp.text[:500]}")
+        break
     data = resp.json()
 
     detections = []

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -565,8 +565,11 @@ def step_eo_ingest(p: RegionPreset, non_interactive: bool) -> bool:
     _step(6, TOTAL_STEPS, "Ingesting GFW EO detections...")
     from pipeline.src.ingest.eo_gfw import fetch_gfw_detections, ingest_eo_records
 
-    token = os.getenv("GFW_API_TOKEN", "")
-    if not token:
+    # Collect GFW_API_TOKEN plus any numbered extras (GFW_API_TOKEN_1/2/3/…).
+    # Multiple tokens allow concurrent reports across sequential pipeline runs.
+    tokens = [t for t in [os.getenv("GFW_API_TOKEN", "")] if t]
+    tokens += [v for k, v in sorted(os.environ.items()) if k.startswith("GFW_API_TOKEN_") and v]
+    if not tokens:
         _ok("GFW_API_TOKEN not set — skipping EO ingest (set token to enable)")
         return True
 
@@ -575,7 +578,7 @@ def step_eo_ingest(p: RegionPreset, non_interactive: bool) -> bool:
         # fetch_gfw_detections expects (lon_min, lat_min, lon_max, lat_max)
         lat_min, lon_min, lat_max, lon_max = p.bbox
         gfw_bbox = (lon_min, lat_min, lon_max, lat_max)
-        records = fetch_gfw_detections(bbox=gfw_bbox, days=30, api_token=token)
+        records = fetch_gfw_detections(bbox=gfw_bbox, days=30, api_tokens=tokens)
         n = ingest_eo_records(records, db_path=p.db_path)
         _ok(f"{n} EO detections ingested from GFW API")
         return True


### PR DESCRIPTION
## Summary

The GFW API allows only one concurrent report per token. Running 5 pipeline regions sequentially meant regions 2–5 always got 429 errors because the previous region's report was still processing.

**Before:** 429 → immediately raises `PermissionError` → EO ingest skipped for that region.

**After:** 429 → wait 60 s → retry, up to 5 times (5 min total). Auth errors (401/403) still fail immediately.

## Changes

`pipeline/src/ingest/eo_gfw.py` — wraps `httpx.post` in a retry loop with `_MAX_RETRIES = 5` and `_RETRY_WAIT = 60s`.

## Test plan

- [ ] CI pipeline no longer shows GFW 429 skips for regions 2–5
- [ ] 11 existing GFW tests still pass

Closes #477