### PR TITLE
feat(watchlist): ATT badge inline per vessel (arktrace#560 phase 1)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,7 +11,8 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { initDuckDB, queryWatchlist, queryMetrics, queryRegions, queryScoreHistoryBulk, queryStatelessVessels } from "./lib/duckdb";
+import { initDuckDB, queryWatchlist, queryMetrics, queryRegions, queryScoreHistoryBulk, queryStatelessVessels, queryAllCausalEffects } from "./lib/duckdb";
+import type { CausalEffectRow } from "./lib/duckdb";
 import { initReviewSchema, getBulkReviewStates, saveReview } from "./lib/reviews";
 import { initBriefCache } from "./lib/briefCache";
 import { initInvestigationStore } from "./lib/investigationStore";
@@ -57,6 +58,7 @@ export default function App() {
   const [reviewStates, setReviewStates] = useState<Map<string, { decision_tier: DecisionTier | null; handoff_state: HandoffState }>>(new Map());
   const [handoffFilter, setHandoffFilter] = useState<HandoffState | "all">("all");
   const [scoreHistory, setScoreHistory] = useState<Map<string, number[]>>(new Map());
+  const [causalEffects, setCausalEffects] = useState<Map<string, CausalEffectRow>>(new Map());
   const [alerts, setAlerts] = useState<AlertEntry[]>(() => loadAlerts());
   const [alertDrawerOpen, setAlertDrawerOpen] = useState(false);
   const prevVesselsRef = useRef<VesselRow[]>([]);
@@ -118,14 +120,16 @@ export default function App() {
   const refreshQuery = useCallback(async () => {
     const conn = connRef.current;
     if (!conn) return;
-    const [vs, m, rs, sh, sl] = await Promise.all([
+    const [vs, m, rs, sh, sl, ce] = await Promise.all([
       queryWatchlist(conn, { minConfidence, regions: selectedRegions.length > 0 ? selectedRegions : undefined }),
       queryMetrics(conn),
       queryRegions(conn),
       queryScoreHistoryBulk(conn),
       queryStatelessVessels(conn),
+      queryAllCausalEffects(conn),
     ]);
     setScoreHistory(sh);
+    setCausalEffects(ce);
     const updatedAlerts = diffAndAppend(prevVesselsRef.current, vs);
     prevVesselsRef.current = vs;
     setAlerts(updatedAlerts);
@@ -335,6 +339,7 @@ export default function App() {
             onClaim={handleClaim}
             exportRegion={selectedRegions.join("_") || "all"}
             scoreHistory={scoreHistory}
+            causalEffects={causalEffects}
           />
         </div>
 

--- a/app/src/components/WatchlistTable.test.ts
+++ b/app/src/components/WatchlistTable.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { attColor } from "./WatchlistTable";
+
+describe("attColor", () => {
+  it("returns muted grey for non-significant ATT regardless of magnitude", () => {
+    expect(attColor(0.5, false)).toBe("#4a5568");
+    expect(attColor(-0.5, false)).toBe("#4a5568");
+    expect(attColor(0.0, false)).toBe("#4a5568");
+  });
+
+  it("returns red for significant ATT ≥ 0.30", () => {
+    expect(attColor(0.30, true)).toBe("#fc8181");
+    expect(attColor(0.50, true)).toBe("#fc8181");
+    expect(attColor(1.00, true)).toBe("#fc8181");
+  });
+
+  it("returns amber for significant ATT in [0.10, 0.30)", () => {
+    expect(attColor(0.10, true)).toBe("#f6ad55");
+    expect(attColor(0.20, true)).toBe("#f6ad55");
+    expect(attColor(0.29, true)).toBe("#f6ad55");
+  });
+
+  it("returns green for significant ATT < 0.10", () => {
+    expect(attColor(0.09, true)).toBe("#68d391");
+    expect(attColor(0.00, true)).toBe("#68d391");
+    expect(attColor(-0.10, true)).toBe("#68d391");
+  });
+});

--- a/app/src/components/WatchlistTable.tsx
+++ b/app/src/components/WatchlistTable.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import type { VesselRow } from "../lib/duckdb";
+import type { VesselRow, CausalEffectRow } from "../lib/duckdb";
 import { tierColor, HANDOFF_STATES, handoffLabel } from "../lib/reviews";
 import type { DecisionTier, HandoffState } from "../lib/reviews";
 
@@ -15,6 +15,7 @@ interface Props {
   onClaim?: (mmsi: string) => void;
   exportRegion?: string;
   scoreHistory?: Map<string, number[]>;
+  causalEffects?: Map<string, CausalEffectRow>;
 }
 
 // ── Sparkline ────────────────────────────────────────────────────────────────
@@ -57,6 +58,36 @@ function Sparkline({ scores }: { scores: number[] }) {
           fill={color}
         />
       </svg>
+    </span>
+  );
+}
+
+// ── ATT badge ─────────────────────────────────────────────────────────────────
+
+export function attColor(att: number, significant: boolean): string {
+  if (!significant) return "#4a5568";
+  if (att >= 0.3) return "#fc8181";
+  if (att >= 0.1) return "#f6ad55";
+  return "#68d391";
+}
+
+function AttBadge({ causal }: { causal: CausalEffectRow }) {
+  const sign = causal.att_estimate >= 0 ? "+" : "";
+  const color = attColor(causal.att_estimate, causal.is_significant);
+  const label = `ATT ${sign}${causal.att_estimate.toFixed(2)}${causal.is_significant ? "*" : ""}`;
+  const title = `ATT ${sign}${causal.att_estimate.toFixed(3)} [${causal.att_ci_lower.toFixed(3)}, ${causal.att_ci_upper.toFixed(3)}] p=${causal.p_value.toFixed(4)} · regime: ${causal.regime}`;
+  return (
+    <span
+      title={title}
+      style={{
+        fontFamily: "ui-monospace,monospace",
+        fontSize: "0.58rem",
+        color,
+        marginLeft: "0.25rem",
+        flexShrink: 0,
+      }}
+    >
+      {label}
     </span>
   );
 }
@@ -166,6 +197,7 @@ export default function WatchlistTable({
   onClaim,
   exportRegion = "all",
   scoreHistory,
+  causalEffects,
 }: Props) {
   const [search, setSearch] = useState("");
   const [hovered, setHovered] = useState<string | null>(null);
@@ -415,8 +447,13 @@ export default function WatchlistTable({
                   >
                     {v.vessel_type || "—"}
                   </td>
-                  <td style={{ padding: "0.35rem 0.5rem", fontWeight: 700, color: confidenceColor(v.confidence) }}>
-                    {v.confidence.toFixed(3)}
+                  <td style={{ padding: "0.35rem 0.5rem", fontWeight: 700, color: confidenceColor(v.confidence), whiteSpace: "nowrap" }}>
+                    <span style={{ display: "inline-flex", alignItems: "center" }}>
+                      <span>{v.confidence.toFixed(3)}</span>
+                      {causalEffects?.has(v.mmsi) && (
+                        <AttBadge causal={causalEffects.get(v.mmsi)!} />
+                      )}
+                    </span>
                   </td>
                   <td style={{ padding: "0.2rem 0.5rem", color: "#718096", whiteSpace: "nowrap" }}>
                     {onClaim && hovered === v.mmsi ? (

--- a/app/src/lib/duckdb.test.ts
+++ b/app/src/lib/duckdb.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { buildCausalEffectsMap } from "./duckdb";
+import type { CausalEffectRow } from "./duckdb";
 
 // Test the ALLOCATED_MIDS set logic by importing the module and checking
 // that known unallocated MIDs are not in the allocated set.
@@ -107,5 +109,44 @@ describe("stateless MMSI detection", () => {
 
   it("does not flag MID 698 (Africa region) as stateless", () => {
     expect(isStateless("698806645")).toBe(false);
+  });
+});
+
+// ── buildCausalEffectsMap ────────────────────────────────────────────────────
+
+const causalRow = (mmsi: string, att: number, significant = true): CausalEffectRow => ({
+  mmsi,
+  regime: "OFAC Iran",
+  att_estimate: att,
+  att_ci_lower: att - 0.05,
+  att_ci_upper: att + 0.05,
+  p_value: significant ? 0.02 : 0.20,
+  is_significant: significant,
+});
+
+describe("buildCausalEffectsMap", () => {
+  it("returns empty map for empty input", () => {
+    expect(buildCausalEffectsMap([]).size).toBe(0);
+  });
+
+  it("keys map by mmsi", () => {
+    const map = buildCausalEffectsMap([causalRow("111111111", 0.3), causalRow("222222222", 0.1)]);
+    expect(map.size).toBe(2);
+    expect(map.get("111111111")?.att_estimate).toBe(0.3);
+    expect(map.get("222222222")?.att_estimate).toBe(0.1);
+  });
+
+  it("last row wins on duplicate mmsi", () => {
+    const map = buildCausalEffectsMap([causalRow("111111111", 0.3), causalRow("111111111", 0.5)]);
+    expect(map.get("111111111")?.att_estimate).toBe(0.5);
+  });
+
+  it("preserves all CausalEffectRow fields", () => {
+    const row = causalRow("123456789", 0.241);
+    const map = buildCausalEffectsMap([row]);
+    const r = map.get("123456789")!;
+    expect(r.regime).toBe("OFAC Iran");
+    expect(r.is_significant).toBe(true);
+    expect(r.p_value).toBeCloseTo(0.02);
   });
 });

--- a/app/src/lib/duckdb.ts
+++ b/app/src/lib/duckdb.ts
@@ -202,6 +202,25 @@ export async function queryCausalEffect(
   }
 }
 
+/** Load causal ATT for all vessels in one query. Returns mmsi → CausalEffectRow map. */
+export async function queryAllCausalEffects(
+  conn: duckdb.AsyncDuckDBConnection
+): Promise<Map<string, CausalEffectRow>> {
+  const map = new Map<string, CausalEffectRow>();
+  if (!isParquetRegistered("causal_effects.parquet")) return map;
+  try {
+    const result = await conn.query(
+      `SELECT mmsi, regime, att_estimate, att_ci_lower, att_ci_upper, p_value, is_significant
+       FROM read_parquet('causal_effects.parquet')`
+    );
+    for (const row of result.toArray()) {
+      const r = row.toJSON() as CausalEffectRow;
+      map.set(r.mmsi, r);
+    }
+  } catch { /* table not yet synced */ }
+  return map;
+}
+
 /**
  * Load 30-day score history for all vessels in one query.
  * Returns a map of mmsi → array of 30 confidence values (oldest first).

--- a/app/src/lib/duckdb.ts
+++ b/app/src/lib/duckdb.ts
@@ -202,23 +202,25 @@ export async function queryCausalEffect(
   }
 }
 
+/** Build mmsi → CausalEffectRow map from a raw row array (exported for tests). */
+export function buildCausalEffectsMap(rows: CausalEffectRow[]): Map<string, CausalEffectRow> {
+  const map = new Map<string, CausalEffectRow>();
+  for (const r of rows) map.set(r.mmsi, r);
+  return map;
+}
+
 /** Load causal ATT for all vessels in one query. Returns mmsi → CausalEffectRow map. */
 export async function queryAllCausalEffects(
   conn: duckdb.AsyncDuckDBConnection
 ): Promise<Map<string, CausalEffectRow>> {
-  const map = new Map<string, CausalEffectRow>();
-  if (!isParquetRegistered("causal_effects.parquet")) return map;
+  if (!isParquetRegistered("causal_effects.parquet")) return new Map();
   try {
     const result = await conn.query(
       `SELECT mmsi, regime, att_estimate, att_ci_lower, att_ci_upper, p_value, is_significant
        FROM read_parquet('causal_effects.parquet')`
     );
-    for (const row of result.toArray()) {
-      const r = row.toJSON() as CausalEffectRow;
-      map.set(r.mmsi, r);
-    }
-  } catch { /* table not yet synced */ }
-  return map;
+    return buildCausalEffectsMap(result.toArray().map((r) => r.toJSON() as CausalEffectRow));
+  } catch { return new Map(); }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`queryAllCausalEffects()`** — new bulk query loading all causal ATT records in one DuckDB scan
- **WatchlistTable ATT badge** — Conf cell now shows `0.516  ATT +0.241*` for every vessel with a causal record. `*` = statistically significant. Colour: red ≥ 0.30 · amber ≥ 0.10 · grey = not significant. Hover tooltip shows full CI, p-value, and sanctions regime.
- **4 unit tests** for `attColor()` colour logic

## What's not in this PR (phase 2 — blocked on indago pipeline outputs)

- AIS gap event detail (start/end/duration/position) → needs `ais_gaps.parquet`
- STS transfer detail → needs `sts_transfers.parquet`
- Ownership graph → needs `ownership_graph.parquet`
- Pre-designation lead time timeline

Closes #560 phase 1

## Test plan
- [ ] Open `http://localhost:5173` — ATT badge visible next to confidence for vessels in `causal_effects.parquet`
- [ ] Hover ATT badge → tooltip shows CI + p-value + regime
- [ ] Red/amber/grey colour changes at 0.30 / 0.10 threshold
- [ ] `npm test -- WatchlistTable` → 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)