### PR TITLE
docs: add arktrace → edgesentry-rs Parquet handoff note

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,6 +118,10 @@
 ┌─────────────────────────────────────────────────────────────────┐
 │  PHYSICAL INVESTIGATION  (edgesentry-app / edgesentry-rs)       │
 │  (out of scope for this repo — see roadmap.md)                  │
+│                                                                 │
+│  Data handoff: arktrace writes candidate_watchlist.parquet      │
+│  → eds parse maritime --source candidate_watchlist.parquet      │
+│    reads it directly (Parquet auto-detected by extension)       │
 └─────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
Documents the data handoff from arktrace to edgesentry-rs: arktrace writes `candidate_watchlist.parquet` and `eds parse maritime` reads it directly (Parquet auto-detected by file extension, implemented in edgesentry-rs #326).