### PR TITLE
config: enable r2sync for all 10 AIS regions

### DIFF
--- a/pipeline/config/launchagents/io.arktrace.r2sync.plist
+++ b/pipeline/config/launchagents/io.arktrace.r2sync.plist
@@ -16,7 +16,7 @@
     <string>/Users/yoheionishi/work/edgesentry/arktrace/scripts/sync_r2.py</string>
     <string>push-ais-dbs</string>
     <string>--regions</string>
-    <string>japansea,blacksea,middleeast,singapore,europe,gulfofmexico,hornofafrica,persiangulf</string>
+    <string>japansea,blacksea,middleeast,singapore,europe,gulfofmexico,hornofafrica,persiangulf,gulfofaden,gulfofguinea</string>
     <string>--data-dir</string>
     <string>/Users/yoheionishi/work/edgesentry/arktrace/data/processed</string>
   </array>


### PR DESCRIPTION
Follow-up to #513 (hourly r2sync interval).

## Change

Adds the two remaining regions — `gulfofaden` and `gulfofguinea` — to the `--regions` list in `io.arktrace.r2sync.plist`, covering all 10 available region DBs.

```diff
- japansea,blacksea,middleeast,singapore,europe,gulfofmexico,hornofafrica,persiangulf
+ japansea,blacksea,middleeast,singapore,europe,gulfofmexico,hornofafrica,persiangulf,gulfofaden,gulfofguinea
```

## Skip behaviour (no extra cost)

`push-ais-dbs` already skips automatically:
- **0 rows** — `ais_positions` table is empty
- **No new data** — local `mtime ≤` remote `mtime`

So adding empty or quiet regions costs no bandwidth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)