### PR TITLE
fix: reset dark backgrounds in dispatch brief PDF export

### DIFF
--- a/app/src/components/DispatchModal.tsx
+++ b/app/src/components/DispatchModal.tsx
@@ -53,7 +53,13 @@ export default function DispatchModal({ vessel, brief, conn, onClose }: Props) {
           -webkit-print-color-adjust: exact;
         }
         #dispatch-print-root * {
-          color: inherit !important;
+          color: #111 !important;
+          background: transparent !important;
+          print-color-adjust: exact;
+          -webkit-print-color-adjust: exact;
+        }
+        /* Re-apply coloured borders for severity badges and brief accent */
+        #dispatch-print-root [style*="border"] {
           print-color-adjust: exact;
           -webkit-print-color-adjust: exact;
         }


### PR DESCRIPTION
## Problem

The **Export PDF** button renders the confidence score badge and analyst brief section blacked out — dark `#1a1f2e` backgrounds are preserved by `print-color-adjust: exact` while light text colours (`#cbd5e0`, `#a0aec0`) become invisible against them.

## Fix

Add `background: transparent !important` to the `#dispatch-print-root *` print rule so all dark container backgrounds are stripped and content renders as black text on white paper. Coloured borders (severity badge outlines, analyst brief blue left stripe) survive because `print-color-adjust: exact` still applies to borders.

Closes #497