### PR TITLE
fix: include hornofafrica in R2 uploads

### DIFF
--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -212,12 +212,15 @@ _DEMO_FILES = [
 _REGION_PREFIX: dict[str, str] = {
     "singapore": "singapore",
     "japan": "japansea",
+    "japansea": "japansea",
+    "blacksea": "blacksea",
     "middleeast": "middleeast",
     "europe": "europe",
     "persiangulf": "persiangulf",
     "gulfofguinea": "gulfofguinea",
     "gulfofaden": "gulfofaden",
     "gulfofmexico": "gulfofmexico",
+    "hornofafrica": "hornofafrica",
 }
 
 # Files always downloaded regardless of region (shared by the API across all regions)
@@ -1425,7 +1428,7 @@ def cmd_push_ducklake_private(args: argparse.Namespace) -> int:
 _AIS_DBS_R2_PREFIX = "ais-dbs/"  # private bucket sub-prefix for raw AIS DB backups
 _GFW_EO_R2_PREFIX = "gfw-eo/"  # private bucket sub-prefix for pre-fetched GFW EO parquets
 _GEBCO_MASKS_R2_PREFIX = "gebco-masks/"  # private bucket sub-prefix for GEBCO depth masks
-_AIS_DB_MIN_SIZE_BYTES = 1_048_576  # skip placeholder DBs smaller than 1 MB
+_AIS_DB_MIN_SIZE_BYTES = 65_536  # skip placeholder DBs smaller than 64 KB (empty schema ~12 KB)
 
 
 def _ais_db_candidates(data_dir: Path, regions: list[str] | None) -> list[Path]:


### PR DESCRIPTION
## Summary

- `hornofafrica.duckdb` (524 KB) was silently dropped by `_ais_db_candidates` because `_AIS_DB_MIN_SIZE_BYTES` was set to 1 MB — a threshold that's too high for sparse regions with low vessel traffic
- Lowered threshold to 64 KB (well above the ~12 KB empty-schema floor)
- Added `hornofafrica`, `blacksea`, and `japansea` as explicit keys in `_REGION_PREFIX` so `--regions` flags accept them by name without relying on the dict `.get(r, r)` fallback

## Test plan

- [ ] Run `uv run python scripts/sync_r2.py push-ais-dbs --regions hornofafrica --data-dir arktrace/data/processed` and confirm hornofafrica.duckdb is uploaded
- [ ] Confirm other regions are unaffected (blacksea, japansea, etc. still upload)
- [ ] Verify no empty placeholder DBs are uploaded (files < 64 KB should still be skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)