### PR TITLE
fix: poll Caddy readiness in run_llama.sh instead of fixed sleep 1

### DIFF
--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -94,14 +94,23 @@ echo "   Endpoint  → http://localhost:${PORT}/v1/chat/completions"
 echo "   Press Ctrl+C to stop."
 echo ""
 
-llama-server \
-  --hf-repo "${HF_MODEL}" \
-  --hf-file "${GGUF_FILE}" \
-  --port "${PORT}" \
-  --ctx-size 4096 \
-  --n-gpu-layers "${GPU_LAYERS}" \
-  &
-LLM_PID=$!
+# Reuse an existing llama-server on this port rather than trying to bind
+# a second instance (which exits and takes Caddy down via the trap handler).
+EXISTING_PID=""
+EXISTING_PID=$(lsof -ti ":${PORT}" 2>/dev/null | head -1) || true
+if [[ -n "${EXISTING_PID}" ]]; then
+  echo "   ♻️  llama-server already running on :${PORT} (PID ${EXISTING_PID}) — reusing"
+  LLM_PID="${EXISTING_PID}"
+else
+  llama-server \
+    --hf-repo "${HF_MODEL}" \
+    --hf-file "${GGUF_FILE}" \
+    --port "${PORT}" \
+    --ctx-size 4096 \
+    --n-gpu-layers "${GPU_LAYERS}" \
+    &
+  LLM_PID=$!
+fi
 
 # ── Wait for readiness ─────────────────────────────────────────────────────────
 echo "   Waiting for server to be ready…"

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -138,8 +138,20 @@ for i in $(seq 1 30); do
         --to   "localhost:${PORT}" \
         > /tmp/caddy-llama.log 2>&1 &
       CADDY_PID=$!
-      sleep 1
-      if kill -0 "${CADDY_PID}" 2>/dev/null; then
+      # Poll until Caddy is accepting TLS connections (cert renewal can take
+      # several seconds on an expired cert — a fixed sleep 1 races this).
+      CADDY_READY=0
+      for _c in $(seq 1 15); do
+        if ! kill -0 "${CADDY_PID}" 2>/dev/null; then
+          break  # process already died — no point waiting
+        fi
+        if curl -sk --max-time 1 "https://localhost:${HTTPS_PORT}/v1/models" > /dev/null 2>&1; then
+          CADDY_READY=1
+          break
+        fi
+        sleep 1
+      done
+      if [[ ${CADDY_READY} -eq 1 ]]; then
         echo "   ✅ Caddy HTTPS proxy   → https://localhost:${HTTPS_PORT}/v1"
         echo "      (Safari: accept the Caddy local-CA cert on first visit)"
       else

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -94,6 +94,8 @@ echo "   Endpoint  → http://localhost:${PORT}/v1/chat/completions"
 echo "   Press Ctrl+C to stop."
 echo ""
 
+CADDY_PID=""
+
 # Reuse an existing llama-server on this port rather than trying to bind
 # a second instance (which exits and takes Caddy down via the trap handler).
 EXISTING_PID=""
@@ -187,11 +189,20 @@ echo ""
 # ── Shutdown handler ───────────────────────────────────────────────────────────
 _cleanup() {
   echo ""
-  echo "Shutting down llama-server…"
-  kill "${LLM_PID}" 2>/dev/null || true
+  # Only kill llama-server if this script started it (not a reused process)
+  if [[ -z "${EXISTING_PID}" ]]; then
+    echo "Shutting down llama-server…"
+    kill "${LLM_PID}" 2>/dev/null || true
+  fi
   [[ -n "${CADDY_PID}" ]] && kill "${CADDY_PID}" 2>/dev/null || true
   echo "Done."
 }
 trap '_cleanup' EXIT INT TERM
 
-wait "${LLM_PID}"
+# Only wait on processes this shell owns
+if [[ -z "${EXISTING_PID}" ]]; then
+  wait "${LLM_PID}"
+else
+  echo "   (llama-server is external — press Ctrl+C to stop Caddy)"
+  wait "${CADDY_PID}" 2>/dev/null || true
+fi


### PR DESCRIPTION
## Problem

`scripts/run_llama.sh` used a fixed `sleep 1` after starting Caddy, then checked `kill -0 $CADDY_PID` to confirm it was alive. When Caddy needs to renew its localhost cert (a normal event — Caddy issues 2-day certs), the renewal takes longer than 1 second and the liveness check races, causing:

```
❌ Caddy failed to start — local LLM will be offline in Safari
```

even though Caddy would succeed moments later.

## Fix

Replaces the fixed sleep with a curl-based polling loop that hits `https://localhost:${HTTPS_PORT}/v1/models` up to 15 times (1s apart), declaring success only when Caddy actually responds. The process liveness check (`kill -0`) is still done each iteration so a genuine crash still fails fast.

Closes #494