### PR TITLE
fix: add redirect:manual to CF Access fetches to suppress Origin:null CORS error

### DIFF
--- a/app/src/lib/auth.test.ts
+++ b/app/src/lib/auth.test.ts
@@ -54,7 +54,7 @@ describe("checkPrivateAuth — cloudflare-access", () => {
     expect(await checkPrivateAuth(CF_CONFIG)).toBe("user@example.com");
     expect(fetch).toHaveBeenCalledWith(
       "https://worker.example.com/whoami",
-      { credentials: "include" }
+      { credentials: "include", redirect: "manual" }
     );
   });
 

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -32,7 +32,7 @@ export async function checkPrivateAuth(config: AppConfig): Promise<string | null
   const origin = privateOrigin(config);
   if (!origin) return null;
   try {
-    const resp = await fetch(`${origin}/whoami`, { credentials: "include" });
+    const resp = await fetch(`${origin}/whoami`, { credentials: "include", redirect: "manual" });
     if (!resp.ok) return null;
     const { email } = (await resp.json()) as { email: string };
     return email || null;

--- a/app/src/lib/opfs.ts
+++ b/app/src/lib/opfs.ts
@@ -151,7 +151,7 @@ export async function fetchManifest(
     const resp = await fetch(url, {
       cache: "no-store",
       ...(config.authProvider === "cloudflare-access"
-        ? { credentials: "include" }
+        ? { credentials: "include", redirect: "manual" }
         : { headers: authToken ? { Authorization: `Bearer ${authToken}` } : {} }),
     });
     if (!resp.ok) throw new Error(`Failed to fetch manifest (${resp.status}): ${url}`);
@@ -246,7 +246,7 @@ export async function syncAndLoad(
       const fetchOpts: RequestInit =
         privateAuth && config
           ? config.authProvider === "cloudflare-access"
-            ? { credentials: "include" }
+            ? { credentials: "include", redirect: "manual" }
             : { headers: authToken ? { Authorization: `Bearer ${authToken}` } : {} }
           : { credentials: "omit" };
       const resp = await fetch(fetchUrl, fetchOpts);


### PR DESCRIPTION
## Problem

When the user is unauthenticated, fetches to \`arktrace-private-capvista.edgesentry.io\` (e.g. \`/whoami\`, \`manifest.json\`) trigger a Cloudflare Access login redirect. The browser strips the \`Origin\` header during the cross-origin redirect, sending \`Origin: null\`, which Cloudflare Access rejects — producing CORS errors in the console even though the app handles the failure gracefully.

```
[Error] Origin null is not allowed by Access-Control-Allow-Origin. Status code: 200
[Error] Fetch API cannot load https://edgesentry.cloudflareaccess.com/cdn-cgi/access/login/...
```

## Fix

Add \`redirect: "manual"\` to all Cloudflare Access credential fetches in:
- `app/src/lib/auth.ts` — `/whoami` probe
- `app/src/lib/opfs.ts` — manifest fetch + file downloads

With \`redirect: "manual"\`, the browser returns an opaque redirect response (\`type === "opaqueredirect"\`, \`ok === false\`) instead of following the cross-origin redirect. The existing \`!resp.ok\` guards already treat this as unauthenticated, so no logic change is needed — just no more CORS errors.

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)