### PR TITLE
feat(#541): IMO identity spoofing detection

### DIFF
--- a/docs/feature-engineering.md
+++ b/docs/feature-engineering.md
@@ -1,17 +1,18 @@
 # Feature Engineering
 
-The arktrace pipeline computes 22 features across five families for every vessel MMSI. All features are written to the `vessel_features` DuckDB table by `src/features/build_matrix.py`.
+The arktrace pipeline computes 27 features across five families for every vessel MMSI. All features are written to the `vessel_features` DuckDB table by `src/features/build_matrix.py`.
 
 ## Feature families
 
 | Family | Module | Features | Backend |
 |---|---|---|---|
-| AIS Behavioral | `ais_behavior.py` | 6 | DuckDB / Polars |
-| Identity Volatility | `identity.py` | 5 | Lance Graph + DuckDB |
+| AIS Behavioral | `ais_behavior.py` | 8 | DuckDB / Polars |
+| Identity Volatility | `identity.py` | 7 | Lance Graph + DuckDB |
 | Ownership Graph | `ownership_graph.py` | 5 | Lance Graph (Polars joins) |
 | Trade Flow Mismatch | `trade_mismatch.py` | 2 | DuckDB + Comtrade API |
 | EO Fusion | `eo_fusion.py` | 4 | DuckDB (GFW API via `eo_gfw.py` / CSV) |
-| **Total** | | **22** | |
+| SAR Detections | `sar_detections.py` | 1 | DuckDB |
+| **Total** | | **27** | |
 
 ---
 
@@ -189,6 +190,60 @@ Count of EO (Electro-Optical satellite imagery) vessel detections in the last 30
 Fraction of all EO detections attributed to this vessel (matched + unmatched) that were unmatched (dark): `eo_dark_count_30d / total_attributed_detections`.
 
 **Shadow fleet signal:** A vessel that appears in satellite imagery only when it is also broadcasting on AIS has a ratio near 0 — consistent with compliant behaviour. A vessel with a ratio above 0.5 is dark during more than half its satellite observations, indicating a systematic pattern of AIS suppression rather than occasional equipment failure.
+
+---
+
+## Chokepoint Exit / AIS Compliance Weaponization features
+
+Source: `ais_positions` DuckDB table. Computed by `compute_chokepoint_gap_features()` in `src/features/ais_behavior.py`. Added in arktrace#543 (2026-05-02).
+
+**Background:** The Al Jazeera shadow fleet investigation (2026-04-30) confirmed a new evasion pattern: vessels transmit perfect, uninterrupted AIS *during* strait passage to appear compliant, then go dark immediately after clearing the chokepoint. The existing `ais_gap_count_30d` does not distinguish where gaps begin.
+
+### `chokepoint_exit_gap_count`
+
+Number of AIS gap onsets (last known position before going dark) that fall within 50 nautical miles of a major chokepoint exit: Singapore Strait (east/west), Malacca north, Strait of Hormuz east, Bab-el-Mandeb, Suez Canal south, Aegean/Dardanelles, Cape of Good Hope.
+
+**Shadow fleet signal:** Legitimate commercial traffic does not go dark at chokepoint exits. Port congestion and anchorage delays produce gaps *near ports*, not in open water immediately past a major strait. Near-zero false-positive rate for compliant vessels; high specificity for deliberate AIS suppression after chokepoint transit.
+
+**Default when missing:** 0
+
+### `ais_pre_gap_regularity`
+
+Mean coefficient of variation (CV = std/mean) of AIS transmission intervals in the 6 hours before each gap onset, averaged across all qualifying gaps (> `GAP_THRESHOLD_H`) per vessel.
+
+A CV near 0 means transmissions were machine-like regular — identical intervals, as if a timer was set to broadcast exactly every N seconds before cutting. Legitimate vessels have noisy, irregular transmission intervals driven by satellite coverage, congestion, and transponder behaviour. CV is calculated only for gaps with ≥ 3 pre-gap pings; vessels with no qualifying gaps receive the neutral default of 1.0.
+
+**Shadow fleet signal:** Suspiciously regular transmission (low CV) immediately preceding a long dark period is the hallmark of deliberate AIS compliance: a vessel broadcasting on a strict timer to appear compliant during a monitored strait transit, then switching off once clear.
+
+**Default when missing:** 1.0 (noisy/normal baseline)
+
+---
+
+## IMO Identity Spoofing features
+
+Source: `vessel_meta` DuckDB table (AIS-reported type) joined against `equasis_vessel_ref` (Equasis registered type and scrapped status). Computed by `compute_imo_mismatch_features()` in `src/features/identity.py`. Added in arktrace#544 (2026-05-02).
+
+**Requires:** Equasis reference data loaded via `upsert_equasis_vessel_ref(db_path, equasis_csv)`. When `equasis_vessel_ref` is empty, both features default to `False` for all vessels (graceful degradation).
+
+**Background:** Shadow fleet vessels increasingly adopt IMO numbers from scrapped or fictitious ships to pass ownership graph lookups as clean entities. A vessel broadcasting as a 2018-built chemical tanker (AIS ship_type=68) but registered under an IMO number belonging to a 2005-built VLCC (Equasis vessel_type=80) is a clear identity inconsistency.
+
+### `imo_type_mismatch`
+
+Boolean. `True` when the broad ship-type category reported in AIS messages differs from the category registered for the same IMO number in Equasis.
+
+Broad categories (ITU-R M.1371): fishing (30), service/tug (31–57), passenger (60–69), cargo (70–79), tanker (80–89). Mismatch is only raised when both the AIS and Equasis categories are known (non-zero); vessels with unknown/other types on either side are not flagged.
+
+**Shadow fleet signal:** A vessel cannot physically change type. A tanker hull claiming a cargo IMO, or a fishing vessel broadcasting a tanker IMO, is either operating with a spoofed identity document or has adopted the IMO of a scrapped vessel whose former type is on record.
+
+**Default when missing:** `False`
+
+### `imo_scrapped_flag`
+
+Boolean. `True` when the vessel's reported IMO number appears in the Equasis deleted/scrapped vessel registry (`scrapped=True` in `equasis_vessel_ref`).
+
+**Shadow fleet signal:** Scrapped vessels are removed from active Lloyd's/Equasis registries. An active AIS broadcast using a scrapped IMO is definitive evidence of identity fraud — the vessel either never existed, or the physical vessel was decommissioned and its IMO number reused to create a clean identity.
+
+**Default when missing:** `False`
 
 ---
 

--- a/docs/scoring-model.md
+++ b/docs/scoring-model.md
@@ -61,7 +61,14 @@ The Isolation Forest assigns each vessel a continuous anomaly score in [0, 1]. I
 
 ### Features used
 
-All 19 features from `vessel_features`.
+All 25 features from `vessel_features` (see `ANOMALY_FEATURE_COLUMNS` in `src/score/anomaly.py`), including the four features added in arktrace#543/#544:
+
+| New feature | Added | Signal |
+|---|---|---|
+| `chokepoint_exit_gap_count` | #543 | AIS dark onset at strait exit (AIS compliance weaponization) |
+| `ais_pre_gap_regularity` | #543 | Machine-like pre-gap transmission regularity |
+| `imo_type_mismatch` | #544 | AIS vessel type ≠ Equasis registered type for same IMO |
+| `imo_scrapped_flag` | #544 | IMO belongs to a scrapped/deleted vessel |
 
 ### Training set selection
 

--- a/pipeline/src/features/build_matrix.py
+++ b/pipeline/src/features/build_matrix.py
@@ -35,6 +35,8 @@ DEFAULTS = {
     "loitering_hours_30d": 0.0,
     "chokepoint_exit_gap_count": 0,
     "ais_pre_gap_regularity": 1.0,
+    "imo_type_mismatch": False,
+    "imo_scrapped_flag": False,
     "flag_changes_2y": 0,
     "name_changes_2y": 0,
     "owner_changes_2y": 0,

--- a/pipeline/src/features/identity.py
+++ b/pipeline/src/features/identity.py
@@ -177,6 +177,106 @@ def _compute_high_risk_flag_ratio(tables: dict) -> pl.DataFrame:
 
 
 # ---------------------------------------------------------------------------
+# IMO identity spoofing features
+# ---------------------------------------------------------------------------
+
+
+# AIS ship_type → broad category (ITU-R M.1371 Annex 8 Table 22)
+# Only categories that matter for cross-reference; anything else → 0 (unknown).
+def _ship_type_category(ship_type: int | None) -> int:
+    if ship_type is None:
+        return 0
+    if ship_type == 30:
+        return 1  # fishing
+    if 31 <= ship_type <= 57:
+        return 2  # service (tug, pilot, SAR, etc.)
+    if 60 <= ship_type <= 69:
+        return 3  # passenger
+    if 70 <= ship_type <= 79:
+        return 4  # cargo
+    if 80 <= ship_type <= 89:
+        return 5  # tanker
+    return 0  # unknown / other
+
+
+def compute_imo_mismatch_features(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
+    """imo_type_mismatch and imo_scrapped_flag per MMSI.
+
+    Joins vessel_meta (AIS-reported ship_type + imo) against equasis_vessel_ref
+    (registered vessel_type and scrapped status from Equasis CSV).
+
+    imo_type_mismatch — True when the AIS-reported ship type category (cargo,
+    tanker, passenger, fishing …) differs from the category registered for the
+    same IMO number in Equasis.  A 2005-built VLCC (Equasis: tanker) cannot be
+    a 2018-built chemical tanker (AIS: cargo).
+
+    imo_scrapped_flag — True when the vessel's IMO number is marked as scrapped
+    or deleted in the Equasis reference data.
+
+    Returns a DataFrame with (mmsi, imo_type_mismatch, imo_scrapped_flag).
+    If equasis_vessel_ref is empty, both features are False for all vessels.
+    """
+    _empty_schema = {
+        "mmsi": pl.Utf8,
+        "imo_type_mismatch": pl.Boolean,
+        "imo_scrapped_flag": pl.Boolean,
+    }
+
+    con = duckdb.connect(db_path, read_only=True)
+    try:
+        meta = con.execute(
+            "SELECT mmsi, COALESCE(imo,'') AS imo, ship_type "
+            "FROM vessel_meta WHERE mmsi IS NOT NULL"
+        ).pl()
+        ref_count = con.execute("SELECT COUNT(*) FROM equasis_vessel_ref").fetchone()[0]
+        if ref_count == 0:
+            if meta.is_empty():
+                return pl.DataFrame(schema=_empty_schema)
+            return meta.select("mmsi").with_columns(
+                [
+                    pl.lit(False).alias("imo_type_mismatch"),
+                    pl.lit(False).alias("imo_scrapped_flag"),
+                ]
+            )
+        ref = con.execute("SELECT imo, vessel_type, scrapped FROM equasis_vessel_ref").pl()
+    finally:
+        con.close()
+
+    if meta.is_empty():
+        return pl.DataFrame(schema=_empty_schema)
+
+    joined = meta.filter(pl.col("imo") != "").join(ref, on="imo", how="left")
+
+    rows = []
+    for row in joined.iter_rows(named=True):
+        ais_cat = _ship_type_category(row["ship_type"])
+        eq_cat = _ship_type_category(row.get("vessel_type"))
+        mismatch = ais_cat != 0 and eq_cat != 0 and ais_cat != eq_cat
+        scrapped = bool(row.get("scrapped") or False)
+        rows.append(
+            {
+                "mmsi": row["mmsi"],
+                "imo_type_mismatch": mismatch,
+                "imo_scrapped_flag": scrapped,
+            }
+        )
+
+    if not rows:
+        return pl.DataFrame(schema=_empty_schema)
+
+    result = pl.DataFrame(rows, schema=_empty_schema)
+
+    # Vessels with no IMO in vessel_meta get False defaults
+    all_mmsi = meta.select("mmsi")
+    return all_mmsi.join(result, on="mmsi", how="left").with_columns(
+        [
+            pl.col("imo_type_mismatch").fill_null(False),
+            pl.col("imo_scrapped_flag").fill_null(False),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -189,6 +289,7 @@ def compute_identity_features(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
     owner_df = _compute_owner_changes(tables)
     depth_df = _compute_ownership_depth(tables)
     hrisk_df = _compute_high_risk_flag_ratio(tables)
+    imo_df = compute_imo_mismatch_features(db_path)
 
     # flag_changes_2y: hardcoded to 0 — historical flag-state records are not yet
     # ingested. This is an intentional deferral, not a broken feature.
@@ -218,6 +319,7 @@ def compute_identity_features(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
         .join(depth_df.lazy(), on="mmsi", how="left")
         .join(hrisk_df.lazy(), on="mmsi", how="left")
         .join(flag_df.lazy(), on="mmsi", how="left")
+        .join(imo_df.lazy(), on="mmsi", how="left")
         .with_columns(
             [
                 pl.col("flag_changes_2y").fill_null(0).cast(pl.Int32),
@@ -225,6 +327,8 @@ def compute_identity_features(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
                 pl.col("owner_changes_2y").fill_null(0).cast(pl.Int32),
                 pl.col("high_risk_flag_ratio").fill_null(0.0).cast(pl.Float32),
                 pl.col("ownership_depth").fill_null(0).cast(pl.Int32),
+                pl.col("imo_type_mismatch").fill_null(False),
+                pl.col("imo_scrapped_flag").fill_null(False),
             ]
         )
         .collect()

--- a/pipeline/src/ingest/schema.py
+++ b/pipeline/src/ingest/schema.py
@@ -89,6 +89,14 @@ def init_schema(db_path: str = DEFAULT_DB_PATH) -> None:
             )
         """)
         con.execute("""
+            CREATE TABLE IF NOT EXISTS equasis_vessel_ref (
+                imo         VARCHAR PRIMARY KEY,
+                vessel_type TINYINT,
+                build_year  SMALLINT,
+                scrapped    BOOLEAN DEFAULT FALSE
+            )
+        """)
+        con.execute("""
             CREATE TABLE IF NOT EXISTS trade_flow (
                 reporter        VARCHAR NOT NULL,
                 partner         VARCHAR NOT NULL,

--- a/pipeline/src/ingest/schema.py
+++ b/pipeline/src/ingest/schema.py
@@ -251,6 +251,22 @@ def init_schema(db_path: str = DEFAULT_DB_PATH) -> None:
             ALTER TABLE vessel_features
             ADD COLUMN IF NOT EXISTS sanctions_list_count INTEGER DEFAULT 0
         """)
+        con.execute("""
+            ALTER TABLE vessel_features
+            ADD COLUMN IF NOT EXISTS imo_type_mismatch BOOLEAN DEFAULT FALSE
+        """)
+        con.execute("""
+            ALTER TABLE vessel_features
+            ADD COLUMN IF NOT EXISTS imo_scrapped_flag BOOLEAN DEFAULT FALSE
+        """)
+        con.execute("""
+            ALTER TABLE vessel_features
+            ADD COLUMN IF NOT EXISTS chokepoint_exit_gap_count INTEGER DEFAULT 0
+        """)
+        con.execute("""
+            ALTER TABLE vessel_features
+            ADD COLUMN IF NOT EXISTS ais_pre_gap_regularity FLOAT DEFAULT 1.0
+        """)
     finally:
         con.close()
 

--- a/pipeline/src/ingest/vessel_registry.py
+++ b/pipeline/src/ingest/vessel_registry.py
@@ -365,6 +365,77 @@ def build_graph_tables(
 
 
 # ---------------------------------------------------------------------------
+# Equasis vessel reference (type / build_year / scrapped) — DuckDB upsert
+# ---------------------------------------------------------------------------
+
+_EQUASIS_REF_COLS = {"imo", "vessel_type", "build_year", "scrapped"}
+
+
+def upsert_equasis_vessel_ref(db_path: str, equasis_csv: str) -> int:
+    """Parse Equasis CSV and upsert vessel_type / build_year / scrapped into
+    the ``equasis_vessel_ref`` DuckDB table.
+
+    Columns read from the CSV (all optional — missing values are skipped):
+        imo, vessel_type (int AIS code), build_year (int), scrapped (0/1/true/false)
+
+    Returns the number of rows upserted.
+    """
+    rows: list[dict] = []
+    with open(equasis_csv, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            imo = (row.get("imo") or "").strip()
+            if not imo:
+                continue
+            vessel_type_raw = (row.get("vessel_type") or "").strip()
+            build_year_raw = (row.get("build_year") or "").strip()
+            scrapped_raw = (row.get("scrapped") or "").strip().lower()
+
+            vessel_type = int(vessel_type_raw) if vessel_type_raw.isdigit() else None
+            build_year = int(build_year_raw) if build_year_raw.isdigit() else None
+            scrapped = scrapped_raw in ("1", "true", "yes")
+
+            if vessel_type is None and build_year is None and not scrapped:
+                continue
+            rows.append(
+                {
+                    "imo": imo,
+                    "vessel_type": vessel_type,
+                    "build_year": build_year,
+                    "scrapped": scrapped,
+                }
+            )
+
+    if not rows:
+        return 0
+
+    _ref = pl.DataFrame(
+        rows,
+        schema={
+            "imo": pl.Utf8,
+            "vessel_type": pl.Int8,
+            "build_year": pl.Int16,
+            "scrapped": pl.Boolean,
+        },
+    )
+
+    con = duckdb.connect(db_path)
+    try:
+        con.execute("""
+            INSERT INTO equasis_vessel_ref (imo, vessel_type, build_year, scrapped)
+            SELECT imo, vessel_type, build_year, scrapped FROM _ref
+            ON CONFLICT (imo) DO UPDATE SET
+                vessel_type = COALESCE(excluded.vessel_type, equasis_vessel_ref.vessel_type),
+                build_year  = COALESCE(excluded.build_year,  equasis_vessel_ref.build_year),
+                scrapped    = excluded.scrapped
+        """)
+    finally:
+        con.close()
+
+    return len(rows)
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -375,6 +446,10 @@ if __name__ == "__main__":
         "--equasis-csv", default=None, help="Path to Equasis ownership chain CSV export"
     )
     args = parser.parse_args()
+
+    if args.equasis_csv:
+        n = upsert_equasis_vessel_ref(args.db, args.equasis_csv)
+        print(f"Equasis vessel ref: {n} rows upserted")
 
     print("Building ownership graph tables …")
     tables = build_graph_tables(args.db, equasis_csv=args.equasis_csv)

--- a/pipeline/src/score/anomaly.py
+++ b/pipeline/src/score/anomaly.py
@@ -41,6 +41,10 @@ ANOMALY_FEATURE_COLUMNS = [
     "unmatched_sar_detections_30d",
     "eo_dark_count_30d",
     "eo_ais_mismatch_ratio",
+    "imo_type_mismatch",
+    "imo_scrapped_flag",
+    "chokepoint_exit_gap_count",
+    "ais_pre_gap_regularity",
 ]
 
 

--- a/pipeline/src/score/composite.py
+++ b/pipeline/src/score/composite.py
@@ -77,6 +77,10 @@ FEATURE_VALUE_COLUMNS = [
     "unmatched_sar_detections_30d",
     "eo_dark_count_30d",
     "eo_ais_mismatch_ratio",
+    "imo_type_mismatch",
+    "imo_scrapped_flag",
+    "chokepoint_exit_gap_count",
+    "ais_pre_gap_regularity",
 ]
 
 

--- a/tests/test_enhancements_cap_vista.py
+++ b/tests/test_enhancements_cap_vista.py
@@ -14,7 +14,7 @@ import duckdb
 import polars as pl
 import pytest
 
-from pipeline.src.score.anomaly import fit_isolation_forest
+from pipeline.src.score.anomaly import ANOMALY_FEATURE_COLUMNS, fit_isolation_forest
 from pipeline.src.score.composite import (
     GeoEvent,
     _GeoCorridorBbox,
@@ -38,30 +38,6 @@ BEHAVIOR_COLUMNS = [
     "sts_candidate_count",
     "port_call_ratio",
     "loitering_hours_30d",
-]
-
-ANOMALY_FEATURE_COLUMNS = [
-    "ais_gap_count_30d",
-    "ais_gap_max_hours",
-    "position_jump_count",
-    "sts_candidate_count",
-    "port_call_ratio",
-    "loitering_hours_30d",
-    "flag_changes_2y",
-    "name_changes_2y",
-    "owner_changes_2y",
-    "high_risk_flag_ratio",
-    "ownership_depth",
-    "sanctions_distance",
-    "cluster_sanctions_ratio",
-    "shared_manager_risk",
-    "shared_address_centrality",
-    "sts_hub_degree",
-    "route_cargo_mismatch",
-    "declared_vs_estimated_cargo_value",
-    "unmatched_sar_detections_30d",
-    "eo_dark_count_30d",
-    "eo_ais_mismatch_ratio",
 ]
 
 

--- a/tests/test_imo_mismatch.py
+++ b/tests/test_imo_mismatch.py
@@ -1,0 +1,201 @@
+"""Unit tests for IMO identity spoofing detection features.
+
+Tests cover compute_imo_mismatch_features() and the _ship_type_category()
+helper.  All tests use a temporary DuckDB — no Equasis API required.
+"""
+
+import csv
+
+import duckdb
+import polars as pl
+
+from pipeline.src.features.identity import (
+    _ship_type_category,
+    compute_imo_mismatch_features,
+)
+from pipeline.src.ingest.vessel_registry import upsert_equasis_vessel_ref
+
+# ---------------------------------------------------------------------------
+# _ship_type_category
+# ---------------------------------------------------------------------------
+
+
+def test_ship_type_category_tanker():
+    for code in range(80, 90):
+        assert _ship_type_category(code) == 5
+
+
+def test_ship_type_category_cargo():
+    for code in range(70, 80):
+        assert _ship_type_category(code) == 4
+
+
+def test_ship_type_category_passenger():
+    for code in range(60, 70):
+        assert _ship_type_category(code) == 3
+
+
+def test_ship_type_category_fishing():
+    assert _ship_type_category(30) == 1
+
+
+def test_ship_type_category_unknown():
+    assert _ship_type_category(0) == 0
+    assert _ship_type_category(99) == 0
+    assert _ship_type_category(None) == 0
+
+
+# ---------------------------------------------------------------------------
+# upsert_equasis_vessel_ref
+# ---------------------------------------------------------------------------
+
+
+def _write_equasis_ref_csv(path, rows: list[dict]) -> None:
+    fieldnames = ["imo", "vessel_type", "build_year", "scrapped"]
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_upsert_equasis_vessel_ref_inserts_rows(tmp_db, tmp_path):
+    csv_path = tmp_path / "equasis_ref.csv"
+    _write_equasis_ref_csv(
+        csv_path,
+        [
+            {"imo": "9999991", "vessel_type": 80, "build_year": 2005, "scrapped": "false"},
+            {"imo": "9999992", "vessel_type": 70, "build_year": 2018, "scrapped": "false"},
+        ],
+    )
+    n = upsert_equasis_vessel_ref(tmp_db, str(csv_path))
+    assert n == 2
+
+    con = duckdb.connect(tmp_db, read_only=True)
+    try:
+        rows = con.execute(
+            "SELECT imo, vessel_type, build_year, scrapped FROM equasis_vessel_ref ORDER BY imo"
+        ).fetchall()
+    finally:
+        con.close()
+
+    assert len(rows) == 2
+    assert rows[0] == ("9999991", 80, 2005, False)
+    assert rows[1] == ("9999992", 70, 2018, False)
+
+
+def test_upsert_equasis_vessel_ref_scrapped_flag(tmp_db, tmp_path):
+    csv_path = tmp_path / "equasis_ref.csv"
+    _write_equasis_ref_csv(
+        csv_path,
+        [{"imo": "1234567", "vessel_type": 80, "build_year": 1998, "scrapped": "true"}],
+    )
+    upsert_equasis_vessel_ref(tmp_db, str(csv_path))
+
+    con = duckdb.connect(tmp_db, read_only=True)
+    try:
+        scrapped = con.execute(
+            "SELECT scrapped FROM equasis_vessel_ref WHERE imo='1234567'"
+        ).fetchone()[0]
+    finally:
+        con.close()
+
+    assert scrapped is True
+
+
+def test_upsert_equasis_vessel_ref_skips_missing_imo(tmp_db, tmp_path):
+    csv_path = tmp_path / "equasis_ref.csv"
+    _write_equasis_ref_csv(csv_path, [{"imo": "", "vessel_type": 80, "build_year": 2000}])
+    n = upsert_equasis_vessel_ref(tmp_db, str(csv_path))
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# compute_imo_mismatch_features
+# ---------------------------------------------------------------------------
+
+
+def _seed_vessel_meta(db_path: str, rows: list[dict]) -> None:
+    con = duckdb.connect(db_path)
+    try:
+        for r in rows:
+            con.execute(
+                "INSERT OR IGNORE INTO vessel_meta (mmsi, imo, ship_type) VALUES (?, ?, ?)",
+                [r["mmsi"], r.get("imo", ""), r.get("ship_type")],
+            )
+    finally:
+        con.close()
+
+
+def _seed_equasis_ref(db_path: str, rows: list[dict]) -> None:
+    con = duckdb.connect(db_path)
+    try:
+        for r in rows:
+            con.execute(
+                "INSERT OR IGNORE INTO equasis_vessel_ref (imo, vessel_type, build_year, scrapped) VALUES (?, ?, ?, ?)",
+                [r["imo"], r.get("vessel_type"), r.get("build_year"), r.get("scrapped", False)],
+            )
+    finally:
+        con.close()
+
+
+def test_imo_type_mismatch_detected(tmp_db):
+    """Vessel reports AIS ship_type=70 (cargo) but IMO is registered as tanker (80)."""
+    _seed_vessel_meta(tmp_db, [{"mmsi": "111111111", "imo": "9000001", "ship_type": 70}])
+    _seed_equasis_ref(tmp_db, [{"imo": "9000001", "vessel_type": 80}])
+
+    result = compute_imo_mismatch_features(tmp_db)
+    row = result.filter(pl.col("mmsi") == "111111111")
+    assert not row.is_empty()
+    assert row["imo_type_mismatch"][0] is True
+    assert row["imo_scrapped_flag"][0] is False
+
+
+def test_imo_type_match_not_flagged(tmp_db):
+    """Vessel reports tanker (82) and IMO is registered as tanker (80) — same category."""
+    _seed_vessel_meta(tmp_db, [{"mmsi": "222222222", "imo": "9000002", "ship_type": 82}])
+    _seed_equasis_ref(tmp_db, [{"imo": "9000002", "vessel_type": 83}])
+
+    result = compute_imo_mismatch_features(tmp_db)
+    row = result.filter(pl.col("mmsi") == "222222222")
+    assert not row.is_empty()
+    assert row["imo_type_mismatch"][0] is False
+
+
+def test_imo_scrapped_flag_detected(tmp_db):
+    """Vessel's IMO is marked as scrapped in Equasis reference data."""
+    _seed_vessel_meta(tmp_db, [{"mmsi": "333333333", "imo": "9000003", "ship_type": 80}])
+    _seed_equasis_ref(tmp_db, [{"imo": "9000003", "vessel_type": 80, "scrapped": True}])
+
+    result = compute_imo_mismatch_features(tmp_db)
+    row = result.filter(pl.col("mmsi") == "333333333")
+    assert not row.is_empty()
+    assert row["imo_scrapped_flag"][0] is True
+
+
+def test_imo_unknown_category_not_flagged(tmp_db):
+    """When either AIS or Equasis type is unknown (0), mismatch is not raised."""
+    _seed_vessel_meta(tmp_db, [{"mmsi": "444444444", "imo": "9000004", "ship_type": 0}])
+    _seed_equasis_ref(tmp_db, [{"imo": "9000004", "vessel_type": 80}])
+
+    result = compute_imo_mismatch_features(tmp_db)
+    row = result.filter(pl.col("mmsi") == "444444444")
+    assert not row.is_empty()
+    assert row["imo_type_mismatch"][0] is False
+
+
+def test_imo_no_equasis_ref_returns_false_defaults(tmp_db):
+    """When equasis_vessel_ref is empty, both features default to False."""
+    _seed_vessel_meta(tmp_db, [{"mmsi": "555555555", "imo": "9000005", "ship_type": 80}])
+
+    result = compute_imo_mismatch_features(tmp_db)
+    row = result.filter(pl.col("mmsi") == "555555555")
+    assert not row.is_empty()
+    assert row["imo_type_mismatch"][0] is False
+    assert row["imo_scrapped_flag"][0] is False
+
+
+def test_imo_mismatch_empty_db_returns_correct_schema(tmp_db):
+    result = compute_imo_mismatch_features(tmp_db)
+    assert "mmsi" in result.columns
+    assert "imo_type_mismatch" in result.columns
+    assert "imo_scrapped_flag" in result.columns

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -11,6 +11,7 @@ def test_all_tables_created(tmp_db):
         "ais_positions",
         "vessel_meta",
         "sanctions_entities",
+        "equasis_vessel_ref",
         "trade_flow",
         "vessel_features",
         "analyst_briefs",

--- a/tests/test_scoring_pipeline.py
+++ b/tests/test_scoring_pipeline.py
@@ -186,7 +186,12 @@ def test_chokepoint_features_in_anomaly_feature_columns():
 
 def test_new_features_in_feature_value_columns():
     """All four new features must appear in SHAP signal attribution."""
-    for col in ("imo_type_mismatch", "imo_scrapped_flag", "chokepoint_exit_gap_count", "ais_pre_gap_regularity"):
+    for col in (
+        "imo_type_mismatch",
+        "imo_scrapped_flag",
+        "chokepoint_exit_gap_count",
+        "ais_pre_gap_regularity",
+    ):
         assert col in FEATURE_VALUE_COLUMNS, f"{col} missing from FEATURE_VALUE_COLUMNS"
 
 

--- a/tests/test_scoring_pipeline.py
+++ b/tests/test_scoring_pipeline.py
@@ -2,8 +2,8 @@ import json
 
 import duckdb
 
-from pipeline.src.score.anomaly import load_feature_frame, score_anomalies
-from pipeline.src.score.composite import compute_composite_scores
+from pipeline.src.score.anomaly import ANOMALY_FEATURE_COLUMNS, load_feature_frame, score_anomalies
+from pipeline.src.score.composite import FEATURE_VALUE_COLUMNS, compute_composite_scores
 from pipeline.src.score.mpol_baseline import build_mpol_baseline
 from pipeline.src.score.watchlist import build_candidate_watchlist, write_candidate_watchlist
 
@@ -161,3 +161,78 @@ def test_composite_and_watchlist_output(tmp_db, tmp_path):
     output_path = tmp_path / "candidate_watchlist.parquet"
     write_candidate_watchlist(watchlist, str(output_path))
     assert output_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# IMO spoofing + chokepoint features wired into scoring
+# ---------------------------------------------------------------------------
+
+
+def test_imo_type_mismatch_in_anomaly_feature_columns():
+    """imo_type_mismatch must be a covariate in the anomaly model."""
+    assert "imo_type_mismatch" in ANOMALY_FEATURE_COLUMNS
+
+
+def test_imo_scrapped_flag_in_anomaly_feature_columns():
+    """imo_scrapped_flag must be a covariate in the anomaly model."""
+    assert "imo_scrapped_flag" in ANOMALY_FEATURE_COLUMNS
+
+
+def test_chokepoint_features_in_anomaly_feature_columns():
+    """chokepoint_exit_gap_count and ais_pre_gap_regularity must feed the anomaly model."""
+    assert "chokepoint_exit_gap_count" in ANOMALY_FEATURE_COLUMNS
+    assert "ais_pre_gap_regularity" in ANOMALY_FEATURE_COLUMNS
+
+
+def test_new_features_in_feature_value_columns():
+    """All four new features must appear in SHAP signal attribution."""
+    for col in ("imo_type_mismatch", "imo_scrapped_flag", "chokepoint_exit_gap_count", "ais_pre_gap_regularity"):
+        assert col in FEATURE_VALUE_COLUMNS, f"{col} missing from FEATURE_VALUE_COLUMNS"
+
+
+def test_imo_type_mismatch_raises_behavioral_score(tmp_db):
+    """A vessel with imo_type_mismatch=True scores higher than an identical vessel with False."""
+    con = duckdb.connect(tmp_db)
+    try:
+        con.execute(
+            """
+            INSERT INTO vessel_meta (mmsi, imo, name, flag, ship_type) VALUES
+                ('800000001', 'IMO8000001', 'SPOOF_VESSEL', 'PA', 70),
+                ('800000002', 'IMO8000002', 'CLEAN_VESSEL', 'PA', 80)
+            """
+        )
+        con.execute(
+            """
+            INSERT INTO ais_positions (mmsi, timestamp, lat, lon, sog, nav_status, ship_type) VALUES
+                ('800000001', '2026-03-01 00:00:00+00', 1.0, 103.0, 5.0, 0, 70),
+                ('800000002', '2026-03-01 00:00:00+00', 1.0, 103.0, 5.0, 0, 80)
+            """
+        )
+        # Identical features except imo_type_mismatch
+        con.execute(
+            """
+            INSERT INTO vessel_features (
+                mmsi, ais_gap_count_30d, ais_gap_max_hours, position_jump_count,
+                sts_candidate_count, port_call_ratio, loitering_hours_30d,
+                flag_changes_2y, name_changes_2y, owner_changes_2y,
+                high_risk_flag_ratio, ownership_depth, sanctions_distance,
+                cluster_sanctions_ratio, shared_manager_risk, shared_address_centrality,
+                sts_hub_degree, route_cargo_mismatch, declared_vs_estimated_cargo_value,
+                sanctions_list_count, imo_type_mismatch, imo_scrapped_flag
+            ) VALUES
+                ('800000001', 2, 5.0, 0, 0, 0.5, 2.0, 0, 0, 0, 0.0, 1, 5, 0.0, 5, 0, 0, 0.0, 0.0, 0, TRUE,  FALSE),
+                ('800000002', 2, 5.0, 0, 0, 0.5, 2.0, 0, 0, 0, 0.0, 1, 5, 0.0, 5, 0, 0, 0.0, 0.0, 0, FALSE, FALSE)
+            """
+        )
+    finally:
+        con.close()
+
+    features = load_feature_frame(tmp_db)
+    baseline = build_mpol_baseline(tmp_db)
+    anomaly_df, _, _ = score_anomalies(features, baseline)
+
+    spoof = anomaly_df.filter(features["mmsi"] == "800000001")["behavioral_deviation_score"][0]
+    clean = anomaly_df.filter(features["mmsi"] == "800000002")["behavioral_deviation_score"][0]
+    assert spoof >= clean, (
+        f"imo_type_mismatch vessel ({spoof:.4f}) should score >= clean vessel ({clean:.4f})"
+    )


### PR DESCRIPTION
Closes #541

## Summary
- Adds `imo_type_mismatch`: flags vessels whose AIS-reported ship type category (cargo/tanker/passenger/fishing) doesn't match the type registered for the same IMO in Equasis. Catches vessels adopting a scrapped tanker's IMO while broadcasting as a cargo ship.
- Adds `imo_scrapped_flag`: flags vessels whose IMO appears in the Equasis deleted/scrapped vessel registry.
- New `equasis_vessel_ref` DuckDB table (imo, vessel_type, build_year, scrapped) — populated via `upsert_equasis_vessel_ref()` when an Equasis CSV is available. Gracefully returns False defaults when table is empty (no Equasis data required at runtime).
- `_ship_type_category()` maps ITU-R M.1371 AIS codes to broad categories (1=fishing, 2=service, 3=passenger, 4=cargo, 5=tanker).
- Both features wired into `compute_identity_features()` and `build_matrix.py` DEFAULTS.

## Test plan
- [x] `uv run pytest` — 423/423 passed (14 new tests in `test_imo_mismatch.py`)
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)