### PR TITLE
config: r2sync hourly upload, add all active AIS regions

### DIFF
--- a/pipeline/config/launchagents/io.arktrace.r2sync.plist
+++ b/pipeline/config/launchagents/io.arktrace.r2sync.plist
@@ -16,7 +16,7 @@
     <string>/Users/yoheionishi/work/edgesentry/arktrace/scripts/sync_r2.py</string>
     <string>push-ais-dbs</string>
     <string>--regions</string>
-    <string>japansea,blacksea,middleeast,singapore,europe</string>
+    <string>japansea,blacksea,middleeast,singapore,europe,gulfofmexico,hornofafrica,persiangulf</string>
     <string>--data-dir</string>
     <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed</string>
   </array>
@@ -38,9 +38,9 @@
     <string>1</string>
   </dict>
 
-  <!-- Run every 6 hours (21600 seconds) -->
+  <!-- Run every hour (3600 seconds); skips DBs whose mtime hasn't changed -->
   <key>StartInterval</key>
-  <integer>21600</integer>
+  <integer>3600</integer>
 
   <key>RunAtLoad</key>
   <true/>


### PR DESCRIPTION
## Changes to `pipeline/config/launchagents/io.arktrace.r2sync.plist`

### 1. Hourly uploads (was every 6 hours)
```diff
- <!-- Run every 6 hours (21600 seconds) -->
- <integer>21600</integer>
+ <!-- Run every hour (3600 seconds); skips DBs whose mtime hasn't changed -->
+ <integer>3600</integer>
```

### 2. All active AIS regions (was 5, now 8)
```diff
- japansea,blacksea,middleeast,singapore,europe
+ japansea,blacksea,middleeast,singapore,europe,gulfofmexico,hornofafrica,persiangulf
```

## No bandwidth waste

`push-ais-dbs` already skips any DB whose local `mtime ≤` remote `mtime` — so if a region's stream produces no new positions between runs, no upload happens. The hourly cadence only adds cost when data is actually new.

## Apply locally

```bash
launchctl unload ~/Library/LaunchAgents/io.arktrace.r2sync.plist
cp pipeline/config/launchagents/io.arktrace.r2sync.plist ~/Library/LaunchAgents/
# fill in AWS credentials
launchctl load ~/Library/LaunchAgents/io.arktrace.r2sync.plist
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)