### PR TITLE
feat(gfw): decouple EO ingest into weekly gfw-ingest.yml job

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -88,41 +88,36 @@ jobs:
           AWS_REGION: auto
         run: uv run python scripts/sync_r2.py pull-watchlists
 
-      - name: Run pipeline — Japan Sea
+      # Pull pre-fetched GFW EO parquets produced by the weekly gfw-ingest.yml job.
+      # The pipeline ingests from these parquets instead of calling the GFW API,
+      # eliminating per-run 429 rate limits and 180s API timeouts.
+      - name: Pull GFW EO parquets from R2
+        continue-on-error: true
         env:
-          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
-          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
-          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+        run: uv run python scripts/sync_r2.py pull-gfw-eo
+
+      - name: Run pipeline — Japan Sea
         run: |
           uv run python scripts/run_pipeline.py \
             --region japan \
             --non-interactive
 
       - name: Run pipeline — Black Sea
-        env:
-          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
-          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
-          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region blacksea \
             --non-interactive
 
       - name: Run pipeline — Middle East
-        env:
-          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
-          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
-          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region middleeast \
             --non-interactive
 
       - name: Run pipeline — Singapore
-        env:
-          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
-          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
-          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region singapore \
@@ -130,9 +125,6 @@ jobs:
 
       - name: Run pipeline — Europe
         env:
-          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
-          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
-          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
         run: |
           uv run python scripts/run_pipeline.py \
             --region europe \

--- a/.github/workflows/gfw-ingest.yml
+++ b/.github/workflows/gfw-ingest.yml
@@ -1,0 +1,58 @@
+name: GFW EO Ingest
+
+# Fetches GFW vessel-presence detections weekly and pushes them to private R2.
+# The daily data-publish pipeline pulls these parquets instead of calling the
+# GFW API directly, avoiding per-run 429 rate limits and 180s API timeouts.
+#
+# Triggers:
+#   - Weekly Monday 00:00 UTC (before data-publish at 01:00)
+#   - Manual dispatch
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # weekly Monday 00:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: gfw-ingest
+  cancel-in-progress: true
+
+jobs:
+  ingest:
+    name: Fetch GFW EO detections & push to R2
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      ARKTRACE_DATA_DIR: data/processed
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --group dev
+
+      - name: Fetch GFW EO detections for all active regions
+        env:
+          GFW_API_TOKEN_1: ${{ secrets.GFW_API_TOKEN_1 }}
+          GFW_API_TOKEN_2: ${{ secrets.GFW_API_TOKEN_2 }}
+          GFW_API_TOKEN_3: ${{ secrets.GFW_API_TOKEN_3 }}
+        run: |
+          uv run python scripts/gfw_ingest.py \
+            --regions singapore,japan,europe,blacksea,middleeast \
+            --days 30
+
+      - name: Push GFW EO parquets to private R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+        run: uv run python scripts/sync_r2.py push-gfw-eo

