### PR TITLE
docs: ownership_chain R2 republish notes + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 cd app && npm install && npm run dev   # http://localhost:5173
 ```
 
-Select a region → watchlist loads → click any vessel → SHAP breakdown and AIS track appear.
+Select a region → watchlist loads → click any vessel → feature attribution, ownership chain, and AIS track appear.
 
 Demo data (no pipeline required):
 

--- a/docs/ref-architecture.md
+++ b/docs/ref-architecture.md
@@ -243,7 +243,7 @@ The live SPA at [arktrace.edgesentry.io](https://arktrace.edgesentry.io) loads *
 
 **Publish path:** [indago](https://github.com/edgesentry/indago) weekly `data-publish.yml` runs `uv run python scripts/sync_r2.py push-arktrace` after scoring. The arktrace repo’s `sync_r2.py push` is for **generation zips** and local dev artifacts only.
 
-Watchlist Parquet includes `ownership_chain` (JSON array of `{role, name, sanctions_distance}`) when the ownership graph has edges for that MMSI. If the column is missing on R2, republish from indago after merging the ownership-chain export fix.
+Watchlist Parquet includes `ownership_chain` (JSON array of `{role, name, sanctions_distance}`) when the ownership graph has edges for that MMSI. If the column is missing on R2, run indago `data-publish` (or `push-arktrace` after a local pipeline) — ensure indago uses the `score/` watchlist path, not stale flat copies at `data/processed/` root.
 
 ### App user pull options
 


### PR DESCRIPTION
## Summary

- `ref-architecture.md`: republish guidance references indago `score/` path (#150).
- `README.md`: quick-start mentions feature attribution + ownership chain panels.

## Test plan

- [x] Docs only

Made with [Cursor](https://cursor.com)