### PR TITLE
chore: disable merge-reviews schedule

### DIFF
--- a/.github/workflows/merge-reviews.yml
+++ b/.github/workflows/merge-reviews.yml
@@ -1,8 +1,9 @@
 name: Merge reviews
 
 on:
-  schedule:
-    - cron: "*/15 * * * *"
+  # Disabled — re-enable schedule once review intake is open (see arktrace#547)
+  # schedule:
+  #   - cron: "*/15 * * * *"
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Disables the every-15-min cron until review intake is open. Workflow still runnable manually via workflow_dispatch. Tracked in #547.