--- a/scripts/gfw_ingest.py
+++ b/scripts/gfw_ingest.py
@@ -1,0 +1,123 @@
+"""Fetch GFW EO vessel-presence detections for all active regions and save as parquet.
+
+Run this script (typically weekly via gfw-ingest.yml) to pre-fetch GFW data
+so the daily data-publish pipeline can ingest it without calling the API directly.
+
+Output: data/processed/{region_prefix}_eo_detections.parquet per region.
+
+Usage:
+    uv run python scripts/gfw_ingest.py
+    uv run python scripts/gfw_ingest.py --regions singapore,japan,europe,blacksea
+    uv run python scripts/gfw_ingest.py --days 30 --out-dir data/processed
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Active regions for GFW EO ingest — subset of run_pipeline.py PRESETS that
+# have real AIS streaming data and are included in the public backtest.
+_ACTIVE_REGIONS = ["singapore", "japan", "europe", "blacksea", "middleeast"]
+
+# Maps pipeline region name → (file_prefix, bbox as lon_min,lat_min,lon_max,lat_max)
+# bbox source: run_pipeline.py PRESETS (stored as lat_min,lon_min,lat_max,lon_max)
+_REGION_META: dict[str, tuple[str, tuple[float, float, float, float]]] = {
+    "singapore": ("singapore", (92.0, -5.0, 122.0, 22.0)),
+    "japan": ("japansea", (115.0, 25.0, 145.0, 48.0)),
+    "europe": ("europe", (-22.0, 30.0, 42.0, 72.0)),
+    "blacksea": ("blacksea", (27.0, 40.0, 42.0, 48.0)),
+    "middleeast": ("middleeast", (32.0, -10.0, 80.0, 30.0)),
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pre-fetch GFW EO detections for all regions")
+    parser.add_argument(
+        "--regions",
+        default=",".join(_ACTIVE_REGIONS),
+        help=f"Comma-separated regions to fetch (default: {','.join(_ACTIVE_REGIONS)})",
+    )
+    parser.add_argument(
+        "--days", type=int, default=30, help="Lookback window in days (default: 30)"
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=os.getenv("ARKTRACE_DATA_DIR", str(Path.home() / ".arktrace" / "data")),
+        metavar="DIR",
+        help="Output directory for parquet files",
+    )
+    args = parser.parse_args()
+
+    import polars as pl
+
+    from pipeline.src.ingest.eo_gfw import fetch_gfw_detections
+
+    tokens = [t for t in [os.getenv("GFW_API_TOKEN", "")] if t]
+    tokens += [v for k, v in sorted(os.environ.items()) if k.startswith("GFW_API_TOKEN_") and v]
+    if not tokens:
+        print("Error: GFW_API_TOKEN not set — cannot fetch GFW EO detections.", file=sys.stderr)
+        return 1
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    regions = [r.strip() for r in args.regions.split(",") if r.strip()]
+
+    fetched_at = datetime.now(UTC).isoformat()
+    success, skipped = 0, 0
+
+    for region in regions:
+        if region not in _REGION_META:
+            print(f"[warn] Unknown region '{region}' — skipping", flush=True)
+            skipped += 1
+            continue
+
+        prefix, bbox = _REGION_META[region]
+        out_path = out_dir / f"{prefix}_eo_detections.parquet"
+        print(
+            f"[{region}] fetching GFW EO detections (bbox={bbox}, days={args.days}) ...", flush=True
+        )
+
+        try:
+            records = fetch_gfw_detections(bbox=bbox, days=args.days, api_tokens=tokens)
+        except PermissionError as exc:
+            print(f"  [skip] {exc}", flush=True)
+            skipped += 1
+            continue
+        except Exception as exc:
+            print(f"  [skip] GFW API error: {exc}", flush=True)
+            skipped += 1
+            continue
+
+        if not records:
+            print("  0 detections — writing empty parquet so pull-gfw-eo can distribute it")
+
+        df = pl.DataFrame(
+            records or [],
+            schema={
+                "detection_id": pl.Utf8,
+                "detected_at": pl.Datetime("us", "UTC"),
+                "lat": pl.Float64,
+                "lon": pl.Float64,
+                "source": pl.Utf8,
+                "confidence": pl.Float32,
+            },
+        ).with_columns(pl.lit(fetched_at).alias("fetched_at"))
+
+        df.write_parquet(out_path)
+        print(f"  {len(df)} detections → {out_path}", flush=True)
+        success += 1
+
+    print(f"\nDone. {success} region(s) fetched, {skipped} skipped.")
+    return 0 if skipped == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Region presets
@@ -557,16 +558,41 @@ def step_custom_feeds(p: RegionPreset, non_interactive: bool) -> bool:
 def step_eo_ingest(p: RegionPreset, non_interactive: bool) -> bool:
     """Ingest GFW EO vessel-presence detections (dark vessels) into eo_detections.
 
