### PR TITLE
config: disable scheduled triggers for data-publish and gfw-ingest

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -4,13 +4,11 @@ name: Publish data to R2
 # watchlists, runs the public backtest, and publishes results to R2.
 #
 # Triggers:
-#   - Daily schedule (01:00 UTC) — keeps watchlists and artifacts fresh
 #   - Automatically after Public Backtest Integration completes on main
 #   - Manual dispatch
+#   - Daily schedule disabled — trigger manually or via workflow_run
 
 on:
-  schedule:
-    - cron: '0 1 * * *'   # daily 01:00 UTC
   workflow_dispatch:
   workflow_run:
     workflows: ["Public Backtest Integration"]

--- a/.github/workflows/gfw-ingest.yml
+++ b/.github/workflows/gfw-ingest.yml
@@ -5,8 +5,8 @@ name: GFW EO Ingest
 # GFW API directly, avoiding per-run 429 rate limits and 180s API timeouts.
 #
 # Triggers:
-#   - Weekly Monday 00:00 UTC (before data-publish at 01:00)
 #   - Manual dispatch
+#   - Weekly schedule disabled — trigger manually when needed
 #
 # Token assignment — GFW allows ONE concurrent report per token, so each
 # parallel job is pinned to a dedicated token to avoid cross-job 429s.
@@ -18,8 +18,6 @@ name: GFW EO Ingest
 #   GFW_API_TOKEN_3 → europe
 
 on:
-  schedule:
-    - cron: '0 0 * * 1'  # weekly Monday 00:00 UTC
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Changes

Removes cron schedule triggers from both workflows. Both remain triggerable manually (`workflow_dispatch`) and `data-publish` still fires automatically after `Public Backtest Integration` completes.

| Workflow | Before | After |
|---|---|---|
| `data-publish.yml` | Daily 01:00 UTC + manual + workflow_run | Manual + workflow_run only |
| `gfw-ingest.yml` | Weekly Monday 00:00 UTC + manual | Manual only |

## Re-enabling

To restore the schedule, add back:
```yaml
# data-publish.yml
schedule:
  - cron: '0 1 * * *'   # daily 01:00 UTC

# gfw-ingest.yml
schedule:
  - cron: '0 0 * * 1'   # weekly Monday 00:00 UTC
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)