### PR TITLE
fix: skip GFW API fallback in CI EO ingest step

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -592,7 +592,13 @@ def step_eo_ingest(p: RegionPreset, non_interactive: bool) -> bool:
         except Exception as exc:
             _ok(f"Parquet ingest failed ({exc}); falling back to GFW API")
 
-    # --- fall back to live API ---
+    # --- fall back to live API (interactive / local only) ---
+    # In non-interactive (CI) mode the GFW API is called by the dedicated
+    # gfw-ingest.yml workflow; data-publish pulls the resulting parquet above.
+    if non_interactive:
+        _ok("No pre-fetched EO parquet found — skipping (gfw-ingest.yml populates this weekly)")
+        return True
+
     tokens = [t for t in [os.getenv("GFW_API_TOKEN", "")] if t]
     tokens += [v for k, v in sorted(os.environ.items()) if k.startswith("GFW_API_TOKEN_") and v]
     if not tokens:


### PR DESCRIPTION
## Problem

In `data-publish` runs, pipeline step 6/11 prints:

```
✓  GFW_API_TOKEN not set — skipping EO ingest (set token to enable)
```

This is misleading — the GFW API should never be called in `data-publish`. That job is handled exclusively by `gfw-ingest.yml` (weekly), which pushes pre-fetched parquets to R2. `data-publish` pulls those parquets via `pull-gfw-eo` before the pipeline runs.

The fallback to a live API call in `step_eo_ingest` was firing because no parquet was present yet (the weekly job hadn't run), leaking GFW API logic into a workflow that's intentionally decoupled from it.

## Fix

When `non_interactive=True` (i.e. CI / data-publish), `step_eo_ingest` now skips immediately after the parquet check with a clear message:

```
✓  No pre-fetched EO parquet found — skipping (gfw-ingest.yml populates this weekly)
```

The live GFW API fallback is only reached in interactive / local runs.

Closes https://github.com/edgesentry/arktrace/actions/runs/24837562617/job/72702123732