### PR TITLE
fix(#503): add middleeast to data-publish backtest evaluation

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Run backtest (skip pipeline, use pulled watchlists)
         run: |
           uv run python scripts/run_public_backtest_batch.py \
-            --regions singapore,japan,europe,blacksea \
+            --regions singapore,japan,europe,blacksea,middleeast \
             --gdelt-days 14 \
             --seed-dummy \
             --skip-pipeline \


### PR DESCRIPTION
Closes #503

## Change

One-line fix: add `middleeast` to the `--regions` list in the backtest step of `data-publish.yml`.

```diff
-            --regions singapore,japan,europe,blacksea \
+            --regions singapore,japan,europe,blacksea,middleeast \
```

## Why it's safe

- The pipeline already runs Middle East and produces `middleeast_watchlist.parquet` (lines 124–128 are unchanged)
- `push-watchlists` already uploads it to R2; `pull-watchlists` already downloads it in CI
- The `--min-watchlist-size=100` guard in `run_public_backtest_batch.py` will skip Middle East gracefully on any run where the watchlist hasn't grown enough yet — no hard failure

## Test plan

- [ ] Trigger `data-publish.yml` manually after merge and confirm Middle East appears in the published summary email under **Evaluated regions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)