### PR TITLE
feat: Export PDF button on dispatch brief modal (#438)

### DIFF
--- a/app/src/components/DispatchModal.test.ts
+++ b/app/src/components/DispatchModal.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../lib/reviews", () => ({
+  getReview: vi.fn(),
+  tierColor: vi.fn(),
+  handoffLabel: vi.fn((s: string) => s),
+}));
+vi.mock("../lib/humanise", () => ({
+  formatLastSeen: vi.fn((v: string | null) => v ?? "—"),
+  confidenceTier: vi.fn((c: number) => (c >= 0.75 ? "CRITICAL" : c >= 0.5 ? "ELEVATED" : "WATCH")),
+  confidenceTierColor: vi.fn(() => "#fc8181"),
+  signalLabel: vi.fn((f: string) => f),
+  signalSeverity: vi.fn(() => "HIGH"),
+  severityColor: vi.fn(() => "#fc8181"),
+}));
+
+import {
+  parseSignals,
+  buildPdfFilename,
+  buildExportPayload,
+  buildCopyMarkdown,
+  type ShapSignal,
+} from "./DispatchModal";
+import type { VesselRow } from "../lib/duckdb";
+import type { VesselReview } from "../lib/reviews";
+
+const BASE_VESSEL: VesselRow = {
+  mmsi: "123456789",
+  imo: "9305609",
+  vessel_name: "TEST VESSEL",
+  flag: "PA",
+  vessel_type: "Tanker",
+  region: "singapore",
+  last_seen: "2026-04-24T08:00:00Z",
+  last_lat: 1.3521,
+  last_lon: 103.8198,
+  confidence: 0.87,
+  top_signals: null,
+};
+
+const SIGNALS: ShapSignal[] = [
+  { feature: "ais_gap_count_30d", value: 4, contribution: 0.42 },
+  { feature: "high_risk_flag_ratio", value: 0.8, contribution: 0.31 },
+];
+
+const REVIEW: VesselReview = {
+  mmsi: "123456789",
+  decision_tier: "Confirmed",
+  handoff_state: "handoff_recommended",
+  reviewer_id: "analyst_01",
+  rationale: "Multiple AIS gaps near known STS zone.",
+  identifier_basis: "MMSI",
+  outcome: null,
+  outcome_notes: null,
+  officer_id: null,
+  created_at: "2026-04-24T07:00:00Z",
+  updated_at: "2026-04-24T08:00:00Z",
+};
+
+const FIXED_DATE = new Date("2026-04-24T09:00:00Z");
+
+// ── parseSignals ─────────────────────────────────────────────────────────────
+
+describe("parseSignals", () => {
+  it("returns empty array for null input", () => {
+    expect(parseSignals(null)).toEqual([]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseSignals("")).toEqual([]);
+  });
+
+  it("returns empty array for invalid JSON", () => {
+    expect(parseSignals("{bad json")).toEqual([]);
+  });
+
+  it("returns empty array when JSON is not an array", () => {
+    expect(parseSignals('{"feature":"x"}')).toEqual([]);
+  });
+
+  it("parses a valid signals array", () => {
+    const raw = JSON.stringify(SIGNALS);
+    expect(parseSignals(raw)).toEqual(SIGNALS);
+  });
+});
+
+// ── buildPdfFilename ─────────────────────────────────────────────────────────
+
+describe("buildPdfFilename", () => {
+  it("produces correct format", () => {
+    expect(buildPdfFilename("123456789", FIXED_DATE)).toBe("dispatch_brief_123456789_2026-04-24");
+  });
+
+  it("uses today's date when no date supplied", () => {
+    const result = buildPdfFilename("999000001");
+    expect(result).toMatch(/^dispatch_brief_999000001_\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("uses the MMSI verbatim", () => {
+    expect(buildPdfFilename("000000001", FIXED_DATE)).toContain("000000001");
+  });
+});
+
+// ── buildExportPayload ───────────────────────────────────────────────────────
+
+describe("buildExportPayload", () => {
+  it("includes core vessel fields", () => {
+    const p = buildExportPayload(BASE_VESSEL, SIGNALS, "brief text", null, FIXED_DATE);
+    expect(p.mmsi).toBe("123456789");
+    expect(p.imo).toBe("9305609");
+    expect(p.vessel_name).toBe("TEST VESSEL");
+    expect(p.flag).toBe("PA");
+    expect(p.confidence).toBe(0.87);
+  });
+
+  it("sets exported_at from the supplied date", () => {
+    const p = buildExportPayload(BASE_VESSEL, SIGNALS, "", null, FIXED_DATE);
+    expect(p.exported_at).toBe("2026-04-24T09:00:00.000Z");
+  });
+
+  it("includes analyst_brief when provided", () => {
+    const p = buildExportPayload(BASE_VESSEL, SIGNALS, "summary here", null, FIXED_DATE);
+    expect(p.analyst_brief).toBe("summary here");
+  });
+
+  it("sets analyst_brief to null for empty string", () => {
+    const p = buildExportPayload(BASE_VESSEL, SIGNALS, "", null, FIXED_DATE);
+    expect(p.analyst_brief).toBeNull();
+  });
+
+  it("maps signals with feature, label, value, contribution", () => {
+    const p = buildExportPayload(BASE_VESSEL, SIGNALS, "", null, FIXED_DATE);
+    expect(p.top_signals).toHaveLength(2);
+    expect(p.top_signals[0].feature).toBe("ais_gap_count_30d");
+    expect(p.top_signals[0].contribution).toBe(0.42);
+  });
+
+  it("sets review to null when not provided", () => {
+    const p = buildExportPayload(BASE_VESSEL, [], "", null, FIXED_DATE);
+    expect(p.review).toBeNull();
+  });
+
+  it("includes review fields when provided", () => {
+    const p = buildExportPayload(BASE_VESSEL, [], "", REVIEW, FIXED_DATE);
+    expect(p.review).not.toBeNull();
+    expect(p.review!.decision_tier).toBe("Confirmed");
+    expect(p.review!.handoff_state).toBe("handoff_recommended");
+    expect(p.review!.reviewer_id).toBe("analyst_01");
+    expect(p.review!.rationale).toBe("Multiple AIS gaps near known STS zone.");
+  });
+
+  it("sets lat/lon to null when absent", () => {
+    const p = buildExportPayload({ ...BASE_VESSEL, last_lat: null, last_lon: null }, [], "", null, FIXED_DATE);
+    expect(p.last_lat).toBeNull();
+    expect(p.last_lon).toBeNull();
+  });
+});
+
+// ── buildCopyMarkdown ────────────────────────────────────────────────────────
+
+describe("buildCopyMarkdown", () => {
+  it("starts with the patrol dispatch heading", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "", null, FIXED_DATE);
+    expect(md).toMatch(/^# Patrol Dispatch Brief/);
+  });
+
+  it("includes MMSI and vessel name", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "", null, FIXED_DATE);
+    expect(md).toContain("**MMSI:** 123456789");
+    expect(md).toContain("**Vessel:** TEST VESSEL");
+  });
+
+  it("includes IMO when present", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "", null, FIXED_DATE);
+    expect(md).toContain("**IMO:** 9305609");
+  });
+
+  it("omits IMO line when null", () => {
+    const md = buildCopyMarkdown({ ...BASE_VESSEL, imo: null }, [], "", null, FIXED_DATE);
+    expect(md).not.toContain("**IMO:**");
+  });
+
+  it("includes confidence score and tier", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "", null, FIXED_DATE);
+    expect(md).toContain("0.870");
+    expect(md).toContain("CRITICAL");
+  });
+
+  it("includes position when lat/lon present", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "", null, FIXED_DATE);
+    expect(md).toContain("**Position:**");
+    expect(md).toContain("1.3521");
+  });
+
+  it("omits position when lat/lon null", () => {
+    const md = buildCopyMarkdown({ ...BASE_VESSEL, last_lat: null, last_lon: null }, [], "", null, FIXED_DATE);
+    expect(md).not.toContain("**Position:**");
+  });
+
+  it("includes top signals section when signals present", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, SIGNALS, "", null, FIXED_DATE);
+    expect(md).toContain("## Top signals");
+    expect(md).toContain("ais_gap_count_30d");
+    expect(md).toContain("42%");
+  });
+
+  it("omits signals section when empty", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "", null, FIXED_DATE);
+    expect(md).not.toContain("## Top signals");
+  });
+
+  it("includes analyst brief when provided", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "vessel is suspicious", null, FIXED_DATE);
+    expect(md).toContain("## Analyst brief");
+    expect(md).toContain("vessel is suspicious");
+  });
+
+  it("omits analyst brief section when empty", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "", null, FIXED_DATE);
+    expect(md).not.toContain("## Analyst brief");
+  });
+
+  it("includes review decision when provided", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "", REVIEW, FIXED_DATE);
+    expect(md).toContain("## Review decision");
+    expect(md).toContain("Confirmed");
+    expect(md).toContain("analyst_01");
+    expect(md).toContain("Multiple AIS gaps");
+  });
+
+  it("omits review section when null", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "", null, FIXED_DATE);
+    expect(md).not.toContain("## Review decision");
+  });
+
+  it("ends with a generation timestamp", () => {
+    const md = buildCopyMarkdown(BASE_VESSEL, [], "", null, FIXED_DATE);
+    expect(md).toContain("*Generated 2026-04-24T09:00:00.000Z*");
+  });
+
+  it("falls back to MMSI when vessel_name is empty", () => {
+    const md = buildCopyMarkdown({ ...BASE_VESSEL, vessel_name: "" }, [], "", null, FIXED_DATE);
+    expect(md).toContain("**Vessel:** 123456789");
+  });
+});

