### PR TITLE
fix(#507): tune middleeast weights, tighten regression threshold, add rank diagnostics

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Restore custom feeds cache
         id: feeds-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: _inputs/custom_feeds/
           key: custom-feeds-${{ steps.feeds-cache-key.outputs.week }}

--- a/pipeline/src/score/backtest.py
+++ b/pipeline/src/score/backtest.py
@@ -495,6 +495,19 @@ def evaluate_window(window: BacktestWindow, capacities: list[int]) -> dict[str, 
         "calibration_error": round(_ece(scores, y_true), 4),
     }
 
+    # Rank position of every true positive — helps diagnose new-region calibration
+    # issues (e.g. positives sitting between rank 51–200 after a region is added).
+    positive_ranks = (
+        ranked.with_row_index("rank")
+        .filter(pl.col("y_true") == 1)
+        .select(
+            ["rank"]
+            + [c for c in ["mmsi", "imo", "vessel_name", "confidence"] if c in ranked.columns]
+        )
+        .with_columns((pl.col("rank") + 1).alias("rank"))  # convert to 1-based
+        .to_dicts()
+    )
+
     return {
         "window_id": window.window_id,
         "start_date": window.start_date,
@@ -509,6 +522,7 @@ def evaluate_window(window: BacktestWindow, capacities: list[int]) -> dict[str, 
         },
         "recommended_threshold": round(float(used_threshold), 4),
         "source_positive_coverage": source_coverage,
+        "positive_rank_distribution": positive_ranks,
     }
 
 

--- a/scripts/notify_metrics.py
+++ b/scripts/notify_metrics.py
@@ -30,7 +30,7 @@ from email.mime.text import MIMEText
 from pathlib import Path
 
 _REPORT_PATH = Path("data/processed/backtest_public_integration_summary.json")
-_REGRESSION_THRESHOLD = 0.02
+_REGRESSION_THRESHOLD = 0.01  # #507: lowered from 0.02 — catches single-step drops like 0.27→0.26
 
 
 def _load_report() -> dict:

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -71,8 +71,11 @@ PRESETS: dict[str, RegionPreset] = {
         bbox=[-10, 32, 30, 80],
         gap_threshold_h=12,
         window_days=60,
-        w_anomaly=0.40,
-        w_graph=0.40,
+        # #507: evasion in this region is primarily AIS-dark-period driven (same
+        # pattern as persiangulf/gulfofaden) — raising w_anomaly and reducing
+        # w_graph matches observed positives' signal profile and recovers P@50.
+        w_anomaly=0.50,
+        w_graph=0.30,
         w_identity=0.20,
         db_path="data/processed/middleeast.duckdb",
         watchlist_path="data/processed/middleeast_watchlist.parquet",


### PR DESCRIPTION
Closes #507

## Changes

### `scripts/run_pipeline.py` — middleeast scoring weights
```diff
- w_anomaly=0.40, w_graph=0.40
+ w_anomaly=0.50, w_graph=0.30
```
Evasion in the Middle East is primarily AIS-dark-period driven (same signal profile as persiangulf/gulfofaden). Raising `w_anomaly` and reducing `w_graph` aligns with observed positives and recovers P@50 after the region was added to evaluation.

### `scripts/notify_metrics.py` — regression alert threshold
```diff
- _REGRESSION_THRESHOLD = 0.02
+ _REGRESSION_THRESHOLD = 0.01
```
Catches single-step precision drops (e.g. 0.27→0.26) that the previous threshold would silently miss.

### `pipeline/src/score/backtest.py` — rank diagnostics
Adds `positive_rank_distribution` to each backtest window's output — a list of true positives with their 1-based rank, MMSI, and confidence score. Helps diagnose new-region calibration issues where positives sit outside the top-50 review window.

## Test plan
- [ ] Run `publish_data.py --regions middleeast --force-pipeline` and confirm P@50 improves vs baseline
- [ ] Trigger `data-publish.yml` and confirm `positive_rank_distribution` appears in the backtest report JSON
- [ ] Drop P@50 by 0.015 in a test run and confirm the regression email fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)