### PR TITLE
fix: resolve GFW token secrets in step env, not matrix values

### DIFF
--- a/.github/workflows/gfw-ingest.yml
+++ b/.github/workflows/gfw-ingest.yml
@@ -36,18 +36,20 @@ jobs:
     permissions:
       contents: read
     strategy:
+      # Secrets cannot be referenced in matrix values — use token_num (1/2/3)
+      # and resolve the actual secret in the step env block below.
       matrix:
         include:
           - region: singapore
-            gfw_api_token: ${{ secrets.GFW_API_TOKEN_1 }}
+            token_num: 1
           - region: japan
-            gfw_api_token: ${{ secrets.GFW_API_TOKEN_2 }}
+            token_num: 2
           - region: europe
-            gfw_api_token: ${{ secrets.GFW_API_TOKEN_3 }}
+            token_num: 3
           - region: blacksea
-            gfw_api_token: ${{ secrets.GFW_API_TOKEN_1 }}
+            token_num: 1
           - region: middleeast
-            gfw_api_token: ${{ secrets.GFW_API_TOKEN_2 }}
+            token_num: 2
       fail-fast: false
     env:
       ARKTRACE_DATA_DIR: data/processed
@@ -66,7 +68,7 @@ jobs:
 
       - name: Fetch GFW EO detections
         env:
-          GFW_API_TOKEN: ${{ matrix.gfw_api_token }}
+          GFW_API_TOKEN: ${{ matrix.token_num == 1 && secrets.GFW_API_TOKEN_1 || matrix.token_num == 2 && secrets.GFW_API_TOKEN_2 || secrets.GFW_API_TOKEN_3 }}
         run: |
           uv run python scripts/gfw_ingest.py \
             --regions ${{ matrix.region }} \


### PR DESCRIPTION
## Problem

https://github.com/edgesentry/arktrace/actions/runs/24872611551 failed immediately with:

> This run likely failed because of a workflow file issue.

`strategy.matrix` values are evaluated before the secrets context is available in GitHub Actions, so `${{ secrets.GFW_API_TOKEN_1 }}` in a matrix entry is invalid and causes a parse/validation error.

## Fix

Replaces the secret expressions in the matrix with a plain integer `token_num: 1/2/3`, then resolves the correct secret in the `Fetch GFW EO detections` step's `env` block using a conditional expression:

```yaml
GFW_API_TOKEN: ${{ matrix.token_num == 1 && secrets.GFW_API_TOKEN_1 || matrix.token_num == 2 && secrets.GFW_API_TOKEN_2 || secrets.GFW_API_TOKEN_3 }}
```

The `env` block is evaluated at job runtime where secrets are fully accessible.