--- a/app/src/components/DispatchModal.test.ts
+++ b/app/src/components/DispatchModal.test.ts
@@ -20,7 +20,7 @@ import {
   buildExportPayload,
   buildCopyMarkdown,
   type ShapSignal,
-} from "./DispatchModal";
+} from "./dispatchBriefUtils";
 import type { VesselRow } from "../lib/duckdb";
 import type { VesselReview } from "../lib/reviews";
 

--- a/app/src/components/DispatchModal.tsx
+++ b/app/src/components/DispatchModal.tsx
@@ -58,6 +58,7 @@ export default function DispatchModal({ vessel, brief, conn, onClose }: Props) {
     style.id = "__dispatch-print-style";
     style.textContent = `
       @media print {
+        @page { margin: 18mm 16mm; }
         body > *:not(#dispatch-print-root) { display: none !important; }
         #dispatch-print-root {
           position: static !important;
@@ -67,17 +68,21 @@ export default function DispatchModal({ vessel, brief, conn, onClose }: Props) {
           background: white !important;
           border: none !important;
           box-shadow: none !important;
-          padding: 2rem !important;
-          font-family: system-ui, sans-serif !important;
-          color: black !important;
+          padding: 0 !important;
+          font-family: system-ui, -apple-system, sans-serif !important;
+          color: #111 !important;
+          print-color-adjust: exact;
+          -webkit-print-color-adjust: exact;
         }
         #dispatch-print-root * {
-          color: black !important;
-          background: transparent !important;
-          border-color: #ccc !important;
+          color: inherit !important;
+          print-color-adjust: exact;
+          -webkit-print-color-adjust: exact;
         }
+        #dispatch-print-header { display: block !important; }
         #dispatch-print-footer { display: none !important; }
       }
+      #dispatch-print-header { display: none; }
     `;
     document.head.appendChild(style);
     return () => {
@@ -222,6 +227,19 @@ export default function DispatchModal({ vessel, brief, conn, onClose }: Props) {
 
         {/* Body */}
         <div style={{ overflowY: "auto", padding: "0.85rem 1rem", flex: 1 }}>
+
+          {/* Print-only header — hidden on screen */}
+          <div id="dispatch-print-header" style={{ marginBottom: "1.2rem", paddingBottom: "0.75rem", borderBottom: "2px solid #111" }}>
+            <div style={{ fontSize: "0.65rem", textTransform: "uppercase", letterSpacing: "0.12em", color: "#555", marginBottom: "0.2rem" }}>
+              Arktrace · Dispatch Brief
+            </div>
+            <div style={{ fontSize: "1.1rem", fontWeight: 700, color: "#111" }}>
+              {vessel.vessel_name || vessel.mmsi}
+            </div>
+            <div style={{ fontSize: "0.72rem", color: "#555", marginTop: "0.2rem" }}>
+              MMSI {vessel.mmsi}{vessel.imo ? ` · IMO ${vessel.imo}` : ""} · Generated {new Date().toISOString().replace("T", " ").slice(0, 19)} UTC
+            </div>
+          </div>
 
           {/* Confidence */}
           <div style={{ marginBottom: "0.75rem" }}>
@@ -371,14 +389,15 @@ export default function DispatchModal({ vessel, brief, conn, onClose }: Props) {
           </button>
           <button
             onClick={() => {
+              const date = new Date().toISOString().slice(0, 10);
               const prev = document.title;
-              document.title = `Patrol Dispatch — ${vessel.vessel_name || vessel.mmsi} (${vessel.mmsi})`;
+              document.title = `dispatch_brief_${vessel.mmsi}_${date}`;
               window.print();
               document.title = prev;
             }}
             style={{ background: "none", border: "1px solid #2d3748", borderRadius: 4, color: "#718096", cursor: "pointer", fontSize: "0.72rem", fontWeight: 600, padding: "0.3rem 0.75rem" }}
           >
-            Print
+            Export PDF
           </button>
           <button onClick={onClose} style={{ marginLeft: "auto", background: "none", border: "1px solid #2d3748", borderRadius: 4, color: "#4a5568", cursor: "pointer", fontSize: "0.72rem", padding: "0.3rem 0.75rem" }}>
             Close

--- a/app/src/components/DispatchModal.tsx
+++ b/app/src/components/DispatchModal.tsx
@@ -13,13 +13,13 @@ import {
   severityColor,
 } from "../lib/humanise";
 
-interface ShapSignal {
+export interface ShapSignal {
   feature: string;
   value: number | string | null;
   contribution: number;
 }
 
-function parseSignals(raw: string | null | undefined): ShapSignal[] {
+export function parseSignals(raw: string | null | undefined): ShapSignal[] {
   if (!raw) return [];
   try {
     const parsed = JSON.parse(raw);
@@ -27,6 +27,96 @@ function parseSignals(raw: string | null | undefined): ShapSignal[] {
   } catch {
     return [];
   }
+}
+
+export function buildPdfFilename(mmsi: string, date?: Date): string {
+  const d = (date ?? new Date()).toISOString().slice(0, 10);
+  return `dispatch_brief_${mmsi}_${d}`;
+}
+
+export function buildExportPayload(
+  vessel: VesselRow,
+  signals: ShapSignal[],
+  brief: string,
+  review: import("../lib/reviews").VesselReview | null,
+  now?: Date,
+) {
+  return {
+    exported_at: (now ?? new Date()).toISOString(),
+    mmsi: vessel.mmsi,
+    imo: vessel.imo ?? null,
+    vessel_name: vessel.vessel_name || null,
+    flag: vessel.flag || null,
+    vessel_type: vessel.vessel_type || null,
+    confidence: vessel.confidence,
+    confidence_tier: confidenceTier(vessel.confidence),
+    region: vessel.region || null,
+    last_lat: vessel.last_lat ?? null,
+    last_lon: vessel.last_lon ?? null,
+    last_seen: vessel.last_seen ?? null,
+    top_signals: signals.map((s) => ({
+      feature: s.feature,
+      label: signalLabel(s.feature),
+      value: s.value,
+      severity: signalSeverity(s.feature, s.value),
+      contribution: s.contribution,
+    })),
+    analyst_brief: brief || null,
+    review: review ? {
+      decision_tier: review.decision_tier,
+      handoff_state: review.handoff_state,
+      reviewer_id: review.reviewer_id || null,
+      rationale: review.rationale || null,
+      updated_at: review.updated_at,
+    } : null,
+  };
+}
+
+export function buildCopyMarkdown(
+  vessel: VesselRow,
+  signals: ShapSignal[],
+  brief: string,
+  review: import("../lib/reviews").VesselReview | null,
+  now?: Date,
+): string {
+  const signalLines = signals
+    .map((s) => {
+      const sev = signalSeverity(s.feature, s.value);
+      return `- **${signalLabel(s.feature)}**: ${s.value ?? "—"}${sev ? ` [${sev}]` : ""} (${(s.contribution * 100).toFixed(0)}%)`;
+    })
+    .join("\n");
+
+  return [
+    `# Patrol Dispatch Brief`,
+    `**Vessel:** ${vessel.vessel_name || vessel.mmsi}`,
+    `**MMSI:** ${vessel.mmsi}`,
+    vessel.imo ? `**IMO:** ${vessel.imo}` : null,
+    `**Flag:** ${vessel.flag || "—"}`,
+    `**Type:** ${vessel.vessel_type || "—"}`,
+    `**Region:** ${vessel.region || "—"}`,
+    `**Last seen:** ${formatLastSeen(vessel.last_seen)}`,
+    vessel.last_lat != null && vessel.last_lon != null
+      ? `**Position:** ${vessel.last_lat.toFixed(4)}°, ${vessel.last_lon.toFixed(4)}°`
+      : null,
+    `**Anomaly confidence:** ${vessel.confidence.toFixed(3)} — ${confidenceTier(vessel.confidence)}`,
+    "",
+    signals.length ? `## Top signals\n${signalLines}` : null,
+    "",
+    brief ? `## Analyst brief\n${brief}` : null,
+    "",
+    review ? [
+      `## Review decision`,
+      review.decision_tier ? `**Tier:** ${review.decision_tier}` : null,
+      `**Status:** ${handoffLabel(review.handoff_state)}`,
+      review.reviewer_id ? `**Reviewer:** ${review.reviewer_id}` : null,
+      review.rationale ? `**Rationale:** ${review.rationale}` : null,
+    ].filter(Boolean).join("\n") : null,
+    "",
+    `---`,
+    `*Generated ${(now ?? new Date()).toISOString()}*`,
+  ]
+    .filter((l) => l !== null)
+    .join("\n");
 }
 
 interface Props {
@@ -93,35 +183,7 @@ export default function DispatchModal({ vessel, brief, conn, onClose }: Props) {
 
   // ── Export JSON ────────────────────────────────────────────────────────────
   function handleExport() {
-    const payload = {
-      exported_at: new Date().toISOString(),
-      mmsi: vessel.mmsi,
-      imo: vessel.imo ?? null,
-      vessel_name: vessel.vessel_name || null,
-      flag: vessel.flag || null,
-      vessel_type: vessel.vessel_type || null,
-      confidence: vessel.confidence,
-      confidence_tier: confidenceTier(vessel.confidence),
-      region: vessel.region || null,
-      last_lat: vessel.last_lat ?? null,
-      last_lon: vessel.last_lon ?? null,
-      last_seen: vessel.last_seen ?? null,
-      top_signals: signals.map((s) => ({
-        feature: s.feature,
-        label: signalLabel(s.feature),
-        value: s.value,
-        severity: signalSeverity(s.feature, s.value),
-        contribution: s.contribution,
-      })),
-      analyst_brief: brief || null,
-      review: review ? {
-        decision_tier: review.decision_tier,
-        handoff_state: review.handoff_state,
-        reviewer_id: review.reviewer_id || null,
-        rationale: review.rationale || null,
-        updated_at: review.updated_at,
-      } : null,
-    };
+    const payload = buildExportPayload(vessel, signals, brief, review);
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -133,44 +195,7 @@ export default function DispatchModal({ vessel, brief, conn, onClose }: Props) {
 
   // ── Copy to clipboard ─────────────────────────────────────────────────────
   function handleCopy() {
-    const signalLines = signals
-      .map((s) => {
-        const sev = signalSeverity(s.feature, s.value);
-        return `- **${signalLabel(s.feature)}**: ${s.value ?? "—"}${sev ? ` [${sev}]` : ""} (${(s.contribution * 100).toFixed(0)}%)`;
-      })
-      .join("\n");
-
-    const md = [
-      `# Patrol Dispatch Brief`,
-      `**Vessel:** ${vessel.vessel_name || vessel.mmsi}`,
-      `**MMSI:** ${vessel.mmsi}`,
-      vessel.imo ? `**IMO:** ${vessel.imo}` : null,
-      `**Flag:** ${vessel.flag || "—"}`,
-      `**Type:** ${vessel.vessel_type || "—"}`,
-      `**Region:** ${vessel.region || "—"}`,
-      `**Last seen:** ${formatLastSeen(vessel.last_seen)}`,
-      vessel.last_lat != null && vessel.last_lon != null
-        ? `**Position:** ${vessel.last_lat.toFixed(4)}°, ${vessel.last_lon.toFixed(4)}°`
-        : null,
-      `**Anomaly confidence:** ${vessel.confidence.toFixed(3)} — ${confidenceTier(vessel.confidence)}`,
-      "",
-      signals.length ? `## Top signals\n${signalLines}` : null,
-      "",
-      brief ? `## Analyst brief\n${brief}` : null,
-      "",
-      review ? [
-        `## Review decision`,
-        review.decision_tier ? `**Tier:** ${review.decision_tier}` : null,
-        `**Status:** ${handoffLabel(review.handoff_state)}`,
-        review.reviewer_id ? `**Reviewer:** ${review.reviewer_id}` : null,
-        review.rationale ? `**Rationale:** ${review.rationale}` : null,
-      ].filter(Boolean).join("\n") : null,
-      "",
-      `---`,
-      `*Generated ${new Date().toISOString()}*`,
-    ]
-      .filter((l) => l !== null)
-      .join("\n");
+    const md = buildCopyMarkdown(vessel, signals, brief, review);
 
     navigator.clipboard.writeText(md).catch(() => {/* ignore */});
   }

--- a/app/src/components/DispatchModal.tsx
+++ b/app/src/components/DispatchModal.tsx
@@ -4,120 +4,8 @@ import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import type { VesselRow } from "../lib/duckdb";
 import { getReview, tierColor, handoffLabel } from "../lib/reviews";
 import type { VesselReview } from "../lib/reviews";
-import {
-  formatLastSeen,
-  confidenceTier,
-  confidenceTierColor,
-  signalLabel,
-  signalSeverity,
-  severityColor,
-} from "../lib/humanise";
-
-export interface ShapSignal {
-  feature: string;
-  value: number | string | null;
-  contribution: number;
-}
-
-export function parseSignals(raw: string | null | undefined): ShapSignal[] {
-  if (!raw) return [];
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as ShapSignal[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-export function buildPdfFilename(mmsi: string, date?: Date): string {
-  const d = (date ?? new Date()).toISOString().slice(0, 10);
-  return `dispatch_brief_${mmsi}_${d}`;
-}
-
-export function buildExportPayload(
-  vessel: VesselRow,
-  signals: ShapSignal[],
-  brief: string,
-  review: import("../lib/reviews").VesselReview | null,
-  now?: Date,
-) {
-  return {
-    exported_at: (now ?? new Date()).toISOString(),
-    mmsi: vessel.mmsi,
-    imo: vessel.imo ?? null,
-    vessel_name: vessel.vessel_name || null,
-    flag: vessel.flag || null,
-    vessel_type: vessel.vessel_type || null,
-    confidence: vessel.confidence,
-    confidence_tier: confidenceTier(vessel.confidence),
-    region: vessel.region || null,
-    last_lat: vessel.last_lat ?? null,
-    last_lon: vessel.last_lon ?? null,
-    last_seen: vessel.last_seen ?? null,
-    top_signals: signals.map((s) => ({
-      feature: s.feature,
-      label: signalLabel(s.feature),
-      value: s.value,
-      severity: signalSeverity(s.feature, s.value),
-      contribution: s.contribution,
-    })),
-    analyst_brief: brief || null,
-    review: review ? {
-      decision_tier: review.decision_tier,
-      handoff_state: review.handoff_state,
-      reviewer_id: review.reviewer_id || null,
-      rationale: review.rationale || null,
-      updated_at: review.updated_at,
-    } : null,
-  };
-}
-
-export function buildCopyMarkdown(
-  vessel: VesselRow,
-  signals: ShapSignal[],
-  brief: string,
-  review: import("../lib/reviews").VesselReview | null,
-  now?: Date,
-): string {
-  const signalLines = signals
-    .map((s) => {
-      const sev = signalSeverity(s.feature, s.value);
-      return `- **${signalLabel(s.feature)}**: ${s.value ?? "—"}${sev ? ` [${sev}]` : ""} (${(s.contribution * 100).toFixed(0)}%)`;
-    })
-    .join("\n");
-
-  return [
-    `# Patrol Dispatch Brief`,
-    `**Vessel:** ${vessel.vessel_name || vessel.mmsi}`,
-    `**MMSI:** ${vessel.mmsi}`,
-    vessel.imo ? `**IMO:** ${vessel.imo}` : null,
-    `**Flag:** ${vessel.flag || "—"}`,
-    `**Type:** ${vessel.vessel_type || "—"}`,
-    `**Region:** ${vessel.region || "—"}`,
-    `**Last seen:** ${formatLastSeen(vessel.last_seen)}`,
-    vessel.last_lat != null && vessel.last_lon != null
-      ? `**Position:** ${vessel.last_lat.toFixed(4)}°, ${vessel.last_lon.toFixed(4)}°`
-      : null,
-    `**Anomaly confidence:** ${vessel.confidence.toFixed(3)} — ${confidenceTier(vessel.confidence)}`,
-    "",
-    signals.length ? `## Top signals\n${signalLines}` : null,
-    "",
-    brief ? `## Analyst brief\n${brief}` : null,
-    "",
-    review ? [
-      `## Review decision`,
-      review.decision_tier ? `**Tier:** ${review.decision_tier}` : null,
-      `**Status:** ${handoffLabel(review.handoff_state)}`,
-      review.reviewer_id ? `**Reviewer:** ${review.reviewer_id}` : null,
-      review.rationale ? `**Rationale:** ${review.rationale}` : null,
-    ].filter(Boolean).join("\n") : null,
-    "",
-    `---`,
-    `*Generated ${(now ?? new Date()).toISOString()}*`,
-  ]
-    .filter((l) => l !== null)
-    .join("\n");
-}
+import { confidenceTier, confidenceTierColor, formatLastSeen, signalLabel, signalSeverity, severityColor } from "../lib/humanise";
+import { parseSignals, buildExportPayload, buildCopyMarkdown, buildPdfFilename } from "./dispatchBriefUtils";
 
 interface Props {
   vessel: VesselRow;
@@ -414,9 +302,8 @@ export default function DispatchModal({ vessel, brief, conn, onClose }: Props) {
           </button>
           <button
             onClick={() => {
-              const date = new Date().toISOString().slice(0, 10);
               const prev = document.title;
-              document.title = `dispatch_brief_${vessel.mmsi}_${date}`;
+              document.title = buildPdfFilename(vessel.mmsi);
               window.print();
               document.title = prev;
             }}

--- a/app/src/components/dispatchBriefUtils.ts
+++ b/app/src/components/dispatchBriefUtils.ts
@@ -1,0 +1,110 @@
+import type { VesselRow } from "../lib/duckdb";
+import type { VesselReview } from "../lib/reviews";
+import { confidenceTier, formatLastSeen, signalLabel, signalSeverity } from "../lib/humanise";
+import { handoffLabel } from "../lib/reviews";
+
+export interface ShapSignal {
+  feature: string;
+  value: number | string | null;
+  contribution: number;
+}
+
+export function parseSignals(raw: string | null | undefined): ShapSignal[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as ShapSignal[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function buildPdfFilename(mmsi: string, date?: Date): string {
+  const d = (date ?? new Date()).toISOString().slice(0, 10);
+  return `dispatch_brief_${mmsi}_${d}`;
+}
+
+export function buildExportPayload(
+  vessel: VesselRow,
+  signals: ShapSignal[],
+  brief: string,
+  review: VesselReview | null,
+  now?: Date,
+) {
+  return {
+    exported_at: (now ?? new Date()).toISOString(),
+    mmsi: vessel.mmsi,
+    imo: vessel.imo ?? null,
+    vessel_name: vessel.vessel_name || null,
+    flag: vessel.flag || null,
+    vessel_type: vessel.vessel_type || null,
+    confidence: vessel.confidence,
+    confidence_tier: confidenceTier(vessel.confidence),
+    region: vessel.region || null,
+    last_lat: vessel.last_lat ?? null,
+    last_lon: vessel.last_lon ?? null,
+    last_seen: vessel.last_seen ?? null,
+    top_signals: signals.map((s) => ({
+      feature: s.feature,
+      label: signalLabel(s.feature),
+      value: s.value,
+      severity: signalSeverity(s.feature, s.value),
+      contribution: s.contribution,
+    })),
+    analyst_brief: brief || null,
+    review: review ? {
+      decision_tier: review.decision_tier,
+      handoff_state: review.handoff_state,
+      reviewer_id: review.reviewer_id || null,
+      rationale: review.rationale || null,
+      updated_at: review.updated_at,
+    } : null,
+  };
+}
+
+export function buildCopyMarkdown(
+  vessel: VesselRow,
+  signals: ShapSignal[],
+  brief: string,
+  review: VesselReview | null,
+  now?: Date,
+): string {
+  const signalLines = signals
+    .map((s) => {
+      const sev = signalSeverity(s.feature, s.value);
+      return `- **${signalLabel(s.feature)}**: ${s.value ?? "—"}${sev ? ` [${sev}]` : ""} (${(s.contribution * 100).toFixed(0)}%)`;
+    })
+    .join("\n");
+
+  return [
+    `# Patrol Dispatch Brief`,
+    `**Vessel:** ${vessel.vessel_name || vessel.mmsi}`,
+    `**MMSI:** ${vessel.mmsi}`,
+    vessel.imo ? `**IMO:** ${vessel.imo}` : null,
+    `**Flag:** ${vessel.flag || "—"}`,
+    `**Type:** ${vessel.vessel_type || "—"}`,
+    `**Region:** ${vessel.region || "—"}`,
+    `**Last seen:** ${formatLastSeen(vessel.last_seen)}`,
+    vessel.last_lat != null && vessel.last_lon != null
+      ? `**Position:** ${vessel.last_lat.toFixed(4)}°, ${vessel.last_lon.toFixed(4)}°`
+      : null,
+    `**Anomaly confidence:** ${vessel.confidence.toFixed(3)} — ${confidenceTier(vessel.confidence)}`,
+    "",
+    signals.length ? `## Top signals\n${signalLines}` : null,
+    "",
+    brief ? `## Analyst brief\n${brief}` : null,
+    "",
+    review ? [
+      `## Review decision`,
+      review.decision_tier ? `**Tier:** ${review.decision_tier}` : null,
+      `**Status:** ${handoffLabel(review.handoff_state)}`,
+      review.reviewer_id ? `**Reviewer:** ${review.reviewer_id}` : null,
+      review.rationale ? `**Rationale:** ${review.rationale}` : null,
+    ].filter(Boolean).join("\n") : null,
+    "",
+    `---`,
+    `*Generated ${(now ?? new Date()).toISOString()}*`,
+  ]
+    .filter((l) => l !== null)
+    .join("\n");
+}


### PR DESCRIPTION
## Summary

Adds a one-click **Export PDF** button to the dispatch brief modal, closes #438.

Uses `window.print()` (no JS library dependency) so it works in offline/air-gapped deployments.

## Changes — `DispatchModal.tsx`

**Export PDF button** (replaces "Print")
- Sets `document.title` to `dispatch_brief_{MMSI}_{YYYY-MM-DD}` before `window.print()` so the browser saves the file with the correct name, then restores the title.

**Print stylesheet improvements**
- `@page { margin: 18mm 16mm }` — proper page margins
- `print-color-adjust: exact` + `-webkit-print-color-adjust: exact` — preserves severity badge colours (red/orange/green) and confidence tier borders in the PDF
- Removed the blanket `color: black !important` override that was stripping all colour from badges

**Print-only header (`#dispatch-print-header`)**
- Hidden on screen (`display: none`), shown in print (`display: block`)
- Contains: "Arktrace · Dispatch Brief" label, vessel name, MMSI/IMO, and ISO UTC generation timestamp
- Separated from body content by a 2px rule — makes the PDF self-contained without a browser chrome header

## Acceptance criteria

- [x] Dispatch brief modal has an Export PDF button
- [x] Generated PDF contains: vessel identity, confidence score, SHAP top signals, ATT value + CI, ownership chain, plain-language brief, timestamp

Closes #438