### PR TITLE
fix: retry R2 multipart upload on InvalidPart transient error

### DIFF
--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -406,14 +406,27 @@ def _delete_timestamp(fs, bucket: str, timestamp: str) -> int:
         return 0
 
 
-def _upload_file(fs, local_path: Path, r2_path: str) -> int:
-    with local_path.open("rb") as src:
-        with fs.open_output_stream(r2_path) as dst:
-            total = 0
-            while chunk := src.read(_CHUNK_SIZE):
-                dst.write(chunk)
-                total += len(chunk)
-    return total
+def _upload_file(fs, local_path: Path, r2_path: str, _retries: int = 3) -> int:
+    # R2 occasionally returns InvalidPart during CompleteMultipartUpload — a
+    # transient condition where uploaded parts are not found on completion.
+    # Retry the entire upload from scratch; do not resume partial parts.
+    for attempt in range(1, _retries + 1):
+        try:
+            with local_path.open("rb") as src:
+                with fs.open_output_stream(r2_path) as dst:
+                    total = 0
+                    while chunk := src.read(_CHUNK_SIZE):
+                        dst.write(chunk)
+                        total += len(chunk)
+            return total
+        except OSError as exc:
+            if "InvalidPart" in str(exc) and attempt < _retries:
+                print(
+                    f"  R2 InvalidPart on attempt {attempt}/{_retries} — retrying upload ...",
+                    flush=True,
+                )
+                continue
+            raise
 
 
 def _download_file(fs, r2_path: str, local_path: Path) -> int:

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -410,6 +410,8 @@ def _upload_file(fs, local_path: Path, r2_path: str, _retries: int = 3) -> int:
     # R2 occasionally returns InvalidPart during CompleteMultipartUpload — a
     # transient condition where uploaded parts are not found on completion.
     # Retry the entire upload from scratch; do not resume partial parts.
+    if _retries < 1:
+        raise ValueError("_retries must be >= 1")
     for attempt in range(1, _retries + 1):
         try:
             with local_path.open("rb") as src:


### PR DESCRIPTION
## Problem

`Back up updated AIS DBs to private R2` failed with:

```
OSError: When completing multiple part upload for key 'ais-dbs/singapore.duckdb'
in bucket 'arktrace-private-capvista': AWS Error UNKNOWN (HTTP status 400) during
CompleteMultipartUpload operation: Unable to parse ExceptionName: InvalidPart
Message: One or more of the specified parts could not be found.
```

This is a known Cloudflare R2 transient condition — parts uploaded successfully during a multipart session occasionally cannot be found when R2 tries to complete the upload. It is not caused by data corruption or a bug in the upload code.

## Fix

`_upload_file` now catches `OSError` containing `InvalidPart` and retries the entire upload from scratch (up to 3 attempts). Each retry opens a fresh multipart session — no partial part reuse — which is the correct recovery since R2 has already discarded the previous session's parts.

All other `OSError` variants are still raised immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)