### PR TITLE
fix: use per-process temp path in download_opensanctions to prevent parallel race

### DIFF
--- a/pipeline/src/ingest/sanctions.py
+++ b/pipeline/src/ingest/sanctions.py
@@ -59,23 +59,30 @@ def download_opensanctions(
         print(f"  Already downloaded: {out_path}")
         return out_path
 
-    tmp_path = out_path.with_suffix(".tmp")
+    # Use a per-process temp path so concurrent pipeline runs (parallel CI)
+    # don't corrupt each other's in-progress download. The rename is atomic on
+    # the same filesystem; the last writer wins harmlessly.
+    tmp_path = out_path.with_name(f"{out_path.stem}-{os.getpid()}.tmp")
     print(f"  Downloading {url} …")
-    with httpx.Client(timeout=600, follow_redirects=True) as client:
-        with client.stream("GET", url) as resp:
-            resp.raise_for_status()
-            total = int(resp.headers.get("content-length", 0))
-            received = 0
-            with open(tmp_path, "wb") as f:
-                for chunk in resp.iter_bytes(chunk_size=65_536):
-                    f.write(chunk)
-                    received += len(chunk)
-                    if total:
-                        pct = received * 100 // total
-                        print(f"\r  {pct}% ({received // 1_048_576} MB)", end="", flush=True)
-    print()
-    tmp_path.rename(out_path)
-    print(f"  Saved: {out_path}")
+    try:
+        with httpx.Client(timeout=600, follow_redirects=True) as client:
+            with client.stream("GET", url) as resp:
+                resp.raise_for_status()
+                total = int(resp.headers.get("content-length", 0))
+                received = 0
+                with open(tmp_path, "wb") as f:
+                    for chunk in resp.iter_bytes(chunk_size=65_536):
+                        f.write(chunk)
+                        received += len(chunk)
+                        if total:
+                            pct = received * 100 // total
+                            print(f"\r  {pct}% ({received // 1_048_576} MB)", end="", flush=True)
+        print()
+        tmp_path.rename(out_path)
+        print(f"  Saved: {out_path}")
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
     return out_path
 
 


### PR DESCRIPTION
## Root cause

Run [24891281580](https://github.com/edgesentry/arktrace/actions/runs/24891281580/job/72884005441) failed with:

```
FileNotFoundError: 'data/raw/sanctions/opensanctions_entities.tmp'
  -> 'data/raw/sanctions/opensanctions_entities.jsonl'
```

All five pipeline regions now run concurrently (PR #506). Every process called `download_opensanctions` which wrote to the **same** `opensanctions_entities.tmp` path. Process A would finish and atomically rename `.tmp → .jsonl`; processes B-E would then fail their own rename because `.tmp` no longer existed.

## Fix

Suffix the temp file with `os.getpid()` so each concurrent download writes to its own path (`opensanctions_entities-12345.tmp`). The final `rename()` to `opensanctions_entities.jsonl` is atomic on the same filesystem — the last writer wins harmlessly, and all others' renames are no-ops (overwrite). The `except` block cleans up the per-PID temp on any download failure.

```diff
-    tmp_path = out_path.with_suffix(".tmp")
+    tmp_path = out_path.with_name(f"{out_path.stem}-{os.getpid()}.tmp")
     try:
         # ... download ...
         tmp_path.rename(out_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
```

## Test plan
- [ ] Trigger `data-publish.yml` and confirm all five "Run pipelines (parallel)" regions complete step 4 (Loading sanctions) without error
- [ ] Confirm only one `opensanctions_entities.jsonl` file exists after the run (no stale per-PID temps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)