### PR TITLE
chore(deps): bump serialize-javascript 7.0.3 → 7.0.5 (CVE-2026-34043)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7306,9 +7306,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "workbox-window": "^7.4.0"
   },
   "overrides": {
-    "serialize-javascript": "7.0.3"
+    "serialize-javascript": "7.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
Fixes Dependabot alert #3 (GHSA-qj8w-gfj5-8c6v / CVE-2026-34043).

Bumps the `overrides` pin in `app/package.json` from `7.0.3` to `7.0.5`. The `overrides` entry was already there from a prior security bump — this just advances it to the patched version.

**Vulnerability:** DoS via CPU exhaustion — serializing a crafted array-like object with a huge `length` property triggers an infinite loop at 100% CPU. Fixed in 7.0.5 by replacing `instanceof Array` with `Array.isArray()`.

**Exploitability:** Low — `serialize-javascript` is a transitive build-time dependency (pulled in by terser/vite), not invoked on untrusted runtime input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)