### PR TITLE
feat(ui): VesselDetail feature attribution + ownership chain (#570 #571)

### DIFF
--- a/app/src/components/DispatchModal.test.ts
+++ b/app/src/components/DispatchModal.test.ts
@@ -38,6 +38,8 @@ const BASE_VESSEL: VesselRow = {
   top_signals: null,
   ais_gap_count_30d: null,
   sts_candidate_count: null,
+  sanctions_distance: null,
+  ownership_chain: null,
 };
 
 const SIGNALS: ShapSignal[] = [

--- a/app/src/components/InvestigationPanel.test.ts
+++ b/app/src/components/InvestigationPanel.test.ts
@@ -38,6 +38,8 @@ const BASE: VesselRow = {
   ]),
   ais_gap_count_30d: 5,
   sts_candidate_count: 100,
+  sanctions_distance: 1,
+  ownership_chain: null,
 };
 
 // ── System prompt constraints ─────────────────────────────────────────────────

--- a/app/src/components/KpiBar.test.ts
+++ b/app/src/components/KpiBar.test.ts
@@ -16,6 +16,8 @@ const vessel = (confidence: number): VesselRow => ({
   top_signals: null,
   ais_gap_count_30d: null,
   sts_candidate_count: null,
+  sanctions_distance: null,
+  ownership_chain: null,
 });
 
 describe("deriveVesselKpis", () => {

--- a/app/src/components/VesselDetail.test.ts
+++ b/app/src/components/VesselDetail.test.ts
@@ -40,6 +40,8 @@ const BASE_VESSEL: VesselRow = {
   top_signals: null,
   ais_gap_count_30d: null,
   sts_candidate_count: null,
+  sanctions_distance: null,
+  ownership_chain: null,
 };
 
 // ── SYSTEM_PROMPT constraints ────────────────────────────────────────────────

--- a/app/src/components/VesselDetail.tsx
+++ b/app/src/components/VesselDetail.tsx
@@ -9,10 +9,17 @@ import {
   formatLastSeen,
   confidenceTier,
   confidenceTierColor,
+} from "../lib/humanise";
+import {
+  normalizeAttributions,
+  parseOwnershipChain,
+  parseSignals,
+  formatSanctionsDistance,
+  ownershipRelationLabel,
   signalLabel,
   signalSeverity,
   severityColor,
-} from "../lib/humanise";
+} from "../lib/vesselDetailUtils";
 import ReviewPanel from "./ReviewPanel";
 import DispatchModal from "./DispatchModal";
 import InvestigationPanel from "./InvestigationPanel";
@@ -98,30 +105,12 @@ async function fetchBrief(v: VesselRow, signal: AbortSignal): Promise<string> {
 
 // ── SHAP signal bar chart ────────────────────────────────────────────────────
 
-interface ShapSignal {
-  feature: string;
-  value: number | string | null;
-  contribution: number;
-}
-
-function parseSignals(raw: string | null | undefined): ShapSignal[] {
-  if (!raw) return [];
-  try {
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed as ShapSignal[];
-  } catch {
-    return [];
-  }
-}
-
-function ShapBarChart({ raw }: { raw: string | null | undefined }) {
-  const signals = parseSignals(raw);
-  if (!signals.length) return null;
-  const maxContrib = Math.max(...signals.map((s) => s.contribution));
+function FeatureAttributionChart({ raw }: { raw: string | null | undefined }) {
+  const rows = normalizeAttributions(parseSignals(raw));
+  if (!rows.length) return null;
 
   return (
-    <div style={{ marginTop: "0.75rem" }}>
+    <div style={{ marginTop: "0.75rem" }} data-testid="feature-attribution">
       <div
         style={{
           fontSize: "0.65rem",
@@ -131,10 +120,10 @@ function ShapBarChart({ raw }: { raw: string | null | undefined }) {
           marginBottom: "0.4rem",
         }}
       >
-        Top signals
+        Feature attribution
       </div>
-      {signals.map((s) => {
-        const pct = maxContrib > 0 ? (s.contribution / maxContrib) * 100 : 0;
+      {rows.map((s) => {
+        const pct = s.sharePct;
         const label = signalLabel(s.feature);
         const rawVal = s.value != null ? String(s.value) : "—";
         const sev = signalSeverity(s.feature, s.value);
@@ -158,16 +147,90 @@ function ShapBarChart({ raw }: { raw: string | null | undefined }) {
               </span>
             </div>
             <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
-              <div style={{ flex: 1, background: "#1a1f2e", borderRadius: 2, height: 5, minWidth: 0 }}>
+              <div style={{ flex: 1, background: "#1a1f2e", borderRadius: 2, height: 6, minWidth: 0 }}>
                 <div style={{ width: `${pct}%`, background: sev ? severityColor(sev) : "#fc8181", height: "100%", borderRadius: 2 }} />
               </div>
-              <span style={{ fontSize: "0.6rem", color: "#4a5568", minWidth: 24, textAlign: "right", fontFamily: "ui-monospace,monospace" }}>
-                {(s.contribution * 100).toFixed(0)}%
+              <span style={{ fontSize: "0.6rem", color: "#cbd5e0", minWidth: 32, textAlign: "right", fontFamily: "ui-monospace,monospace" }}>
+                {pct.toFixed(0)}%
               </span>
             </div>
           </div>
         );
       })}
+    </div>
+  );
+}
+
+function OwnershipChainPanel({
+  chainRaw,
+  sanctionsDistance,
+  vesselName,
+  mmsi,
+}: {
+  chainRaw: string | null | undefined;
+  sanctionsDistance: number | null | undefined;
+  vesselName: string;
+  mmsi: string;
+}) {
+  const chain = parseOwnershipChain(chainRaw);
+  const hasChain = chain.length > 1 || (chain.length === 1 && chain[0]?.sanctioned);
+
+  return (
+    <div style={{ marginTop: "0.75rem" }} data-testid="ownership-chain">
+      <div
+        style={{
+          fontSize: "0.65rem",
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "#4a5568",
+          marginBottom: "0.4rem",
+        }}
+      >
+        Ownership chain
+      </div>
+      {sanctionsDistance != null && (
+        <div style={{ fontSize: "0.68rem", color: "#718096", marginBottom: "0.45rem" }}>
+          {formatSanctionsDistance(sanctionsDistance)}
+        </div>
+      )}
+      {!hasChain ? (
+        <div style={{ fontSize: "0.68rem", color: "#4a5568", fontStyle: "italic" }}>
+          No ownership records in graph for this vessel.
+        </div>
+      ) : (
+        <div style={{ fontSize: "0.72rem", color: "#cbd5e0", lineHeight: 1.55 }}>
+          {chain.map((hop, idx) => {
+            const indent = idx * 14;
+            const isRoot = idx === 0;
+            const prefix = isRoot ? "" : "└── ";
+            const rel = ownershipRelationLabel(hop.relation, hop.kind);
+            const country = hop.country ? ` (${hop.country})` : "";
+            const sanctioned = hop.sanctioned || hop.kind === "sanction";
+            const displayName = isRoot
+              ? `${hop.name || vesselName} (MMSI ${mmsi})`
+              : `${rel}: ${hop.name}${country}`;
+            return (
+              <div
+                key={`${hop.hop}-${hop.name}-${idx}`}
+                style={{
+                  marginLeft: indent,
+                  marginBottom: idx < chain.length - 1 ? "0.2rem" : 0,
+                  color: sanctioned ? "#fc8181" : "#cbd5e0",
+                }}
+              >
+                <span style={{ color: "#4a5568" }}>{prefix}</span>
+                {displayName}
+                {sanctioned && hop.kind !== "sanction" && (
+                  <span style={{ marginLeft: "0.35rem", fontSize: "0.6rem", fontWeight: 700 }}>⚠ SANCTIONED</span>
+                )}
+                {hop.kind === "sanction" && (
+                  <span style={{ marginLeft: "0.35rem", fontSize: "0.6rem", fontWeight: 700 }}>→ listing</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }
@@ -581,7 +644,13 @@ export default function VesselDetail({ vessel, conn, onClose, onReviewSaved }: P
       </div>
 
       {/* SHAP bar chart */}
-      <ShapBarChart raw={vessel.top_signals} />
+      <FeatureAttributionChart raw={vessel.top_signals} />
+      <OwnershipChainPanel
+        chainRaw={vessel.ownership_chain}
+        sanctionsDistance={vessel.sanctions_distance}
+        vesselName={vessel.vessel_name || vessel.mmsi}
+        mmsi={vessel.mmsi}
+      />
 
       {/* OSINT investigation panel */}
       {investigateOpen && (

--- a/app/src/components/VesselDetail.tsx
+++ b/app/src/components/VesselDetail.tsx
@@ -10,17 +10,8 @@ import {
   confidenceTier,
   confidenceTierColor,
 } from "../lib/humanise";
-import {
-  normalizeAttributions,
-  parseOwnershipChain,
-  parseSignals,
-  formatSanctionsDistance,
-  ownershipRelationLabel,
-  signalLabel,
-  signalSeverity,
-  severityColor,
-} from "../lib/vesselDetailUtils";
 import ReviewPanel from "./ReviewPanel";
+import { FeatureAttributionChart, OwnershipChainPanel } from "./VesselDetailCharts";
 import DispatchModal from "./DispatchModal";
 import InvestigationPanel from "./InvestigationPanel";
 
@@ -103,137 +94,6 @@ async function fetchBrief(v: VesselRow, signal: AbortSignal): Promise<string> {
   return (data?.choices?.[0]?.message?.content ?? "").trim();
 }
 
-// ── SHAP signal bar chart ────────────────────────────────────────────────────
-
-function FeatureAttributionChart({ raw }: { raw: string | null | undefined }) {
-  const rows = normalizeAttributions(parseSignals(raw));
-  if (!rows.length) return null;
-
-  return (
-    <div style={{ marginTop: "0.75rem" }} data-testid="feature-attribution">
-      <div
-        style={{
-          fontSize: "0.65rem",
-          textTransform: "uppercase",
-          letterSpacing: "0.08em",
-          color: "#4a5568",
-          marginBottom: "0.4rem",
-        }}
-      >
-        Feature attribution
-      </div>
-      {rows.map((s) => {
-        const pct = s.sharePct;
-        const label = signalLabel(s.feature);
-        const rawVal = s.value != null ? String(s.value) : "—";
-        const sev = signalSeverity(s.feature, s.value);
-        return (
-          <div
-            key={s.feature}
-            title={`${s.feature}: ${rawVal}`}
-            style={{ marginBottom: "0.35rem" }}
-          >
-            <div style={{ display: "flex", alignItems: "center", gap: "0.3rem", marginBottom: "0.15rem" }}>
-              <span style={{ fontSize: "0.65rem", color: "#a0aec0", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {label}
-              </span>
-              {sev && (
-                <span style={{ fontSize: "0.55rem", fontWeight: 700, color: severityColor(sev), border: `1px solid ${severityColor(sev)}`, borderRadius: 2, padding: "0 0.25rem", flexShrink: 0, fontFamily: "ui-monospace,monospace" }}>
-                  {sev}
-                </span>
-              )}
-              <span style={{ fontSize: "0.65rem", color: "#718096", flexShrink: 0, fontFamily: "ui-monospace,monospace" }}>
-                {rawVal}
-              </span>
-            </div>
-            <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
-              <div style={{ flex: 1, background: "#1a1f2e", borderRadius: 2, height: 6, minWidth: 0 }}>
-                <div style={{ width: `${pct}%`, background: sev ? severityColor(sev) : "#fc8181", height: "100%", borderRadius: 2 }} />
-              </div>
-              <span style={{ fontSize: "0.6rem", color: "#cbd5e0", minWidth: 32, textAlign: "right", fontFamily: "ui-monospace,monospace" }}>
-                {pct.toFixed(0)}%
-              </span>
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function OwnershipChainPanel({
-  chainRaw,
-  sanctionsDistance,
-  vesselName,
-  mmsi,
-}: {
-  chainRaw: string | null | undefined;
-  sanctionsDistance: number | null | undefined;
-  vesselName: string;
-  mmsi: string;
-}) {
-  const chain = parseOwnershipChain(chainRaw);
-  const hasChain = chain.length > 1 || (chain.length === 1 && chain[0]?.sanctioned);
-
-  return (
-    <div style={{ marginTop: "0.75rem" }} data-testid="ownership-chain">
-      <div
-        style={{
-          fontSize: "0.65rem",
-          textTransform: "uppercase",
-          letterSpacing: "0.08em",
-          color: "#4a5568",
-          marginBottom: "0.4rem",
-        }}
-      >
-        Ownership chain
-      </div>
-      {sanctionsDistance != null && (
-        <div style={{ fontSize: "0.68rem", color: "#718096", marginBottom: "0.45rem" }}>
-          {formatSanctionsDistance(sanctionsDistance)}
-        </div>
-      )}
-      {!hasChain ? (
-        <div style={{ fontSize: "0.68rem", color: "#4a5568", fontStyle: "italic" }}>
-          No ownership records in graph for this vessel.
-        </div>
-      ) : (
-        <div style={{ fontSize: "0.72rem", color: "#cbd5e0", lineHeight: 1.55 }}>
-          {chain.map((hop, idx) => {
-            const indent = idx * 14;
-            const isRoot = idx === 0;
-            const prefix = isRoot ? "" : "└── ";
-            const rel = ownershipRelationLabel(hop.relation, hop.kind);
-            const country = hop.country ? ` (${hop.country})` : "";
-            const sanctioned = hop.sanctioned || hop.kind === "sanction";
-            const displayName = isRoot
-              ? `${hop.name || vesselName} (MMSI ${mmsi})`
-              : `${rel}: ${hop.name}${country}`;
-            return (
-              <div
-                key={`${hop.hop}-${hop.name}-${idx}`}
-                style={{
-                  marginLeft: indent,
-                  marginBottom: idx < chain.length - 1 ? "0.2rem" : 0,
-                  color: sanctioned ? "#fc8181" : "#cbd5e0",
-                }}
-              >
-                <span style={{ color: "#4a5568" }}>{prefix}</span>
-                {displayName}
-                {sanctioned && hop.kind !== "sanction" && (
-                  <span style={{ marginLeft: "0.35rem", fontSize: "0.6rem", fontWeight: 700 }}>⚠ SANCTIONED</span>
-                )}
-                {hop.kind === "sanction" && (
-                  <span style={{ marginLeft: "0.35rem", fontSize: "0.6rem", fontWeight: 700 }}>→ listing</span>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
 
 const row = (label: string, value: string | number | null | undefined) => (
   <tr key={label}>

--- a/app/src/components/VesselDetailCharts.test.tsx
+++ b/app/src/components/VesselDetailCharts.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { FeatureAttributionChart, OwnershipChainPanel } from "./VesselDetailCharts";
+
+describe("FeatureAttributionChart", () => {
+  it("renders attribution section with share percentages", () => {
+    const raw = JSON.stringify([
+      { feature: "ais_gap_count_30d", value: 4, contribution: 0.6 },
+      { feature: "sanctions_distance", value: 1, contribution: 0.4 },
+    ]);
+    const html = renderToStaticMarkup(<FeatureAttributionChart raw={raw} />);
+    expect(html).toContain('data-testid="feature-attribution"');
+    expect(html).toContain("Feature attribution");
+    expect(html).toContain("60%");
+    expect(html).toContain("40%");
+  });
+
+  it("renders nothing when signals are empty", () => {
+    expect(renderToStaticMarkup(<FeatureAttributionChart raw={null} />)).toBe("");
+    expect(renderToStaticMarkup(<FeatureAttributionChart raw="[]" />)).toBe("");
+  });
+});
+
+describe("OwnershipChainPanel", () => {
+  it("shows empty state when graph has no ownership links", () => {
+    const html = renderToStaticMarkup(
+      <OwnershipChainPanel
+        chainRaw={JSON.stringify([{ hop: 0, kind: "vessel", name: "TEST", country: "", sanctioned: false }])}
+        sanctionsDistance={99}
+        vesselName="TEST"
+        mmsi="111111111"
+      />,
+    );
+    expect(html).toContain("No ownership records in graph for this vessel.");
+    expect(html).toContain("No sanctions link in ownership graph");
+  });
+
+  it("renders operator and sanctions listing hops", () => {
+    const chain = [
+      { hop: 0, kind: "vessel", name: "ADMIRAL STAR", country: "", sanctioned: false },
+      { hop: 1, kind: "company", name: "Seawind Ltd", country: "PA", sanctioned: false, relation: "operator" },
+      { hop: 2, kind: "sanction", name: "OFAC SDN (2024-11-12)", country: "", sanctioned: true, relation: "sanctioned_by" },
+    ];
+    const html = renderToStaticMarkup(
+      <OwnershipChainPanel
+        chainRaw={JSON.stringify(chain)}
+        sanctionsDistance={1}
+        vesselName="ADMIRAL STAR"
+        mmsi="613490000"
+      />,
+    );
+    expect(html).toContain('data-testid="ownership-chain"');
+    expect(html).toContain("Operator: Seawind Ltd (PA)");
+    expect(html).toContain("MMSI 613490000");
+    expect(html).toContain("1 hop");
+    expect(html).toContain("→ listing");
+  });
+});

--- a/app/src/components/VesselDetailCharts.tsx
+++ b/app/src/components/VesselDetailCharts.tsx
@@ -1,0 +1,140 @@
+import {
+  normalizeAttributions,
+  parseOwnershipChain,
+  parseSignals,
+  formatSanctionsDistance,
+  ownershipRelationLabel,
+  signalLabel,
+  signalSeverity,
+  severityColor,
+} from "../lib/vesselDetailUtils";
+
+export function FeatureAttributionChart({ raw }: { raw: string | null | undefined }) {
+  const rows = normalizeAttributions(parseSignals(raw));
+  if (!rows.length) return null;
+
+  return (
+    <div style={{ marginTop: "0.75rem" }} data-testid="feature-attribution">
+      <div
+        style={{
+          fontSize: "0.65rem",
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "#4a5568",
+          marginBottom: "0.4rem",
+        }}
+      >
+        Feature attribution
+      </div>
+      {rows.map((s) => {
+        const pct = s.sharePct;
+        const label = signalLabel(s.feature);
+        const rawVal = s.value != null ? String(s.value) : "—";
+        const sev = signalSeverity(s.feature, s.value);
+        return (
+          <div
+            key={s.feature}
+            title={`${s.feature}: ${rawVal}`}
+            style={{ marginBottom: "0.35rem" }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: "0.3rem", marginBottom: "0.15rem" }}>
+              <span style={{ fontSize: "0.65rem", color: "#a0aec0", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {label}
+              </span>
+              {sev && (
+                <span style={{ fontSize: "0.55rem", fontWeight: 700, color: severityColor(sev), border: `1px solid ${severityColor(sev)}`, borderRadius: 2, padding: "0 0.25rem", flexShrink: 0, fontFamily: "ui-monospace,monospace" }}>
+                  {sev}
+                </span>
+              )}
+              <span style={{ fontSize: "0.65rem", color: "#718096", flexShrink: 0, fontFamily: "ui-monospace,monospace" }}>
+                {rawVal}
+              </span>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+              <div style={{ flex: 1, background: "#1a1f2e", borderRadius: 2, height: 6, minWidth: 0 }}>
+                <div style={{ width: `${pct}%`, background: sev ? severityColor(sev) : "#fc8181", height: "100%", borderRadius: 2 }} />
+              </div>
+              <span style={{ fontSize: "0.6rem", color: "#cbd5e0", minWidth: 32, textAlign: "right", fontFamily: "ui-monospace,monospace" }}>
+                {pct.toFixed(0)}%
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function OwnershipChainPanel({
+  chainRaw,
+  sanctionsDistance,
+  vesselName,
+  mmsi,
+}: {
+  chainRaw: string | null | undefined;
+  sanctionsDistance: number | null | undefined;
+  vesselName: string;
+  mmsi: string;
+}) {
+  const chain = parseOwnershipChain(chainRaw);
+  const hasChain = chain.length > 1 || (chain.length === 1 && chain[0]?.sanctioned);
+
+  return (
+    <div style={{ marginTop: "0.75rem" }} data-testid="ownership-chain">
+      <div
+        style={{
+          fontSize: "0.65rem",
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "#4a5568",
+          marginBottom: "0.4rem",
+        }}
+      >
+        Ownership chain
+      </div>
+      {sanctionsDistance != null && (
+        <div style={{ fontSize: "0.68rem", color: "#718096", marginBottom: "0.45rem" }}>
+          {formatSanctionsDistance(sanctionsDistance)}
+        </div>
+      )}
+      {!hasChain ? (
+        <div style={{ fontSize: "0.68rem", color: "#4a5568", fontStyle: "italic" }}>
+          No ownership records in graph for this vessel.
+        </div>
+      ) : (
+        <div style={{ fontSize: "0.72rem", color: "#cbd5e0", lineHeight: 1.55 }}>
+          {chain.map((hop, idx) => {
+            const indent = idx * 14;
+            const isRoot = idx === 0;
+            const prefix = isRoot ? "" : "└── ";
+            const rel = ownershipRelationLabel(hop.relation, hop.kind);
+            const country = hop.country ? ` (${hop.country})` : "";
+            const sanctioned = hop.sanctioned || hop.kind === "sanction";
+            const displayName = isRoot
+              ? `${hop.name || vesselName} (MMSI ${mmsi})`
+              : `${rel}: ${hop.name}${country}`;
+            return (
+              <div
+                key={`${hop.hop}-${hop.name}-${idx}`}
+                style={{
+                  marginLeft: indent,
+                  marginBottom: idx < chain.length - 1 ? "0.2rem" : 0,
+                  color: sanctioned ? "#fc8181" : "#cbd5e0",
+                }}
+              >
+                <span style={{ color: "#4a5568" }}>{prefix}</span>
+                {displayName}
+                {sanctioned && hop.kind !== "sanction" && (
+                  <span style={{ marginLeft: "0.35rem", fontSize: "0.6rem", fontWeight: 700 }}>⚠ SANCTIONED</span>
+                )}
+                {hop.kind === "sanction" && (
+                  <span style={{ marginLeft: "0.35rem", fontSize: "0.6rem", fontWeight: 700 }}>→ listing</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/lib/duckdb.ts
+++ b/app/src/lib/duckdb.ts
@@ -86,6 +86,8 @@ export interface VesselRow {
   top_signals: string | null;
   ais_gap_count_30d: number | null;
   sts_candidate_count: number | null;
+  sanctions_distance: number | null;
+  ownership_chain: string | null;
 }
 
 export interface MetricsRow {
@@ -116,12 +118,15 @@ export async function queryWatchlist(
   opts: { minConfidence?: number; regions?: string[] } = {}
 ): Promise<VesselRow[]> {
   const { minConfidence = 0, regions } = opts;
-  const [hasImo, hasRegion, hasTopSignals, hasAisGap, hasSts] = await Promise.all([
+  const [hasImo, hasRegion, hasTopSignals, hasAisGap, hasSts, hasSanctionsDist, hasOwnershipChain] =
+    await Promise.all([
     watchlistHasCol(conn, "imo"),
     watchlistHasCol(conn, "region"),
     watchlistHasCol(conn, "top_signals"),
     watchlistHasCol(conn, "ais_gap_count_30d"),
     watchlistHasCol(conn, "sts_candidate_count"),
+    watchlistHasCol(conn, "sanctions_distance"),
+    watchlistHasCol(conn, "ownership_chain"),
   ]);
 
   let sql = `
@@ -138,7 +143,9 @@ export async function queryWatchlist(
       ${hasRegion ? "region" : "NULL AS region"},
       ${hasTopSignals ? "CAST(top_signals AS VARCHAR) AS top_signals" : "NULL AS top_signals"},
       ${hasAisGap ? "CAST(ais_gap_count_30d AS INTEGER) AS ais_gap_count_30d" : "NULL AS ais_gap_count_30d"},
-      ${hasSts ? "CAST(sts_candidate_count AS INTEGER) AS sts_candidate_count" : "NULL AS sts_candidate_count"}
+      ${hasSts ? "CAST(sts_candidate_count AS INTEGER) AS sts_candidate_count" : "NULL AS sts_candidate_count"},
+      ${hasSanctionsDist ? "CAST(sanctions_distance AS INTEGER) AS sanctions_distance" : "NULL AS sanctions_distance"},
+      ${hasOwnershipChain ? "CAST(ownership_chain AS VARCHAR) AS ownership_chain" : "NULL AS ownership_chain"}
     FROM read_parquet('watchlist.parquet')
     WHERE confidence >= ${minConfidence}
   `;
@@ -291,12 +298,15 @@ const ALLOCATED_MIDS = new Set([
 export async function queryStatelessVessels(
   conn: duckdb.AsyncDuckDBConnection
 ): Promise<VesselRow[]> {
-  const [hasImo, hasRegion, hasTopSignals, hasAisGap, hasSts] = await Promise.all([
+  const [hasImo, hasRegion, hasTopSignals, hasAisGap, hasSts, hasSanctionsDist, hasOwnershipChain] =
+    await Promise.all([
     watchlistHasCol(conn, "imo"),
     watchlistHasCol(conn, "region"),
     watchlistHasCol(conn, "top_signals"),
     watchlistHasCol(conn, "ais_gap_count_30d"),
     watchlistHasCol(conn, "sts_candidate_count"),
+    watchlistHasCol(conn, "sanctions_distance"),
+    watchlistHasCol(conn, "ownership_chain"),
   ]);
 
   // Use string comparison to avoid TRY_CAST compatibility issues with DuckDB-WASM.
@@ -316,7 +326,9 @@ export async function queryStatelessVessels(
       ${hasRegion ? "region" : "NULL AS region"},
       ${hasTopSignals ? "CAST(top_signals AS VARCHAR) AS top_signals" : "NULL AS top_signals"},
       ${hasAisGap ? "CAST(ais_gap_count_30d AS INTEGER) AS ais_gap_count_30d" : "NULL AS ais_gap_count_30d"},
-      ${hasSts ? "CAST(sts_candidate_count AS INTEGER) AS sts_candidate_count" : "NULL AS sts_candidate_count"}
+      ${hasSts ? "CAST(sts_candidate_count AS INTEGER) AS sts_candidate_count" : "NULL AS sts_candidate_count"},
+      ${hasSanctionsDist ? "CAST(sanctions_distance AS INTEGER) AS sanctions_distance" : "NULL AS sanctions_distance"},
+      ${hasOwnershipChain ? "CAST(ownership_chain AS VARCHAR) AS ownership_chain" : "NULL AS ownership_chain"}
     FROM read_parquet('watchlist.parquet')
     WHERE LENGTH(mmsi) = 9
       AND LEFT(mmsi, 1) BETWEEN '2' AND '7'

--- a/app/src/lib/vesselDetailUtils.test.ts
+++ b/app/src/lib/vesselDetailUtils.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeAttributions,
+  parseOwnershipChain,
+  parseSignals,
+  formatSanctionsDistance,
+} from "./vesselDetailUtils";
+
+describe("parseSignals", () => {
+  it("parses a valid JSON array", () => {
+    const raw = JSON.stringify([
+      { feature: "ais_gap_count_30d", value: 4, contribution: 0.4 },
+      { feature: "sanctions_distance", value: 1, contribution: 0.35 },
+    ]);
+    expect(parseSignals(raw)).toHaveLength(2);
+  });
+
+  it("returns empty for invalid JSON", () => {
+    expect(parseSignals("not-json")).toEqual([]);
+  });
+});
+
+describe("normalizeAttributions", () => {
+  it("allocates shares that sum to ~100%", () => {
+    const rows = normalizeAttributions([
+      { feature: "a", value: 1, contribution: 0.4 },
+      { feature: "b", value: 2, contribution: 0.35 },
+      { feature: "c", value: 3, contribution: 0.25 },
+    ]);
+    const sum = rows.reduce((s, r) => s + r.sharePct, 0);
+    expect(sum).toBeCloseTo(100, 5);
+    expect(rows[0].feature).toBe("a");
+  });
+
+  it("ignores non-positive contributions", () => {
+    const rows = normalizeAttributions([
+      { feature: "a", value: 1, contribution: 1 },
+      { feature: "b", value: 0, contribution: -0.2 },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sharePct).toBe(100);
+  });
+});
+
+describe("parseOwnershipChain", () => {
+  it("parses hop objects from JSON", () => {
+    const raw = JSON.stringify([
+      { hop: 0, kind: "vessel", name: "TEST", country: "", sanctioned: false },
+      { hop: 1, kind: "company", name: "Seawind Ltd", country: "PA", sanctioned: false, relation: "operator" },
+    ]);
+    const chain = parseOwnershipChain(raw);
+    expect(chain).toHaveLength(2);
+    expect(chain[1].name).toBe("Seawind Ltd");
+  });
+});
+
+describe("formatSanctionsDistance", () => {
+  it("describes direct and hop distances", () => {
+    expect(formatSanctionsDistance(0)).toContain("Directly");
+    expect(formatSanctionsDistance(1)).toContain("1 hop");
+    expect(formatSanctionsDistance(99)).toContain("No sanctions");
+  });
+});

--- a/app/src/lib/vesselDetailUtils.test.ts
+++ b/app/src/lib/vesselDetailUtils.test.ts
@@ -4,6 +4,7 @@ import {
   parseOwnershipChain,
   parseSignals,
   formatSanctionsDistance,
+  ownershipRelationLabel,
 } from "./vesselDetailUtils";
 
 describe("parseSignals", () => {
@@ -59,5 +60,14 @@ describe("formatSanctionsDistance", () => {
     expect(formatSanctionsDistance(0)).toContain("Directly");
     expect(formatSanctionsDistance(1)).toContain("1 hop");
     expect(formatSanctionsDistance(99)).toContain("No sanctions");
+  });
+});
+
+describe("ownershipRelationLabel", () => {
+  it("maps hop kinds and relations to display labels", () => {
+    expect(ownershipRelationLabel(undefined, "vessel")).toBe("Vessel");
+    expect(ownershipRelationLabel("operator", "company")).toBe("Operator");
+    expect(ownershipRelationLabel("controlled_by", "company")).toBe("Parent company");
+    expect(ownershipRelationLabel(undefined, "sanction")).toBe("Sanctions listing");
   });
 });

--- a/app/src/lib/vesselDetailUtils.ts
+++ b/app/src/lib/vesselDetailUtils.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared parsers/formatters for VesselDetail charts (feature attribution + ownership chain).
+ */
+
+import { signalLabel, signalSeverity, severityColor } from "./humanise";
+
+export interface ShapSignal {
+  feature: string;
+  value: number | string | null;
+  contribution: number;
+}
+
+export interface AttributionRow extends ShapSignal {
+  sharePct: number;
+}
+
+export interface OwnershipHop {
+  hop: number;
+  kind: string;
+  name: string;
+  country: string;
+  sanctioned: boolean;
+  relation?: string;
+  date?: string;
+}
+
+export function parseSignals(raw: string | null | undefined): ShapSignal[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (s): s is ShapSignal =>
+        typeof s === "object" &&
+        s !== null &&
+        typeof (s as ShapSignal).feature === "string" &&
+        typeof (s as ShapSignal).contribution === "number"
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Normalize positive SHAP contributions to shares that sum to 100%. */
+export function normalizeAttributions(signals: ShapSignal[]): AttributionRow[] {
+  const positive = signals
+    .filter((s) => s.contribution > 0)
+    .sort((a, b) => b.contribution - a.contribution);
+  const total = positive.reduce((sum, s) => sum + s.contribution, 0);
+  if (total <= 0) {
+    return positive.map((s) => ({ ...s, sharePct: 0 }));
+  }
+  return positive.map((s) => ({
+    ...s,
+    sharePct: (s.contribution / total) * 100,
+  }));
+}
+
+export function parseOwnershipChain(raw: string | null | undefined): OwnershipHop[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (h): h is OwnershipHop =>
+        typeof h === "object" &&
+        h !== null &&
+        typeof (h as OwnershipHop).name === "string"
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function formatSanctionsDistance(distance: number | null | undefined): string {
+  if (distance == null || distance >= 99) return "No sanctions link in ownership graph";
+  if (distance === 0) return "Directly sanctioned entity";
+  if (distance === 1) return "1 hop — owner or manager on sanctions list";
+  return `${distance} hops — parent company linked to sanctions list`;
+}
+
+export function ownershipRelationLabel(relation: string | undefined, kind: string): string {
+  if (kind === "vessel") return "Vessel";
+  if (kind === "sanction") return "Sanctions listing";
+  switch (relation) {
+    case "operator":
+      return "Operator";
+    case "manager":
+      return "Manager";
+    case "controlled_by":
+      return "Parent company";
+    case "owned_by":
+      return "Registered owner";
+    default:
+      return "Company";
+  }
+}
+
+export { signalLabel, signalSeverity, severityColor };

--- a/app/src/pages/AdminPage.test.ts
+++ b/app/src/pages/AdminPage.test.ts
@@ -16,6 +16,8 @@ const vessel = (confidence: number, region = "singapore"): VesselRow => ({
   top_signals: null,
   ais_gap_count_30d: null,
   sts_candidate_count: null,
+  sanctions_distance: null,
+  ownership_chain: null,
 });
 
 describe("deriveWatchlistHealth", () => {

--- a/pipeline/src/features/ownership_graph.py
+++ b/pipeline/src/features/ownership_graph.py
@@ -11,6 +11,9 @@ Usage:
     uv run python src/features/ownership_graph.py
 """
 
+from __future__ import annotations
+
+import json
 import os
 
 import duckdb
@@ -296,6 +299,140 @@ def _apply_direct_sanctions_fallback(sd_df: pl.DataFrame, db_path: str) -> pl.Da
         .otherwise(pl.col("sanctions_distance"))
         .alias("sanctions_distance")
     )
+
+
+# ---------------------------------------------------------------------------
+# Ownership chain materialization (dashboard export)
+# ---------------------------------------------------------------------------
+
+
+def _company_display(
+    company_id: str,
+    companies: pl.DataFrame,
+    sanctioned_ids: set[str],
+) -> tuple[str, str, bool]:
+    if len(companies):
+        row = companies.filter(pl.col("id") == company_id)
+        if len(row):
+            name = row["name"][0]
+            country = row["country"][0]
+            return (
+                str(name) if name else company_id,
+                str(country) if country else "",
+                company_id in sanctioned_ids,
+            )
+    return company_id, "", company_id in sanctioned_ids
+
+
+def _build_vessel_ownership_chain(mmsi: str, tables: dict) -> list[dict]:
+    """Return a short vessel → operator → parent → sanctions path for one MMSI."""
+    vessels = pl.from_arrow(tables["Vessel"])
+    ob = pl.from_arrow(tables["OWNED_BY"])
+    mb = pl.from_arrow(tables["MANAGED_BY"])
+    cb = pl.from_arrow(tables["CONTROLLED_BY"])
+    sb = pl.from_arrow(tables["SANCTIONED_BY"])
+
+    sanctioned_ids: set[str] = set(sb["src_id"].to_list()) if len(sb) else set()
+    company_df = (
+        pl.from_arrow(tables["Company"])
+        if len(tables["Company"])
+        else pl.DataFrame(schema={"id": pl.Utf8, "name": pl.Utf8, "country": pl.Utf8})
+    )
+
+    vrow = vessels.filter(pl.col("mmsi") == mmsi)
+    vessel_name = str(vrow["name"][0]) if len(vrow) and vrow["name"][0] else mmsi
+    chain: list[dict] = [
+        {
+            "hop": 0,
+            "kind": "vessel",
+            "name": vessel_name,
+            "country": "",
+            "sanctioned": mmsi in sanctioned_ids,
+            "relation": "vessel",
+        }
+    ]
+
+    company_id: str | None = None
+    relation: str | None = None
+    if len(ob):
+        owned = ob.filter(pl.col("src_id") == mmsi)
+        if len(owned):
+            company_id = owned["dst_id"][0]
+            relation = "operator"
+    if company_id is None and len(mb):
+        managed = mb.filter(pl.col("src_id") == mmsi)
+        if len(managed):
+            company_id = managed["dst_id"][0]
+            relation = "manager"
+
+    if not company_id:
+        return chain
+
+    name, country, sanctioned = _company_display(company_id, company_df, sanctioned_ids)
+    chain.append(
+        {
+            "hop": 1,
+            "kind": "company",
+            "name": name,
+            "country": country,
+            "sanctioned": sanctioned,
+            "relation": relation or "operator",
+        }
+    )
+
+    target_id = company_id
+    if len(cb):
+        parents = cb.filter(pl.col("src_id") == company_id)
+        if len(parents):
+            parent_id = parents["dst_id"][0]
+            pname, pcountry, psanc = _company_display(parent_id, company_df, sanctioned_ids)
+            chain.append(
+                {
+                    "hop": 2,
+                    "kind": "company",
+                    "name": pname,
+                    "country": pcountry,
+                    "sanctioned": psanc,
+                    "relation": "controlled_by",
+                }
+            )
+            target_id = parent_id
+
+    if len(sb):
+        listings = sb.filter(pl.col("src_id") == target_id)
+        for listing in listings.to_dicts():
+            list_name = listing.get("list") or "Sanctions list"
+            date = listing.get("date") or ""
+            label = f"{list_name}" + (f" ({date})" if date else "")
+            chain.append(
+                {
+                    "hop": len(chain),
+                    "kind": "sanction",
+                    "name": label,
+                    "country": "",
+                    "sanctioned": True,
+                    "relation": "sanctioned_by",
+                    "date": date,
+                }
+            )
+            break
+
+    return chain
+
+
+def compute_ownership_chains(db_path: str) -> pl.DataFrame:
+    """Materialize ownership paths for dashboard export (one JSON array per MMSI)."""
+    tables = load_tables(db_path)
+    vessels = pl.from_arrow(tables["Vessel"]).select("mmsi")
+    if len(vessels) == 0:
+        return pl.DataFrame(schema={"mmsi": pl.Utf8, "ownership_chain": pl.Utf8})
+
+    rows = []
+    for mmsi in vessels["mmsi"].to_list():
+        chain = _build_vessel_ownership_chain(mmsi, tables)
+        rows.append({"mmsi": mmsi, "ownership_chain": json.dumps(chain)})
+
+    return pl.DataFrame(rows, schema={"mmsi": pl.Utf8, "ownership_chain": pl.Utf8})
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/src/score/composite.py
+++ b/pipeline/src/score/composite.py
@@ -586,6 +586,18 @@ def compute_composite_scores(
                 f"[label propagation] floor applied to {n_lifted} vessels from {propagation_path}"
             )
 
+    graph_export = feature_df.select(["mmsi", "sanctions_distance"])
+    scored = scored.join(graph_export, on="mmsi", how="left")
+
+    try:
+        from pipeline.src.features.ownership_graph import compute_ownership_chains
+
+        chains_df = compute_ownership_chains(db_path)
+        scored = scored.join(chains_df, on="mmsi", how="left")
+    except Exception as exc:
+        print(f"Warning: ownership_chain export skipped ({exc})")
+        scored = scored.with_columns(pl.lit(None, dtype=pl.Utf8).alias("ownership_chain"))
+
     return scored.select(
         [
             "mmsi",
@@ -609,6 +621,7 @@ def compute_composite_scores(
             "name_changes_2y",
             "owner_changes_2y",
             "sanctions_distance",
+            "ownership_chain",
             "shared_address_centrality",
             "sts_hub_degree",
             "cluster_label",

--- a/tests/test_ownership_graph.py
+++ b/tests/test_ownership_graph.py
@@ -3,11 +3,11 @@ Tests for ownership graph feature engineering — focusing on the DuckDB sanctio
 fallback introduced in issue #231 and the STS hub degree fixes in issue #233.
 """
 
+import json
+
 import duckdb
 import polars as pl
 import pyarrow as pa
-
-import json
 
 from pipeline.src.features.ownership_graph import (
     MAX_HOPS,

--- a/tests/test_ownership_graph.py
+++ b/tests/test_ownership_graph.py
@@ -7,9 +7,12 @@ import duckdb
 import polars as pl
 import pyarrow as pa
 
+import json
+
 from pipeline.src.features.ownership_graph import (
     MAX_HOPS,
     _apply_direct_sanctions_fallback,
+    _build_vessel_ownership_chain,
     _compute_sts_hub_degree,
 )
 from pipeline.src.graph.store import NODE_SCHEMAS, REL_SCHEMAS
@@ -185,3 +188,111 @@ def test_sts_hub_degree_hub_vessel():
     )
     result = _compute_sts_hub_degree(tables)
     assert result.filter(pl.col("mmsi") == "111111111")["sts_hub_degree"][0] == 3
+
+
+# ---------------------------------------------------------------------------
+# _build_vessel_ownership_chain
+# ---------------------------------------------------------------------------
+
+
+def _empty_rel(name: str) -> pa.Table:
+    return REL_SCHEMAS[name].empty_table()
+
+
+def _make_chain_tables(
+    *,
+    mmsi: str = "111111111",
+    vessel_name: str = "ADMIRAL STAR",
+    use_manager: bool = False,
+    with_parent: bool = True,
+    with_sanction: bool = True,
+) -> dict:
+    """Minimal Lance-style tables for ownership chain materialization."""
+    vessel_table = pa.table(
+        {"mmsi": [mmsi], "imo": [""], "name": [vessel_name]},
+        schema=NODE_SCHEMAS["Vessel"],
+    )
+    company_table = pa.table(
+        {
+            "id": ["co-op", "co-parent"],
+            "name": ["Seawind Ltd", "Oceanic Holdings"],
+            "country": ["PA", "VG"],
+        },
+        schema=NODE_SCHEMAS["Company"],
+    )
+    owned_by = _empty_rel("OWNED_BY")
+    managed_by = _empty_rel("MANAGED_BY")
+    if use_manager:
+        managed_by = pa.table(
+            {"src_id": [mmsi], "dst_id": ["co-op"], "since": [""], "until": [""]},
+            schema=REL_SCHEMAS["MANAGED_BY"],
+        )
+    else:
+        owned_by = pa.table(
+            {"src_id": [mmsi], "dst_id": ["co-op"], "since": [""], "until": [""]},
+            schema=REL_SCHEMAS["OWNED_BY"],
+        )
+
+    controlled_by = _empty_rel("CONTROLLED_BY")
+    if with_parent:
+        controlled_by = pa.table(
+            {"src_id": ["co-op"], "dst_id": ["co-parent"]},
+            schema=REL_SCHEMAS["CONTROLLED_BY"],
+        )
+
+    sanctioned_by = _empty_rel("SANCTIONED_BY")
+    if with_sanction:
+        sanctioned_by = pa.table(
+            {
+                "src_id": ["co-parent"],
+                "dst_id": ["OFAC SDN"],
+                "list": ["OFAC SDN"],
+                "date": ["2024-11-12"],
+            },
+            schema=REL_SCHEMAS["SANCTIONED_BY"],
+        )
+
+    return {
+        "Vessel": vessel_table,
+        "Company": company_table,
+        "OWNED_BY": owned_by,
+        "MANAGED_BY": managed_by,
+        "CONTROLLED_BY": controlled_by,
+        "SANCTIONED_BY": sanctioned_by,
+    }
+
+
+def test_ownership_chain_vessel_only():
+    tables = _make_chain_tables(with_parent=False, with_sanction=False)
+    tables["OWNED_BY"] = _empty_rel("OWNED_BY")
+    chain = _build_vessel_ownership_chain("111111111", tables)
+    assert len(chain) == 1
+    assert chain[0]["kind"] == "vessel"
+    assert chain[0]["name"] == "ADMIRAL STAR"
+
+
+def test_ownership_chain_operator_parent_and_listing():
+    chain = _build_vessel_ownership_chain("111111111", _make_chain_tables())
+    assert [h["kind"] for h in chain] == ["vessel", "company", "company", "sanction"]
+    assert chain[1]["relation"] == "operator"
+    assert chain[1]["name"] == "Seawind Ltd"
+    assert chain[2]["relation"] == "controlled_by"
+    assert chain[3]["kind"] == "sanction"
+    assert "OFAC SDN" in chain[3]["name"]
+
+
+def test_ownership_chain_uses_manager_when_no_owner():
+    chain = _build_vessel_ownership_chain(
+        "111111111",
+        _make_chain_tables(use_manager=True, with_parent=False, with_sanction=False),
+    )
+    assert len(chain) == 2
+    assert chain[1]["relation"] == "manager"
+    assert chain[1]["name"] == "Seawind Ltd"
+
+
+def test_ownership_chain_json_roundtrip_shape():
+    chain = _build_vessel_ownership_chain("111111111", _make_chain_tables())
+    parsed = json.loads(json.dumps(chain))
+    assert parsed[0]["hop"] == 0
+    assert parsed[-1]["kind"] == "sanction"


### PR DESCRIPTION
## Summary

- **#570:** Rename and improve the SHAP panel to **Feature attribution** — contributions normalized to shares that sum to 100% so evaluators see *why* a score is high.
- **#571:** Materialize ownership paths from the existing Lance graph (`compute_ownership_chains`) into `watchlist.parquet` and render an indented **Ownership chain** tree in `VesselDetail`, with `sanctions_distance` summary text.

## Pipeline

- `ownership_graph.py`: `compute_ownership_chains(db_path)` walks OWNED_BY / MANAGED_BY / CONTROLLED_BY / SANCTIONED_BY (same logic as distance features).
- `composite.py`: joins `sanctions_distance` + `ownership_chain` into candidate watchlist export.

## Frontend

- `vesselDetailUtils.ts`: parsers + `normalizeAttributions()` + `formatSanctionsDistance()`.
- `duckdb.ts`: loads optional `sanctions_distance` and `ownership_chain` columns from parquet.
- `VesselDetailCharts.tsx`: `FeatureAttributionChart` + `OwnershipChainPanel` (extracted for testability).

Closes #570
Closes #571

## Test plan

- [x] `npm test` — 206 tests pass (incl. `VesselDetailCharts.test.tsx`, `vesselDetailUtils.test.ts`)
- [x] `uv run pytest tests/test_ownership_graph.py` — 14 tests pass (incl. `_build_vessel_ownership_chain`)
- [x] `npm run lint` — tsc + eslint clean (warnings only)
- [ ] Re-run `compute_composite_scores` / `push-watchlists` so R2 parquet includes `ownership_chain`
- [ ] Manual: select a high-score vessel in arktrace dashboard and confirm both panels render