-    Skipped automatically when GFW_API_TOKEN is not set — the feature layer
-    will then produce zero EO features, which is correct for offline runs.
+    Prefers a pre-fetched parquet produced by scripts/gfw_ingest.py and pulled
+    from R2 via pull-gfw-eo.  Falls back to a live GFW API call when no parquet
+    is found and GFW_API_TOKEN is set.  Skips gracefully when neither is available.
     """
     import os
 
     _step(6, TOTAL_STEPS, "Ingesting GFW EO detections...")
     from pipeline.src.ingest.eo_gfw import fetch_gfw_detections, ingest_eo_records
 
-    # Collect GFW_API_TOKEN plus any numbered extras (GFW_API_TOKEN_1/2/3/…).
-    # Multiple tokens allow concurrent reports across sequential pipeline runs.
+    data_dir = Path(os.getenv("ARKTRACE_DATA_DIR", str(Path.home() / ".arktrace" / "data")))
+    parquet_path = data_dir / f"{Path(p.db_path).stem}_eo_detections.parquet"
+
+    # --- prefer pre-fetched parquet (pushed by gfw-ingest.yml weekly job) ---
+    if parquet_path.exists():
+        try:
+            import polars as pl
+
+            df = pl.read_parquet(
+                parquet_path,
+                columns=["detection_id", "detected_at", "lat", "lon", "source", "confidence"],
+            )
+            records = df.to_dicts()
+            # Convert detected_at back to datetime objects if needed
+            for r in records:
+                if not hasattr(r["detected_at"], "tzinfo"):
+                    from datetime import UTC
+
+                    r["detected_at"] = r["detected_at"].replace(tzinfo=UTC)
+            n = ingest_eo_records(records, db_path=p.db_path)
+            _ok(f"{n} EO detections ingested from pre-fetched parquet ({parquet_path.name})")
+            return True
+        except Exception as exc:
+            _ok(f"Parquet ingest failed ({exc}); falling back to GFW API")
+
+    # --- fall back to live API ---
     tokens = [t for t in [os.getenv("GFW_API_TOKEN", "")] if t]
     tokens += [v for k, v in sorted(os.environ.items()) if k.startswith("GFW_API_TOKEN_") and v]
     if not tokens:
@@ -589,7 +615,6 @@ def step_eo_ingest(p: RegionPreset, non_interactive: bool) -> bool:
         _ok(f"Skipping EO ingest — GFW response truncated ({exc}), will retry on next run")
         return True
     except Exception as exc:
-        # Treat network timeouts / disconnects as a soft skip so the pipeline continues.
         exc_str = str(exc)
         _TRANSIENT = (
             "timed out",

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1539,6 +1539,7 @@ def cmd_push_ducklake_private(args: argparse.Namespace) -> int:
 
 
 _AIS_DBS_R2_PREFIX = "ais-dbs/"  # private bucket sub-prefix for raw AIS DB backups
+_GFW_EO_R2_PREFIX = "gfw-eo/"  # private bucket sub-prefix for pre-fetched GFW EO parquets
 _AIS_DB_MIN_SIZE_BYTES = 1_048_576  # skip placeholder DBs smaller than 1 MB
 
 
@@ -1570,6 +1571,78 @@ def _ais_db_candidates(data_dir: Path, regions: list[str] | None) -> list[Path]:
             continue
         candidates.append(p)
     return candidates
+
+
+def cmd_push_gfw_eo(args: argparse.Namespace) -> int:
+    """Upload pre-fetched GFW EO detection parquets to arktrace-private-capvista/gfw-eo/.
+
+    Each file must be named ``{region_prefix}_eo_detections.parquet`` and live
+    in --data-dir.  Run ``scripts/gfw_ingest.py`` first to generate them.
+    """
+    data_dir = Path(args.data_dir)
+    parquets = sorted(data_dir.glob("*_eo_detections.parquet"))
+    if not parquets:
+        print(
+            f"No *_eo_detections.parquet files found in {data_dir}. "
+            "Run scripts/gfw_ingest.py first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    fs = _build_r2_fs()
+    prefix = f"{_PRIVATE_BUCKET}/{_GFW_EO_R2_PREFIX}"
+    print(f"Uploading {len(parquets)} GFW EO parquet(s) to {prefix}")
+    for p in parquets:
+        r2_path = f"{prefix}{p.name}"
+        size_kb = p.stat().st_size / 1024
+        print(f"  {p.name} ({size_kb:.1f} KB) → {r2_path} ...", end="", flush=True)
+        _upload_file(fs, p, r2_path)
+        print(" ✓")
+    print(f"\nDone. GFW EO parquets pushed to {prefix}")
+    return 0
+
+
+def cmd_pull_gfw_eo(args: argparse.Namespace) -> int:
+    """Download pre-fetched GFW EO detection parquets from arktrace-private-capvista/gfw-eo/.
+
+    Files are written to --data-dir as ``{region_prefix}_eo_detections.parquet``.
+    The daily pipeline ingests these instead of calling the GFW API directly.
+    """
+    if not (os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY")):
+        print(
+            "Error: AWS credentials not set — pull-gfw-eo requires private bucket access.",
+            file=sys.stderr,
+        )
+        return 1
+
+    import pyarrow.fs as pafs
+
+    data_dir = Path(args.data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    fs = _build_r2_fs()
+    prefix = f"{_PRIVATE_BUCKET}/{_GFW_EO_R2_PREFIX}"
+
+    try:
+        infos = fs.get_file_info(pafs.FileSelector(prefix, recursive=False))
+    except Exception as exc:
+        print(f"Error listing {prefix}: {exc}", file=sys.stderr)
+        return 1
+
+    parquets = [i for i in infos if i.type == pafs.FileType.File and i.path.endswith(".parquet")]
+    if not parquets:
+        print(f"No GFW EO parquets found at {prefix} — run gfw-ingest workflow first.")
+        return 0
+
+    print(f"Found {len(parquets)} GFW EO parquet(s) in {prefix}")
+    for info in parquets:
+        filename = Path(info.path).name
+        local_path = data_dir / filename
+        size_kb = info.size / 1024
+        print(f"  {filename} ({size_kb:.1f} KB) ...", end="", flush=True)
+        _download_file(fs, info.path, local_path)
+        print(f" ✓ ({size_kb:.1f} KB)")
+    print(f"\nDone. GFW EO parquets restored to {data_dir}/")
+    return 0
 
 
 def cmd_push_ais_dbs(args: argparse.Namespace) -> int:
@@ -2049,6 +2122,18 @@ def main() -> int:
         help="Overwrite local file even if it is newer than the remote copy",
     )
 
+    push_gfw_eo_p = sub.add_parser(
+        "push-gfw-eo",
+        help="Upload *_eo_detections.parquet files to arktrace-private-capvista/gfw-eo/",
+    )
+    push_gfw_eo_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
+
+    pull_gfw_eo_p = sub.add_parser(
+        "pull-gfw-eo",
+        help="Download GFW EO parquets from arktrace-private-capvista/gfw-eo/ into data-dir",
+    )
+    pull_gfw_eo_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
+
     sub.add_parser("list", help="List snapshot zips and shared objects in R2")
 
     args = parser.parse_args()
@@ -2068,6 +2153,7 @@ def main() -> int:
         "pull-reviews",
         "pull-custom-feeds",
         "pull-ais-dbs",
+        "pull-gfw-eo",
         "list",
     )
     if not _check_env(require_credentials=not read_only):
@@ -2093,6 +2179,8 @@ def main() -> int:
         "push-ducklake-private": cmd_push_ducklake_private,
         "push-ais-dbs": cmd_push_ais_dbs,
         "pull-ais-dbs": cmd_pull_ais_dbs,
+        "push-gfw-eo": cmd_push_gfw_eo,
+        "pull-gfw-eo": cmd_pull_gfw_eo,
         "list": cmd_list,
     }
     return dispatch[args.command](args)

--- a/tests/test_gfw_eo_ingest.py
+++ b/tests/test_gfw_eo_ingest.py
@@ -1,0 +1,280 @@
+"""Tests for the GFW EO weekly ingest feature (#480).
+
+Covers:
+- sync_r2.cmd_push_gfw_eo / cmd_pull_gfw_eo
+- scripts/gfw_ingest.py main()
+- run_pipeline.step_eo_ingest parquet-first path
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import polars as pl
+
+import scripts.sync_r2 as sync_r2
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_eo_parquet(path: Path, n_rows: int = 5) -> None:
+    """Write a minimal *_eo_detections.parquet at the given path."""
+    df = pl.DataFrame(
+        {
+            "detection_id": [f"id-{i}" for i in range(n_rows)],
+            "detected_at": [datetime(2026, 1, 1, tzinfo=UTC)] * n_rows,
+            "lat": [1.0 + i * 0.1 for i in range(n_rows)],
+            "lon": [103.0 + i * 0.1 for i in range(n_rows)],
+            "source": ["gfw"] * n_rows,
+            "confidence": [0.9] * n_rows,
+            "fetched_at": ["2026-01-01T00:00:00+00:00"] * n_rows,
+        }
+    )
+    df.write_parquet(path)
+
+
+# ---------------------------------------------------------------------------
+# cmd_push_gfw_eo
+# ---------------------------------------------------------------------------
+
+
+def test_push_gfw_eo_returns_1_when_no_parquets(tmp_path):
+    """Returns 1 when no *_eo_detections.parquet files are found."""
+    args = argparse.Namespace(data_dir=str(tmp_path))
+    result = sync_r2.cmd_push_gfw_eo(args)
+    assert result == 1
+
+
+def test_push_gfw_eo_uploads_all_parquets(tmp_path):
+    """Calls _upload_file once per parquet found."""
+    for name in ("singapore_eo_detections.parquet", "japansea_eo_detections.parquet"):
+        _make_eo_parquet(tmp_path / name)
+
+    mock_fs = MagicMock()
+    args = argparse.Namespace(data_dir=str(tmp_path))
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_upload_file") as mock_upload:
+            result = sync_r2.cmd_push_gfw_eo(args)
+
+    assert result == 0
+    assert mock_upload.call_count == 2
+    uploaded_names = {Path(c.args[1]).name for c in mock_upload.call_args_list}
+    assert uploaded_names == {
+        "singapore_eo_detections.parquet",
+        "japansea_eo_detections.parquet",
+    }
+
+
+def test_push_gfw_eo_r2_path_uses_private_bucket(tmp_path):
+    """Uploaded paths are under arktrace-private-capvista/gfw-eo/."""
+    _make_eo_parquet(tmp_path / "singapore_eo_detections.parquet")
+
+    mock_fs = MagicMock()
+    args = argparse.Namespace(data_dir=str(tmp_path))
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_upload_file") as mock_upload:
+            sync_r2.cmd_push_gfw_eo(args)
+
+    r2_path = mock_upload.call_args.args[2]
+    assert r2_path == f"{sync_r2._PRIVATE_BUCKET}/gfw-eo/singapore_eo_detections.parquet"
+
+
+# ---------------------------------------------------------------------------
+# cmd_pull_gfw_eo
+# ---------------------------------------------------------------------------
+
+
+def test_pull_gfw_eo_returns_1_without_credentials(tmp_path, monkeypatch):
+    """Returns 1 when AWS credentials are absent."""
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    args = argparse.Namespace(data_dir=str(tmp_path))
+    result = sync_r2.cmd_pull_gfw_eo(args)
+    assert result == 1
+
+
+def test_pull_gfw_eo_returns_0_when_bucket_empty(tmp_path, monkeypatch):
+    """Returns 0 gracefully when no parquets exist in R2."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+
+    mock_fs = MagicMock()
+    mock_fs.get_file_info.return_value = []
+
+    args = argparse.Namespace(data_dir=str(tmp_path))
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        result = sync_r2.cmd_pull_gfw_eo(args)
+
+    assert result == 0
+
+
+def test_pull_gfw_eo_downloads_parquets(tmp_path, monkeypatch):
+    """Downloads each parquet from R2 into data_dir."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+
+    import pyarrow.fs as pafs
+
+    mock_info = MagicMock()
+    mock_info.type = pafs.FileType.File
+    mock_info.path = f"{sync_r2._PRIVATE_BUCKET}/gfw-eo/singapore_eo_detections.parquet"
+    mock_info.size = 1024
+
+    mock_fs = MagicMock()
+    mock_fs.get_file_info.return_value = [mock_info]
+
+    args = argparse.Namespace(data_dir=str(tmp_path))
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_download_file") as mock_dl:
+            result = sync_r2.cmd_pull_gfw_eo(args)
+
+    assert result == 0
+    mock_dl.assert_called_once()
+    local_path = mock_dl.call_args.args[2]
+    assert local_path == tmp_path / "singapore_eo_detections.parquet"
+
+
+# ---------------------------------------------------------------------------
+# gfw_ingest.main()
+# ---------------------------------------------------------------------------
+
+
+def test_gfw_ingest_returns_1_without_token(monkeypatch):
+    """Exits with 1 when no GFW token is configured."""
+    monkeypatch.delenv("GFW_API_TOKEN", raising=False)
+    for i in range(1, 4):
+        monkeypatch.delenv(f"GFW_API_TOKEN_{i}", raising=False)
+
+    import scripts.gfw_ingest as gfw_ingest
+
+    with patch("sys.argv", ["gfw_ingest.py"]):
+        result = gfw_ingest.main()
+    assert result == 1
+
+
+def test_gfw_ingest_writes_parquet_per_region(tmp_path, monkeypatch):
+    """Writes one parquet per region on success."""
+    monkeypatch.setenv("GFW_API_TOKEN", "test-token")
+
+    import scripts.gfw_ingest as gfw_ingest
+
+    fake_records = [
+        {
+            "detection_id": "abc",
+            "detected_at": datetime(2026, 1, 1, tzinfo=UTC),
+            "lat": 1.0,
+            "lon": 103.0,
+            "source": "gfw",
+            "confidence": 0.9,
+        }
+    ]
+
+    with patch(
+        "sys.argv", ["gfw_ingest.py", "--regions", "singapore,japan", "--out-dir", str(tmp_path)]
+    ):
+        with patch("pipeline.src.ingest.eo_gfw.fetch_gfw_detections", return_value=fake_records):
+            result = gfw_ingest.main()
+
+    assert result == 0
+    assert (tmp_path / "singapore_eo_detections.parquet").exists()
+    assert (tmp_path / "japansea_eo_detections.parquet").exists()
+
+
+def test_gfw_ingest_skips_failed_region(tmp_path, monkeypatch):
+    """Skips a region that raises PermissionError and returns 1."""
+    monkeypatch.setenv("GFW_API_TOKEN", "test-token")
+
+    import scripts.gfw_ingest as gfw_ingest
+
+    with patch("sys.argv", ["gfw_ingest.py", "--regions", "singapore", "--out-dir", str(tmp_path)]):
+        with patch(
+            "pipeline.src.ingest.eo_gfw.fetch_gfw_detections", side_effect=PermissionError("429")
+        ):
+            result = gfw_ingest.main()
+
+    assert result == 1
+    assert not (tmp_path / "singapore_eo_detections.parquet").exists()
+
+
+# ---------------------------------------------------------------------------
+# step_eo_ingest — parquet-first path
+# ---------------------------------------------------------------------------
+
+
+def test_step_eo_ingest_prefers_parquet_over_api(tmp_path, monkeypatch):
+    """step_eo_ingest ingests from parquet without calling the GFW API."""
+    monkeypatch.setenv("ARKTRACE_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("GFW_API_TOKEN", raising=False)
+
+    parquet_path = tmp_path / "singapore_eo_detections.parquet"
+    _make_eo_parquet(parquet_path, n_rows=3)
+
+    # Create a minimal DuckDB so ingest_eo_records doesn't fail
+    import duckdb
+
+    db_path = str(tmp_path / "singapore.duckdb")
+    con = duckdb.connect(db_path)
+    con.execute(
+        """
+        CREATE TABLE eo_detections (
+            detection_id VARCHAR PRIMARY KEY,
+            detected_at TIMESTAMPTZ,
+            lat DOUBLE,
+            lon DOUBLE,
+            source VARCHAR,
+            confidence FLOAT
+        )
+        """
+    )
+    con.close()
+
+    from scripts.run_pipeline import PRESETS, step_eo_ingest
+
+    preset = PRESETS["singapore"]
+    preset_copy = type(preset)(
+        name=preset.name,
+        label=preset.label,
+        bbox=preset.bbox,
+        gap_threshold_h=preset.gap_threshold_h,
+        window_days=preset.window_days,
+        w_anomaly=preset.w_anomaly,
+        w_graph=preset.w_graph,
+        w_identity=preset.w_identity,
+        db_path=db_path,
+        watchlist_path=preset.watchlist_path,
+    )
+
+    with patch("pipeline.src.ingest.eo_gfw.fetch_gfw_detections") as mock_api:
+        result = step_eo_ingest(preset_copy, non_interactive=True)
+
+    assert result is True
+    mock_api.assert_not_called()
+
+    con = duckdb.connect(db_path, read_only=True)
+    count = con.execute("SELECT COUNT(*) FROM eo_detections").fetchone()[0]
+    con.close()
+    assert count == 3
+
+
+def test_step_eo_ingest_falls_back_to_api_when_no_parquet(tmp_path, monkeypatch):
+    """step_eo_ingest calls GFW API when no parquet exists."""
+    monkeypatch.setenv("ARKTRACE_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("GFW_API_TOKEN", "test-token")
+
+    from scripts.run_pipeline import PRESETS, step_eo_ingest
+
+    preset = PRESETS["singapore"]
+
+    with patch("pipeline.src.ingest.eo_gfw.fetch_gfw_detections", return_value=[]) as mock_api:
+        with patch("pipeline.src.ingest.eo_gfw.ingest_eo_records", return_value=0):
+            result = step_eo_ingest(preset, non_interactive=True)
+
+    assert result is True
+    mock_api.assert_called_once()


### PR DESCRIPTION
## Summary

GFW data has **monthly temporal resolution** — fetching it on every daily pipeline run caused 429 rate limits, 180s timeouts per region, and made the daily metrics email fragile on GFW outages.

## Changes

| File | Change |
|---|---|
| `scripts/gfw_ingest.py` | New script: fetches GFW EO detections for all active regions, writes `{prefix}_eo_detections.parquet` |
| `scripts/sync_r2.py` | New `push-gfw-eo` / `pull-gfw-eo` subcommands under `arktrace-private-capvista/gfw-eo/` |
| `scripts/run_pipeline.py` | `step_eo_ingest` prefers pre-fetched parquet over live API call; API is fallback only |
| `.github/workflows/gfw-ingest.yml` | New weekly workflow (Monday 00:00 UTC) — fetch all 5 regions + push to R2 |
| `.github/workflows/data-publish.yml` | Adds `pull-gfw-eo` step; removes `GFW_API_TOKEN_*` from pipeline steps |

## Flow after this PR

```
Weekly (Monday 00:00 UTC):
  gfw-ingest.yml → gfw_ingest.py → push-gfw-eo → R2

Daily (01:00 UTC):
  data-publish.yml → pull-gfw-eo ← R2 → step_eo_ingest reads parquet
```

## Test plan

- [ ] Trigger `gfw-ingest.yml` manually, verify parquets appear in `arktrace-private-capvista/gfw-eo/`
- [ ] Trigger `data-publish.yml`, verify pipeline logs show "ingested from pre-fetched parquet"
- [ ] No GFW 429 errors in data-publish logs
- [ ] 11 existing GFW tests still pass

Closes #480