### PR TITLE
feat(graph): extend sanctions_distance to 3-hop UBO level

### DIFF
--- a/pipeline/src/features/ownership_graph.py
+++ b/pipeline/src/features/ownership_graph.py
@@ -4,7 +4,7 @@ Ownership graph feature engineering.
 Queries the Lance Graph datasets for graph-based risk features.
 
 Output columns (one row per MMSI):
-    mmsi, sanctions_distance, cluster_sanctions_ratio,
+    mmsi, sanctions_distance (0/1/2/3/99), cluster_sanctions_ratio,
     shared_manager_risk, shared_address_centrality, sts_hub_degree
 
 Usage:
@@ -36,6 +36,7 @@ def _compute_sanctions_distance(tables: dict) -> pl.DataFrame:
     0 = vessel directly sanctioned
     1 = owner or manager is sanctioned
     2 = parent company (via CONTROLLED_BY) is sanctioned
+    3 = grandparent / UBO level (CONTROLLED_BY × 2) is sanctioned
     99 = no sanctions connection
     """
     vessels = pl.from_arrow(tables["Vessel"]).select("mmsi")
@@ -69,17 +70,39 @@ def _compute_sanctions_distance(tables: dict) -> pl.DataFrame:
 
     # 2-hop: vessel → company → (CONTROLLED_BY) → sanctioned parent
     two_hop: set[str] = set()
-    if len(cb) and len(ob or mb):
+    if len(cb) and (len(ob) or len(mb)):
         sanctioned_parents = set(
             cb.filter(pl.col("dst_id").is_in(sanctioned_ids))["src_id"].to_list()
         )
-        if sanctioned_parents and (len(ob) or len(mb)):
+        if sanctioned_parents:
             two_hop_vessels = (
                 vessel_companies.filter(pl.col("dst_id").is_in(sanctioned_parents))["src_id"]
                 .unique()
                 .to_list()
             )
             two_hop = set(two_hop_vessels)
+
+    # 3-hop: vessel → company → parent → (CONTROLLED_BY) → sanctioned grandparent (UBO level)
+    three_hop: set[str] = set()
+    if len(cb) and (len(ob) or len(mb)):
+        # Companies one CONTROLLED_BY step away from sanctioned entities
+        sanctioned_grandparents = set(
+            cb.filter(pl.col("dst_id").is_in(sanctioned_ids))["src_id"].to_list()
+        )
+        # Companies two CONTROLLED_BY steps away (grandparent chain)
+        if sanctioned_grandparents:
+            sanctioned_via_grandparent = set(
+                cb.filter(pl.col("dst_id").is_in(sanctioned_grandparents))["src_id"].to_list()
+            )
+            if sanctioned_via_grandparent:
+                three_hop_vessels = (
+                    vessel_companies.filter(
+                        pl.col("dst_id").is_in(sanctioned_via_grandparent)
+                    )["src_id"]
+                    .unique()
+                    .to_list()
+                )
+                three_hop = set(three_hop_vessels)
 
     rows = []
     for mmsi in vessels["mmsi"].to_list():
@@ -89,6 +112,8 @@ def _compute_sanctions_distance(tables: dict) -> pl.DataFrame:
             dist = 1
         elif mmsi in two_hop:
             dist = 2
+        elif mmsi in three_hop:
+            dist = 3
         else:
             dist = MAX_HOPS
         rows.append({"mmsi": mmsi, "sanctions_distance": dist})

--- a/pipeline/src/score/causal_sanction.py
+++ b/pipeline/src/score/causal_sanction.py
@@ -238,9 +238,9 @@ def _identify_treatment_groups(
     """
     Return (treated_mmsis, control_mmsis) for a given regime.
 
-    Treated : sanctions_distance ≤ 2 AND vessel in Neo4j graph connected to
+    Treated : sanctions_distance ≤ 3 AND vessel in Neo4j graph connected to
               a sanctions_entities row whose list_source contains the regime
-              substring.
+              substring (distance 3 = UBO / grandparent level).
 
     Control : sanctions_distance = 99 (no graph link to any sanctioned entity).
 
@@ -257,7 +257,7 @@ def _identify_treatment_groups(
             SELECT DISTINCT vf.mmsi
             FROM vessel_features vf
             JOIN vessel_meta vm ON vm.mmsi = vf.mmsi
-            WHERE vf.sanctions_distance <= 2
+            WHERE vf.sanctions_distance <= 3
             """,
         ).fetchall()
         treated = [r[0] for r in treated_rows]


### PR DESCRIPTION
## Summary

Extends ownership graph traversal from 2 hops to 3 hops to capture vessels linked to sanctioned entities at the UBO (Ultimate Beneficial Owner) / grandparent level.

| Distance | Meaning |
|---|---|
| 0 | Vessel directly sanctioned |
| 1 | Owner / manager sanctioned |
| 2 | Parent company sanctioned |
| **3** | **Grandparent / UBO sanctioned ← new** |
| 99 | No connection |

- 3-hop follows `CONTROLLED_BY × 2` from the vessel's direct company
- DiD treatment group threshold updated `≤ 2 → ≤ 3` so new distance-3 vessels are included in causal effect estimation
- `composite.py` graph_risk_score formula (`1 - distance/5`) already handles distance 3 correctly (score = 0.4), no change needed
- All 37 existing tests pass

Part of #516. Issue #534 tracks the remaining Item 1 (macro-event covariates).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)