### PR TITLE
fix(duckdb): probe region column before use to survive stale OPFS schema

### DIFF
--- a/app/src/lib/duckdb.ts
+++ b/app/src/lib/duckdb.ts
@@ -116,8 +116,9 @@ export async function queryWatchlist(
   opts: { minConfidence?: number; regions?: string[] } = {}
 ): Promise<VesselRow[]> {
   const { minConfidence = 0, regions } = opts;
-  const [hasImo, hasTopSignals, hasAisGap, hasSts] = await Promise.all([
+  const [hasImo, hasRegion, hasTopSignals, hasAisGap, hasSts] = await Promise.all([
     watchlistHasCol(conn, "imo"),
+    watchlistHasCol(conn, "region"),
     watchlistHasCol(conn, "top_signals"),
     watchlistHasCol(conn, "ais_gap_count_30d"),
     watchlistHasCol(conn, "sts_candidate_count"),
@@ -134,14 +135,14 @@ export async function queryWatchlist(
       last_lat,
       last_lon,
       CAST(last_seen AS VARCHAR) AS last_seen,
-      region,
+      ${hasRegion ? "region" : "NULL AS region"},
       ${hasTopSignals ? "CAST(top_signals AS VARCHAR) AS top_signals" : "NULL AS top_signals"},
       ${hasAisGap ? "CAST(ais_gap_count_30d AS INTEGER) AS ais_gap_count_30d" : "NULL AS ais_gap_count_30d"},
       ${hasSts ? "CAST(sts_candidate_count AS INTEGER) AS sts_candidate_count" : "NULL AS sts_candidate_count"}
     FROM read_parquet('watchlist.parquet')
     WHERE confidence >= ${minConfidence}
   `;
-  if (regions && regions.length > 0) {
+  if (hasRegion && regions && regions.length > 0) {
     const list = regions.map((r) => `'${r.replace(/'/g, "''")}'`).join(", ");
     sql += ` AND region IN (${list})`;
   }


### PR DESCRIPTION
## Summary

- Stale OPFS-cached `watchlist.parquet` from older pipeline runs may lack the `region` column
- `queryWatchlist` used `region` unconditionally in `SELECT` and `WHERE region IN (...)`, throwing a Binder Error that bubbled to the top-level catch and rendered the app as **"DuckDB init failed"**
- Probe `region` via `watchlistHasCol` (same pattern as `imo`, `top_signals`, etc.); fall back to `NULL AS region` and skip the `WHERE region IN (...)` filter if absent

## Test plan

- [ ] Clear site data (DevTools → Application → Storage → Clear site data) to force a fresh OPFS state
- [ ] App loads without "DuckDB init failed" on Chrome
- [ ] With fresh cache containing current `watchlist.parquet`, region filtering works normally

Closes #527

🤖 Generated with [Claude Code](https://claude.ai/claude-code)