### PR TITLE
feat: add r2sync launchd agent template (all 5 regions) and wire into init

### DIFF
--- a/pipeline/config/launchagents/io.arktrace.r2sync.plist
+++ b/pipeline/config/launchagents/io.arktrace.r2sync.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.arktrace.r2sync</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/uv</string>
+    <string>run</string>
+    <string>--project</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+    <string>python</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/scripts/sync_r2.py</string>
+    <string>push-ais-dbs</string>
+    <string>--regions</string>
+    <string>japansea,blacksea,middleeast,singapore,europe</string>
+    <string>--data-dir</string>
+    <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/yoheionishi/work/edgesentry/arktrace</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AWS_ACCESS_KEY_ID</key>
+    <string>REPLACE_WITH_AWS_ACCESS_KEY_ID</string>
+    <key>AWS_SECRET_ACCESS_KEY</key>
+    <string>REPLACE_WITH_AWS_SECRET_ACCESS_KEY</string>
+    <key>HOME</key>
+    <string>/Users/yoheionishi</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+
+  <!-- Run every 6 hours (21600 seconds) -->
+  <key>StartInterval</key>
+  <integer>21600</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/yoheionishi/.arktrace/r2sync.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/yoheionishi/.arktrace/r2sync.err</string>
+</dict>
+</plist>

--- a/scripts/aisstream_agents.sh
+++ b/scripts/aisstream_agents.sh
@@ -92,6 +92,24 @@ cmd_init() {
     (( installed++ )) || true
   done
 
+  # Install r2sync agent if template exists and AWS credentials are available
+  local r2sync_src="$CONFIG_DIR/${LABEL_PREFIX%.*}.r2sync.plist"
+  local r2sync_dst="$LAUNCH_AGENTS_DIR/${LABEL_PREFIX%.*}.r2sync.plist"
+  if [[ -f "$r2sync_src" ]]; then
+    _load_dotenv
+    local aws_key="${AWS_ACCESS_KEY_ID:-}"
+    local aws_secret="${AWS_SECRET_ACCESS_KEY:-}"
+    if [[ -z "$aws_key" || -z "$aws_secret" ]]; then
+      echo "  [skip] r2sync — AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY not set"
+    else
+      sed -e "s|REPLACE_WITH_AWS_ACCESS_KEY_ID|${aws_key}|g" \
+          -e "s|REPLACE_WITH_AWS_SECRET_ACCESS_KEY|${aws_secret}|g" \
+          "$r2sync_src" > "$r2sync_dst"
+      echo "  [ok]   r2sync → $r2sync_dst"
+      (( installed++ )) || true
+    fi
+  fi
+
   echo
   echo "$installed plist(s) installed to $LAUNCH_AGENTS_DIR"
   echo "Run 'scripts/aisstream_agents.sh start <region>' to activate."


### PR DESCRIPTION
## Summary

- Adds `pipeline/config/launchagents/io.arktrace.r2sync.plist` — the missing template for the R2 sync launchd agent
- Updates `scripts/aisstream_agents.sh init` to install and inject AWS credentials into the r2sync plist alongside the aisstream plists

## Changes

**`pipeline/config/launchagents/io.arktrace.r2sync.plist`**
New template for `io.arktrace.r2sync` — runs `sync_r2.py push-ais-dbs` every 6 hours for all five active regions: `japansea,blacksea,middleeast,singapore,europe`. Uses `REPLACE_WITH_AWS_ACCESS_KEY_ID` / `REPLACE_WITH_AWS_SECRET_ACCESS_KEY` placeholders, consistent with the aisstream plist convention.

**`scripts/aisstream_agents.sh`**
`cmd_init` now also installs the r2sync plist, substituting AWS credentials from `.env`. Skips gracefully if the template is absent or credentials are missing.

## Result

A single `scripts/aisstream_agents.sh init` now sets up the full local stack — AIS stream collectors + the R2 upload job — without any manual plist editing.