### PR TITLE
fix: pin actions/cache to full SHA (startup_failure follow-up)

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Restore custom feeds cache
         id: feeds-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: _inputs/custom_feeds/
           key: custom-feeds-${{ steps.feeds-cache-key.outputs.week }}


### PR DESCRIPTION
## Problem

\`actions/cache@v4\` added in #506 was not pinned to a full commit SHA, violating the repo's action allowlist policy:

> The action actions/cache@v4 is not allowed because all actions must be pinned to a full-length commit SHA.

Caused \`startup_failure\` on runs [24890377162](https://github.com/edgesentry/arktrace/actions/runs/24890377162) and [24890670173](https://github.com/edgesentry/arktrace/actions/runs/24890670173).

## Fix

Pin \`actions/cache@v4\` → \`actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830\`, matching the pinned-SHA pattern used by every other action in this workflow (\`actions/checkout\`, \`astral-sh/setup-uv\`).

## Test plan
- [ ] Confirm \`data-publish\` workflow starts successfully after merge (no \`startup_failure\`)